### PR TITLE
Add support for Keycloak Dev Realm

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -1,4 +1,9 @@
+# Dev credentials can be found here <insert drive link>
+
 KEYCLOAK_SECRET=private key from keycloak
+KEYCLOAK_URL=base url for keycloak
+
 DATABASE_URL=url for postgres database
 DEV_DATABASE=TRUE
+
 SENDGRID_API_KEY=private key from sendgrid

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -1,4 +1,5 @@
-# Dev credentials can be found here <insert drive link>
+# Dev credentials can be found here:
+# https://docs.google.com/document/d/1D4CJ9l6lnR39YYPUvw_HbeUVXNR-tAbNF6eT89oxEuk
 
 KEYCLOAK_SECRET=private key from keycloak
 KEYCLOAK_URL=base url for keycloak

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -42,6 +42,9 @@ app.use(express.json());
 app.use('/API',electionRouter)
 // app.use('/debug',debugRouter)
 
+const prodEndpoints : any = [
+  'https://star-vote.herokuapp.com/',
+];
 
 // TODO: This should probably be placed under a route as well. I considered putting it under elections.routes.js, but it doesn't seem like a good fit
 app.post('/API/Token', (req, res) => {
@@ -51,18 +54,17 @@ app.post('/API/Token', (req, res) => {
     //       this probably means I'm making my /API/Token call in a bad place?
     // TODO: load this from a shared config file
     //       Github Issue:  https://github.com/Equal-Vote/star-server/issues/14
-    const keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting/protocol/openid-connect'
+
+    const keycloakBaseUrl = process.env.KEYCLOAK_URL;
     const keycloakAuthConfig = {
         clientId: 'star_vote_web',
         responseType: 'code',
-        // redirectUri: window.location.origin,
-        // logoutUri: window.location.origin,
         endpoints: {
-            login: `${keycloakBaseUrl}/auth`,
-            logout: `${keycloakBaseUrl}/logout`,
-            token: `${keycloakBaseUrl}/token`,
-            authorize: `${keycloakBaseUrl}/auth`,
-            userinfo: `${keycloakBaseUrl}/userinfo`
+            login: `${process.env.KEYCLOAK_URL}/auth`,
+            logout: `${process.env.KEYCLOAK_URL}/logout`,
+            token: `${process.env.KEYCLOAK_URL}/token`,
+            authorize: `${process.env.KEYCLOAK_URL}/auth`,
+            userinfo: `${process.env.KEYCLOAK_URL}/userinfo`
         },
     }
     const authConfig = keycloakAuthConfig;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,10 @@ import { ThemeProvider } from '@material-ui/styles'
 import ElectionHome from './components/ElectionHome'
 import Sandbox from './components/Sandbox'
 
+const prodEndpoints = [
+  'https://star-vote.herokuapp.com/',
+];
+
 const App = () => {
   /* oAuth2 reference
    * Express Guide: https://www.youtube.com/watch?v=Ppeqd9xXp3Q 
@@ -21,41 +25,14 @@ const App = () => {
    * openid.net: https://openid.net/specs/openid-connect-core-1_0.html
    */
 
-  // Q: Why not use relative links for the local endpoints? That way you don't have to consider the window location at all
-  // A: That was my initial plan, but since the oAuth endpoints will almost always be direct endpoints, I figured I'd keep
-  //    it consistent for the testing cases as well
-  const localBaseUrl = window.location.origin;
-  const localAuthConfig = {
-    clientId: 'abcd', // dummy client id for now
-    responseType: 'code',
-    redirectUri: window.location.origin,
-    logoutUri: window.location.origin,
-    endpoints: {
-      login: `${localBaseUrl}/Login`,
-      logout: `${localBaseUrl}/logout`,
-      token: `${localBaseUrl}/API/oAuth2/token`,
-      authorize: `${localBaseUrl}/API/oAuth2/authorize`,
-      userinfo: `${localBaseUrl}/API/oAuth2/userinfo`
-    },
-  }
-
-  const cognitoBaseUrl = 'https://star.auth.us-east-1.amazoncognito.com'
-  const cognitoAuthConfig = {
-    clientId: '3j4jcchkffod8q1onipug0oqa4',
-    responseType: 'code',
-    redirectUri: window.location.origin,
-    logoutUri: window.location.origin,
-    endpoints: {
-      login: `${cognitoBaseUrl}/login`,
-      logout: `${cognitoBaseUrl}/logout`,
-      token: `${cognitoBaseUrl}/oauth2/token`,
-      authorize: `${cognitoBaseUrl}/oauth2/authorize`,
-      userinfo: `${cognitoBaseUrl}/oauth2/userinfo`
-    },
-  }
-
   // http://keycloak.6j0.org/auth/realms/STAR%20Voting/.well-known/openid-configuration
-  const keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting/protocol/openid-connect'
+  let keycloakBaseUrl;
+  if(prodEndpoints.includes(window.location.origin)){
+    keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting/protocol/openid-connect';
+  }else{
+    keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting%20Dev/protocol/openid-connect';
+  }
+  
   const keycloakAuthConfig = {
     clientId: 'star_vote_web',
     responseType: 'code',


### PR DESCRIPTION
This update will let us use the Keycloak Dev Realm for local testing. This way we can add a bunch of test users without polluting the production user base

In addition to the code change, I also did the following in KeyCloak
 * Create a new Realm called "STAR Voting Dev"
 * Create a new client within the realm called star_vote_web
 * Copied all the settings from the production realm's star_vote_web client to the dev realm client

Here's the remaining manual steps on the heroku end
 * Update the PR deployment .env to use the dev keycloak url + secret
 * Update the Production .env to use the prod keycloak url (the prod secret is still the same)