### PR TITLE
Admin, election roll, frontend structure updates

### DIFF
--- a/backend/src/Controllers/auth.controllers.ts
+++ b/backend/src/Controllers/auth.controllers.ts
@@ -29,7 +29,7 @@ const getUser = (req: any, res: any, next: any) => {
 
 const hasPermission = (permission: any) => {
   return (req: any, res: any, next: any) => {
-    if (req.user_auth.roles.some( (role:any) => permission.includes(role))) {
+    if (!req.user_auth.roles.some( (role:any) => permission.includes(role))) {
       console.log("Does not have permission")
       return res.status('401').json({
         error: "Does not have permission"

--- a/backend/src/Controllers/auth.controllers.ts
+++ b/backend/src/Controllers/auth.controllers.ts
@@ -20,6 +20,9 @@ const getUser = (req: any, res: any, next: any) => {
     if (req.election.audit_ids && req.election.audit_ids.includes(req.user.email)){
       req.user_auth.roles.push(roles.auditor)
     }
+    if (req.election.credential_ids && req.election.credential_ids.includes(req.user.email)){
+      req.user_auth.roles.push(roles.credentialer)
+    }
   }
   next()
 }

--- a/backend/src/Controllers/ballots.controllers.ts
+++ b/backend/src/Controllers/ballots.controllers.ts
@@ -89,6 +89,11 @@ const submitBallot = async (req: any, res: any, next: any) => {
         req.electionRollEntry.submitted = true
         req.ballot = savedBallot;
         req.electionRollEntry.ballot_id = savedBallot.ballot_id;
+        req.electionRollEntry.history.push({
+            action_type:"submit",
+            actor: ballot.user_id || "unknown",
+            timestamp:ballot.date_submitted,
+        })
         return next();
 
     } catch (err) {

--- a/backend/src/Controllers/voterRolls.controller.ts
+++ b/backend/src/Controllers/voterRolls.controller.ts
@@ -240,7 +240,12 @@ const getVoterAuth = async (req: any, res: any, next: any) => {
         req.authorized_voter = true;
         if (req.electionRollEntry.length == 0) {
             //Adds voter to roll if they aren't currently
-            const NewElectionRoll = await ElectionRollModel.submitElectionRoll(req.election.election_id, [req.voter_id], false)
+            const history = [{
+                action_type: 'added',
+                actor: req.user?.email || req.voter_id,
+                timestamp: Date.now(),
+            }]
+            const NewElectionRoll = await ElectionRollModel.submitElectionRoll(req.election.election_id, [req.voter_id], false,'approved',history)
             if (!NewElectionRoll)
                 return res.status('400').json({
                     error: "Voter Roll not found"

--- a/backend/src/Models/ElectionRolls.ts
+++ b/backend/src/Models/ElectionRolls.ts
@@ -103,13 +103,13 @@ class ElectionRollDB {
     }
     update(election_roll: ElectionRoll): Promise<ElectionRoll | null> {
         console.log(`-> ElectionRollDB.updateRoll`);
-        var sqlString = `UPDATE ${this._tableName} SET ballot_id=$1, submitted=$2, state, history=$3  WHERE election_id = $3 AND voter_id=$4`;
+        var sqlString = `UPDATE ${this._tableName} SET ballot_id=$1, submitted=$2, state=$3, history=$4  WHERE election_id = $5 AND voter_id=$6`;
         console.log(sqlString);
         console.log(election_roll)
         var p = this._postgresClient.query({
             text: sqlString,
 
-            values: [election_roll.ballot_id, election_roll.submitted, election_roll.state, election_roll.history, election_roll.election_id, election_roll.voter_id]
+            values: [election_roll.ballot_id, election_roll.submitted, election_roll.state, JSON.stringify(election_roll.history), election_roll.election_id, election_roll.voter_id]
 
         });
         return p.then((response: any) => {

--- a/backend/src/Models/Elections.ts
+++ b/backend/src/Models/Elections.ts
@@ -28,6 +28,7 @@ class ElectionsDB {
             owner_id      VARCHAR,
             audit_ids     json,
             admin_ids     json,
+            credential_ids json,
             state         VARCHAR,
             races         json NOT NULL,
             settings      json
@@ -36,13 +37,22 @@ class ElectionsDB {
         Logger.debug(appInitContext, query);
         var p = this._postgresClient.query(query);
         return p.then((_: any) => {
+            //This will add the new field to the live DB in prod.  Once that's done we can remove this
+            var credentialQuery = `
+            ALTER TABLE ${this._tableName} ADD COLUMN IF NOT EXISTS credential_ids json
+            `;
+            return this._postgresClient.query(credentialQuery).catch((err:any) => {
+                console.log("err adding credential_ids column to DB: " + err.message);
+                return err;
+            });
+        }).then((_:any)=> {
             return this;
         });
     }
 
     createElection(election: Election): Promise<Election> {
         console.log(`-> ElectionDB.create`);
-        var sqlString = `INSERT INTO ${this._tableName} (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,state,races,settings)
+        var sqlString = `INSERT INTO ${this._tableName} (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,credential_ids,state,races,settings)
         VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *;`;
 
         var p = this._postgresClient.query({
@@ -56,6 +66,7 @@ class ElectionsDB {
             election.owner_id,
             JSON.stringify(election.audit_ids),
             JSON.stringify(election.admin_ids),
+            JSON.stringify(election.credential_ids),
             election.state,
             JSON.stringify(election.races),
             JSON.stringify(election.settings)]
@@ -69,7 +80,7 @@ class ElectionsDB {
 
     updateElection(election: Election): Promise<Election> {
         console.log(`-> ElectionDB.update ${election.election_id}`);
-        var sqlString = `UPDATE ${this._tableName} SET (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,state,races,settings) =
+        var sqlString = `UPDATE ${this._tableName} SET (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,credential_ids,state,races,settings) =
         ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) WHERE election_id = $1 RETURNING *;`;
 
         var p = this._postgresClient.query({
@@ -85,6 +96,7 @@ class ElectionsDB {
                 election.owner_id,
                 JSON.stringify(election.audit_ids),
                 JSON.stringify(election.admin_ids),
+                JSON.stringify(election.credential_ids),
                 election.state,
                 JSON.stringify(election.races),
                 JSON.stringify(election.settings)

--- a/backend/src/Models/Elections.ts
+++ b/backend/src/Models/Elections.ts
@@ -81,7 +81,7 @@ class ElectionsDB {
     updateElection(election: Election): Promise<Election> {
         console.log(`-> ElectionDB.update ${election.election_id}`);
         var sqlString = `UPDATE ${this._tableName} SET (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,credential_ids,state,races,settings) =
-        ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) WHERE election_id = $1 RETURNING *;`;
+        ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) WHERE election_id = $1 RETURNING *;`;
 
         var p = this._postgresClient.query({
             text: sqlString,

--- a/backend/src/Models/Elections.ts
+++ b/backend/src/Models/Elections.ts
@@ -53,7 +53,7 @@ class ElectionsDB {
     createElection(election: Election): Promise<Election> {
         console.log(`-> ElectionDB.create`);
         var sqlString = `INSERT INTO ${this._tableName} (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,credential_ids,state,races,settings)
-        VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *;`;
+        VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,$13) RETURNING *;`;
 
         var p = this._postgresClient.query({
             text: sqlString,

--- a/backend/src/Models/__mocks__/ElectionRolls.ts
+++ b/backend/src/Models/__mocks__/ElectionRolls.ts
@@ -1,18 +1,20 @@
 import { Vote } from '../../../../domain_model/Vote';
-import { ElectionRoll } from '../../../../domain_model/ElectionRoll';
+import { ElectionRoll, ElectionRollAction } from '../../../../domain_model/ElectionRoll';
 
 class ElectionRollDB {
 
     electionRolls: ElectionRoll[] = []
     constructor() {
     }
-    submitElectionRoll(election_id: string, voter_ids: string[],submitted:boolean): Promise<boolean>{
+    submitElectionRoll(election_id: string, voter_ids: string[],submitted:boolean,state: string, history: ElectionRollAction): Promise<boolean>{
         for (var i = 0; i < voter_ids.length; i++){
             this.electionRolls.push({
                 election_roll_id: '0',
                 election_id: election_id,
                 voter_id: voter_ids[i],
                 submitted: submitted,
+                state: state,
+                history: [history]
             })
         }
         return Promise.resolve(true)

--- a/backend/src/Routes/elections.routes.js
+++ b/backend/src/Routes/elections.routes.js
@@ -5,7 +5,7 @@ const electionController = require('../Controllers/elections.controllers')
 const ballotController = require('../Controllers/ballots.controllers')
 const voterRollController = require('../Controllers/voterRolls.controller')
 const authController = require('../Controllers/auth.controllers')
-const permissions  = require('../auth/permissions')
+const {permissions} = require('../auth/permissions')
 
 router.get('/Election/:id',
     authController.getUser,
@@ -33,7 +33,10 @@ router.get('/Election/:id/rolls/:voter_id',
     authController.getUser,
     authController.hasPermission(permissions.canViewElectionRoll),
     voterRollController.getByVoterID)
-router.put('/Election/:id/rolls/',
+router.put('/Election/:id/rolls/state',
+    authController.getUser,
+    voterRollController.changeElectionRollState)
+router.post('/Election/:id/rolls/',
     authController.getUser,
     authController.hasPermission(permissions.canEditElectionRoll),
     voterRollController.editElectionRoll)
@@ -69,14 +72,7 @@ router.post('/Election/:id/vote',
             }
         );
     },
-    )
-router.post('/Election/:id/finalize',
-        authController.getUser,
-        authController.isLoggedIn,
-        authController.assertOwnership,
-        electionController.finalize,
-        voterRollController.getRollsByElectionID,
-        voterRollController.sendInvitations)
+)
 router.post('/Election/:id/finalize',
     authController.getUser,
     authController.isLoggedIn,

--- a/backend/src/auth/permissions.ts
+++ b/backend/src/auth/permissions.ts
@@ -1,13 +1,16 @@
 const roles = require('./roles')
 const permissions = {
-  canEditElectionAdmins:    [roles.system_admin, roles.owner],
-  canEditElectionAuditors:  [roles.system_admin, roles.owner],
-  canViewElection:          [roles.system_admin, roles.owner, roles.admin, roles.auditor],
+  canEditElectionRoles:     [roles.system_admin, roles.owner],
+  canViewElection:          [roles.system_admin, roles.owner, roles.admin, roles.auditor, roles.credentialer],
   canEditElection:          [roles.system_admin, roles.owner, roles.admin],
   canDeleteElection:        [roles.system_admin, roles.owner],
   canEditElectionRoll:      [roles.system_admin, roles.owner],
   canAddToElectionRoll:     [roles.system_admin, roles.owner, roles.admin],
-  canViewElectionRoll:      [roles.system_admin, roles.owner, roles.admin, roles.auditor],
+  canViewElectionRoll:      [roles.system_admin, roles.owner, roles.admin, roles.auditor, roles.credentialer],
+  canFlagElectionRoll:      [roles.system_admin, roles.owner, roles.admin, roles.auditor, roles.credentialer],
+  canApproveElectionRoll:   [roles.system_admin, roles.owner, roles.admin, roles.credentialer],
+  canUnflagElectionRoll:    [roles.system_admin, roles.owner, roles.admin],
+  canInvalidateElectionRoll:[roles.system_admin, roles.owner, roles.admin],
   canDeleteElectionRoll:    [roles.system_admin, roles.owner],
   canViewElectionRollIDs:   [roles.system_admin, roles.auditor],
   canViewBallots:           [roles.system_admin, roles.owner, roles.admin, roles.auditor],
@@ -18,4 +21,12 @@ const permissions = {
   canEditElectionState:     [roles.system_admin, roles.owner],
   canViewPreliminaryResults:[roles.system_admin, roles.owner, roles.admin, roles.auditor],
 }
-module.exports = permissions
+
+const hasPermission = (roles:string[],permission:string[]) => {
+  return roles.some( (role:any) => permission.includes(role))
+}
+
+module.exports = {
+  permissions,
+  hasPermission,
+}

--- a/backend/src/auth/roles.ts
+++ b/backend/src/auth/roles.ts
@@ -3,4 +3,5 @@ module.exports = {
     admin: 'admin',
     auditor: 'auditor',
     system_admin: 'system_admin',
+    credentialer: 'credentialer'
 }

--- a/domain_model/Election.ts
+++ b/domain_model/Election.ts
@@ -11,8 +11,9 @@ export interface Election {
     end_time?:      Date;   // when the election ends
     support_email?: string; // email available to voters to request support
     owner_id:       Uid;  // user_id of owner of election
-    audit_ids?:      Uid[];  // user_id of account with audit access
-    admin_ids?:      Uid[];  // user_id of account with admin access
+    audit_ids?:     Uid[];  // user_id of account with audit access
+    admin_ids?:     Uid[];  // user_id of account with admin access
+    credential_ids?:Uid[];  // user_id of account with credentialling access
     state:          string; // State of election, In development, finalized, etc
     races:          Race[]; // one or more race definitions
     settings:      ElectionSettings;

--- a/domain_model/ElectionRoll.ts
+++ b/domain_model/ElectionRoll.ts
@@ -6,4 +6,14 @@ export interface ElectionRoll {
     voter_id: Uid; //ID of voter who cast ballot
     ballot_id?:  Uid; //ID of ballot, unsure if this is needed
     submitted: boolean; //has ballot been submitted
+    state: string;
+    history?: ElectionRollAction[];
 }
+
+export interface ElectionRollAction {
+    action_type:string;
+    actor:Uid;
+    timestamp:number;
+}
+
+export const ElectionStates = {}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,67 +1,16 @@
 import React from 'react'
-import Header from './components/Header'
-import Elections from './components/Elections'
-import AddElection from './components/AddElection'
-import EditElection from './components/EditElection'
-import VotePage from './components/VotePage'
-import Login from './components/Login'
-import ViewElectionResults from './components/ViewElectionResults'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
-import { oAuthSession } from './oAuthSession'
 import theme from './theme'
 import { ThemeProvider } from '@material-ui/styles'
-import ElectionHome from './components/ElectionHome'
+import authSession from './authSession'
+import Header from './components/Header'
+import Elections from './components/Elections'
+import Login from './components/Login'
+import AddElection from './components/AddElection'
+import Election from './components/Election'
 import Sandbox from './components/Sandbox'
-import Admin from './components/Admin'
-
-const prodEndpoints = [
-  'https://star-vote.herokuapp.com/',
-];
 
 const App = () => {
-  /* oAuth2 reference
-   * Express Guide: https://www.youtube.com/watch?v=Ppeqd9xXp3Q 
-   * Cognito oAuth Endpoints Reference: https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html
-   * Auth0 Endpoints: https://auth0.com/docs/authorization/protocols/protocol-oauth2
-   * openid.net: https://openid.net/specs/openid-connect-core-1_0.html
-   */
-
-  console.log("trying to start app...");
-  // http://keycloak.6j0.org/auth/realms/STAR%20Voting/.well-known/openid-configuration
-  let keycloakBaseUrl;
-  if(prodEndpoints.includes(window.location.origin)){
-    keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting/protocol/openid-connect';
-  }else{
-    keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting%20Dev/protocol/openid-connect';
-  }
-  
-  const keycloakAuthConfig = {
-    clientId: 'star_vote_web',
-    responseType: 'code',
-    redirectUri: window.location.origin,
-    logoutUri: window.location.origin,
-    endpoints: {
-      login: `${keycloakBaseUrl}/auth`,
-      logout: `${keycloakBaseUrl}/logout`,
-      token: `${keycloakBaseUrl}/token`,
-      authorize: `${keycloakBaseUrl}/auth`,
-      userinfo: `${keycloakBaseUrl}/userinfo`
-    },
-  }
-
-  // TODO: load all the above values from a yaml file
-
-  const authConfig = keycloakAuthConfig;
-
-  const authSession = new oAuthSession({
-    clientId: authConfig.clientId,
-    responseType: authConfig.responseType,
-    redirectUri: authConfig.redirectUri,
-    endpoints: authConfig.endpoints,
-  })
-
-  // TODO: insert urls for keycloak 
-
   return (
     <Router>
       <ThemeProvider theme={theme}>
@@ -70,11 +19,7 @@ const App = () => {
           <Route path='/' element={<Elections authSession={authSession}/>} />
           <Route path='/Login' element={<Login />} />
           <Route path='/CreateElection' element={<AddElection authSession={authSession}/>} />
-          <Route path='/Election/:id' element={<ElectionHome authSession={authSession}/>} />
-          <Route path='/Election/:id/vote' element={<VotePage />} />
-          <Route path='/Election/:id/results' element={<ViewElectionResults />} />
-          <Route path='/Election/:id/edit' element={<EditElection authSession={authSession}/>} />
-          <Route path='/Election/:id/admin' element={<Admin authSession={authSession}/>} />
+          <Route path='/Election/:id/*' element={<Election authSession={authSession}/>} />
           <Route path='/Sandbox' element={<Sandbox />} />
         </Routes>
       </ThemeProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import theme from './theme'
 import { ThemeProvider } from '@material-ui/styles'
 import ElectionHome from './components/ElectionHome'
 import Sandbox from './components/Sandbox'
+import Admin from './components/Admin'
 
 const prodEndpoints = [
   'https://star-vote.herokuapp.com/',
@@ -73,6 +74,7 @@ const App = () => {
           <Route path='/Election/:id/vote' element={<VotePage />} />
           <Route path='/Election/:id/results' element={<ViewElectionResults />} />
           <Route path='/Election/:id/edit' element={<EditElection authSession={authSession}/>} />
+          <Route path='/Election/:id/admin' element={<Admin authSession={authSession}/>} />
           <Route path='/Sandbox' element={<Sandbox />} />
         </Routes>
       </ThemeProvider>

--- a/frontend/src/authSession.js
+++ b/frontend/src/authSession.js
@@ -1,0 +1,49 @@
+import { oAuthSession } from './oAuthSession'
+/* oAuth2 reference
+ * Express Guide: https://www.youtube.com/watch?v=Ppeqd9xXp3Q 
+ * Cognito oAuth Endpoints Reference: https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html
+ * Auth0 Endpoints: https://auth0.com/docs/authorization/protocols/protocol-oauth2
+ * openid.net: https://openid.net/specs/openid-connect-core-1_0.html
+ */
+
+
+console.log("trying to start app...");
+// http://keycloak.6j0.org/auth/realms/STAR%20Voting/.well-known/openid-configuration
+
+// TODO: insert urls for keycloak 
+const prodEndpoints = [
+    'https://star-vote.herokuapp.com/',
+  ];
+let keycloakBaseUrl;
+if (prodEndpoints.includes(window.location.origin)) {
+    keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting/protocol/openid-connect';
+} else {
+    keycloakBaseUrl = 'https://keycloak.6j0.org/auth/realms/STAR%20Voting%20Dev/protocol/openid-connect';
+}
+
+const keycloakAuthConfig = {
+    clientId: 'star_vote_web',
+    responseType: 'code',
+    redirectUri: window.location.origin,
+    logoutUri: window.location.origin,
+    endpoints: {
+        login: `${keycloakBaseUrl}/auth`,
+        logout: `${keycloakBaseUrl}/logout`,
+        token: `${keycloakBaseUrl}/token`,
+        authorize: `${keycloakBaseUrl}/auth`,
+        userinfo: `${keycloakBaseUrl}/userinfo`
+    },
+}
+
+// TODO: load all the above values from a yaml file
+
+const authConfig = keycloakAuthConfig;
+
+const authSession = new oAuthSession({
+    clientId: authConfig.clientId,
+    responseType: authConfig.responseType,
+    redirectUri: authConfig.redirectUri,
+    endpoints: authConfig.endpoints,
+})
+
+export default authSession;

--- a/frontend/src/components/AddElection.tsx
+++ b/frontend/src/components/AddElection.tsx
@@ -1,36 +1,22 @@
 import React from 'react'
+import useFetch from '../useFetch';
 import ElectionForm from "./ElectionForm";
 
 const AddElection = ({ authSession }) => {
+
+    const { makeRequest: postElection } = useFetch('/API/Elections', 'post')
     const onAddElection = async (election, voterIds) => {
-        // try {
-        const res = await fetch('/API/Elections', {
-            method: 'POST',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
+        // calls post election api, throws error if response not ok
+        if ((! await postElection(
+            {
                 Election: election,
                 VoterIDList: voterIds,
-            })
-        })
-        if (!res.ok) {
-            Error('Could not fetch data')
+            }))) {
+            throw Error("Error submitting election");
         }
-        return res
-        // console.log(res)
-        // if (!res.ok) {
-        //     throw Error('Could not fetch data')
-        // }
-        // console.log('Navigating')
-        // } catch (error) {
-        //     console.log(error)
-        //     return
-        // }
     }
 
-    return ( <ElectionForm authSession={authSession} onSubmitElection={onAddElection} prevElectionData={null} submitText='Create Election'/> );
+    return (<ElectionForm authSession={authSession} onSubmitElection={onAddElection} prevElectionData={null} submitText='Create Election' />);
 }
 
 export default AddElection

--- a/frontend/src/components/Admin.tsx
+++ b/frontend/src/components/Admin.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react"
+import StarBallot from "./StarBallot";
+import useFetch from "../useFetch";
+import { useParams } from "react-router";
+import React from 'react'
+import { useNavigate } from "react-router";
+import { Ballot } from "../../../domain_model/Ballot";
+import { Vote } from "../../../domain_model/Vote";
+import { Score } from "../../../domain_model/Score";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import Container from '@material-ui/core/Container';
+import IconButton from '@material-ui/core/IconButton'
+import ExpandLess from '@material-ui/icons/ExpandLess'
+import ExpandMore from '@material-ui/icons/ExpandMore'
+import ProfilePic from '../images/blank-profile.png'
+import { Link } from "react-router-dom"
+import { createTheme } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/styles';
+import TextField from "@material-ui/core/TextField";
+import Box from '@material-ui/core/Box';
+import { Tooltip } from "@material-ui/core";
+import ViewElectionRolls from "./ViewElectionRolls";
+const Admin = ({ authSession }) => {
+    return (
+        <Container >
+            <ViewElectionRolls />
+        </Container>
+    )
+}
+
+export default Admin

--- a/frontend/src/components/DuplicateElection.tsx
+++ b/frontend/src/components/DuplicateElection.tsx
@@ -10,19 +10,16 @@ const DuplicateElection = ({ authSession }) => {
 
     const [data, setData] = useState(null);
 
-    let { data: prevData, isPending, error } = useFetch(`/API/Election/${id}`,{
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-        },
-    });
-
+    let { data: prevData, isPending, error, makeRequest: fetchElection } = useFetch(`/API/Election/${id}`, 'get');
+    useEffect(() => {
+        fetchElection()
+    }, [])
+    
     useEffect(
         () => {
-            if(prevData && prevData.election){
-                setData({...prevData, election: {...prevData.election, title: `Copy of ${prevData.election.title}`}});
-            } 
+            if (prevData && prevData.election) {
+                setData({ ...prevData, election: { ...prevData.election, title: `Copy of ${prevData.election.title}` } });
+            }
         }, [prevData]
     )
 
@@ -46,12 +43,12 @@ const DuplicateElection = ({ authSession }) => {
 
     return (
         <Container >
-        {error && <div> {error} </div>}
-        {isPending && <div> Loading Election... </div>}
-        {!authSession.isLoggedIn() && <div> Must be logged in to create elections </div>}
-        {authSession.isLoggedIn() && data && data.election &&
-            <ElectionForm authSession={authSession} onSubmitElection={onCreateElection} prevElectionData={data.election} submitText='Create Election'/>
-        }
+            {error && <div> {error} </div>}
+            {isPending && <div> Loading Election... </div>}
+            {!authSession.isLoggedIn() && <div> Must be logged in to create elections </div>}
+            {authSession.isLoggedIn() && data && data.election &&
+                <ElectionForm authSession={authSession} onSubmitElection={onCreateElection} prevElectionData={data.election} submitText='Create Election' />
+            }
         </Container>
     )
 }

--- a/frontend/src/components/EditElection.tsx
+++ b/frontend/src/components/EditElection.tsx
@@ -4,44 +4,27 @@ import useFetch from "../useFetch";
 import Container from '@material-ui/core/Container';
 import ElectionForm from "./ElectionForm";
 
-const EditElection = ({ authSession }) => {
+const EditElection = ({ authSession, election }) => {
     const { id } = useParams();
-    const { data, isPending, error } = useFetch(`/API/Election/${id}`,{
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-        },
-    })
-
-    console.log(data);
-
+    const { isPending, error, makeRequest: editElection } = useFetch(`/API/Election/${election.election_id}/edit`,'post')
     const onEditElection = async (election, voterIds) => {
-        const res = await fetch(`/API/Election/${election.election_id}/edit`, {
-            method: 'POST',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
+        if ((! await editElection(
+            {
                 Election: election,
                 VoterIDList: voterIds,
-            })
-        })
-        if (!res.ok) {
-            Error('Could not fetch data')
+            }))) {
+            throw Error("Error editing election");
         }
-        return res
     }
 
     return (
         <Container >
         <>
         {error && <div> {error} </div>}
-        {isPending && <div> Loading Election... </div>}
+        {isPending && <div> Submitting... </div>}
         {!authSession.isLoggedIn() && <div> Must be logged in to edit </div>}
-        {authSession.isLoggedIn() && data && data.election && authSession.getIdField('sub') == data.election.owner_id &&
-            <ElectionForm authSession={authSession} onSubmitElection={onEditElection} prevElectionData={data.election} submitText='Apply Updates'/>
+        {authSession.isLoggedIn() && authSession.getIdField('sub') == election.owner_id &&
+            <ElectionForm authSession={authSession} onSubmitElection={onEditElection} prevElectionData={election} submitText='Apply Updates'/>
         }
         </>
         </Container>

--- a/frontend/src/components/EditElectionRoll.tsx
+++ b/frontend/src/components/EditElectionRoll.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react"
+import React from 'react'
+import { useNavigate } from "react-router"
+import { Election } from '../../../domain_model/Election'
+import { Race } from "../../../domain_model/Race"
+import { Candidate } from "../../../domain_model/Candidate"
+import AddCandidate from "./AddCandidate"
+// import Button from "./Button"
+import Grid from "@material-ui/core/Grid";
+import TextField from "@material-ui/core/TextField";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import FormControl from "@material-ui/core/FormControl";
+import FormLabel from "@material-ui/core/FormLabel";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import Radio from "@material-ui/core/Radio";
+// https://stackoverflow.com/questions/122102/what-is-the-most-efficient-way-to-deep-clone-an-object-in-javascript
+// https://web.dev/structured-clone/
+import structuredClone from '@ungap/structured-clone';
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import Slider from "@material-ui/core/Slider";
+import Button from "@material-ui/core/Button";
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import Container from '@material-ui/core/Container';
+import { ElectionSettings } from "../../../domain_model/ElectionSettings"
+import { Box, Checkbox, InputLabel } from "@material-ui/core"
+import { isReturnStatement } from "typescript"
+
+const EditElectionRoll = ({ roll }) => {
+    // I'm referencing 4th option here
+    // https://daveceddia.com/usestate-hook-examples/
+
+
+    const [updatedRoll, setUpdatedRoll] = useState(roll)
+    // TODO: I need to figure out how to load previous voter ID list
+    const [voterIDList, setVoterIDList] = useState('')
+    const [titleError, setTitleError] = useState(false)
+
+    const applyRollUpdate = (updateFunc) => {
+        const electionCopy = structuredClone(updatedRoll)
+        updateFunc(electionCopy)
+        setUpdatedRoll(electionCopy)
+    };
+
+    const navigate = useNavigate()
+
+    const onSubmit = (e) => {
+
+    }
+
+    const getDateString = (dateNum) => {
+        const event = new Date(dateNum);
+        return event.toLocaleString();
+    }
+
+    return (
+        <form onSubmit={onSubmit}>
+            <Container>
+                <Grid container direction="column" >
+                    <Grid item sm={12}>
+                        <Typography align='left' gutterBottom variant="h6" component="h6">
+                            {`Voter ID: ${updatedRoll.voter_id}`}
+                        </Typography>
+                    </Grid>
+                    <Grid item sm={12}>
+                        <Typography align='left' gutterBottom variant="h6" component="h6">
+                            {`Has Voted: ${updatedRoll.submitted.toString()}`}
+                        </Typography>
+                    </Grid>
+                    {updatedRoll.submitted &&
+                        <Grid item sm={4}>
+                            <Button variant='outlined' onClick={() => { }} > Invalidate Ballot </Button>
+                        </Grid>}
+                    {!updatedRoll.submitted &&
+                        <Grid item sm={4}>
+                            <Button variant='outlined' onClick={() => { }} > Delete </Button>
+                        </Grid>}
+                    <Grid container direction="column" >
+                        <Grid item sm={12}>
+                            <Grid container >
+                                <Grid item sm={4}>
+                                    <Typography align='left' gutterBottom variant="h6" component="h6">
+                                        Action
+                                    </Typography>
+                                </Grid>
+                                <Grid item sm={4}>
+                                    <Typography align='left' gutterBottom variant="h6" component="h6">
+                                        Actor
+                                    </Typography>
+                                </Grid>
+                                <Grid item sm={4}>
+                                    <Typography align='left' gutterBottom variant="h6" component="h6">
+                                        Timestamp
+                                    </Typography>
+                                </Grid>
+                            </Grid>
+                            <Divider light />
+                        </Grid>
+                        {updatedRoll.history.map((history) => (
+                            <Grid item sm={12}>
+                                <Grid container direction="row">
+                                    <Grid item sm={4}>
+                                        <Typography align='left' gutterBottom variant="h6" component="h6">
+                                            {history.action}
+                                        </Typography>
+                                    </Grid>
+                                    <Grid item sm={4}>
+                                        <Typography align='left' gutterBottom variant="h6" component="h6">
+                                            {history.actor}
+                                        </Typography>
+                                    </Grid>
+                                    <Grid item sm={4}>
+                                        <Typography align='left' gutterBottom variant="h6" component="h6">
+                                            {getDateString(history.timestamp)}
+                                        </Typography>
+                                    </Grid>
+                                </Grid>
+                                <Divider light />
+                            </Grid>
+                        ))}
+                    </Grid>
+                </Grid>
+            </Container>
+        </form>
+    )
+}
+
+export default EditElectionRoll 

--- a/frontend/src/components/EditElectionRoll.tsx
+++ b/frontend/src/components/EditElectionRoll.tsx
@@ -1,128 +1,70 @@
 import { useState } from "react"
 import React from 'react'
-import { useNavigate } from "react-router"
-import { Election } from '../../../domain_model/Election'
-import { Race } from "../../../domain_model/Race"
-import { Candidate } from "../../../domain_model/Candidate"
-import AddCandidate from "./AddCandidate"
-// import Button from "./Button"
 import Grid from "@material-ui/core/Grid";
-import TextField from "@material-ui/core/TextField";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import FormControl from "@material-ui/core/FormControl";
-import FormLabel from "@material-ui/core/FormLabel";
-import RadioGroup from "@material-ui/core/RadioGroup";
-import Radio from "@material-ui/core/Radio";
-// https://stackoverflow.com/questions/122102/what-is-the-most-efficient-way-to-deep-clone-an-object-in-javascript
-// https://web.dev/structured-clone/
-import structuredClone from '@ungap/structured-clone';
-import Select from "@material-ui/core/Select";
-import MenuItem from "@material-ui/core/MenuItem";
-import Slider from "@material-ui/core/Slider";
 import Button from "@material-ui/core/Button";
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
 import Container from '@material-ui/core/Container';
-import { ElectionSettings } from "../../../domain_model/ElectionSettings"
-import { Box, Checkbox, InputLabel } from "@material-ui/core"
-import { isReturnStatement } from "typescript"
+import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@material-ui/core";
 
-const EditElectionRoll = ({ roll }) => {
-    // I'm referencing 4th option here
-    // https://daveceddia.com/usestate-hook-examples/
-
-
+const EditElectionRoll = ({ roll, onClose }) => {
     const [updatedRoll, setUpdatedRoll] = useState(roll)
-    // TODO: I need to figure out how to load previous voter ID list
-    const [voterIDList, setVoterIDList] = useState('')
-    const [titleError, setTitleError] = useState(false)
-
-    const applyRollUpdate = (updateFunc) => {
-        const electionCopy = structuredClone(updatedRoll)
-        updateFunc(electionCopy)
-        setUpdatedRoll(electionCopy)
-    };
-
-    const navigate = useNavigate()
-
-    const onSubmit = (e) => {
-
-    }
-
     const getDateString = (dateNum) => {
         const event = new Date(dateNum);
         return event.toLocaleString();
     }
-
     return (
-        <form onSubmit={onSubmit}>
-            <Container>
-                <Grid container direction="column" >
-                    <Grid item sm={12}>
-                        <Typography align='left' gutterBottom variant="h6" component="h6">
-                            {`Voter ID: ${updatedRoll.voter_id}`}
-                        </Typography>
-                    </Grid>
-                    <Grid item sm={12}>
-                        <Typography align='left' gutterBottom variant="h6" component="h6">
-                            {`Has Voted: ${updatedRoll.submitted.toString()}`}
-                        </Typography>
-                    </Grid>
-                    {updatedRoll.submitted &&
-                        <Grid item sm={4}>
-                            <Button variant='outlined' onClick={() => { }} > Invalidate Ballot </Button>
-                        </Grid>}
-                    {!updatedRoll.submitted &&
-                        <Grid item sm={4}>
-                            <Button variant='outlined' onClick={() => { }} > Delete </Button>
-                        </Grid>}
-                    <Grid container direction="column" >
-                        <Grid item sm={12}>
-                            <Grid container >
-                                <Grid item sm={4}>
-                                    <Typography align='left' gutterBottom variant="h6" component="h6">
-                                        Action
-                                    </Typography>
-                                </Grid>
-                                <Grid item sm={4}>
-                                    <Typography align='left' gutterBottom variant="h6" component="h6">
-                                        Actor
-                                    </Typography>
-                                </Grid>
-                                <Grid item sm={4}>
-                                    <Typography align='left' gutterBottom variant="h6" component="h6">
-                                        Timestamp
-                                    </Typography>
-                                </Grid>
-                            </Grid>
-                            <Divider light />
-                        </Grid>
-                        {updatedRoll.history.map((history) => (
-                            <Grid item sm={12}>
-                                <Grid container direction="row">
-                                    <Grid item sm={4}>
-                                        <Typography align='left' gutterBottom variant="h6" component="h6">
-                                            {history.action}
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item sm={4}>
-                                        <Typography align='left' gutterBottom variant="h6" component="h6">
-                                            {history.actor}
-                                        </Typography>
-                                    </Grid>
-                                    <Grid item sm={4}>
-                                        <Typography align='left' gutterBottom variant="h6" component="h6">
-                                            {getDateString(history.timestamp)}
-                                        </Typography>
-                                    </Grid>
-                                </Grid>
-                                <Divider light />
-                            </Grid>
-                        ))}
-                    </Grid>
+        <Container>
+            <Grid container direction="column" >
+                <Grid item sm={12}>
+                    <Typography align='left' gutterBottom variant="h6" component="h6">
+                        {`Voter ID: ${updatedRoll.voter_id}`}
+                    </Typography>
                 </Grid>
-            </Container>
-        </form>
+                <Grid item sm={12}>
+                    <Typography align='left' gutterBottom variant="h6" component="h6">
+                        {`Has Voted: ${updatedRoll.submitted.toString()}`}
+                    </Typography>
+                </Grid>
+                {updatedRoll.state !== 'flagged' &&
+                    <Grid item sm={4}>
+                        <Button variant='outlined' onClick={() => { }} > Flag </Button>
+                    </Grid>}
+                {updatedRoll.submitted &&
+                    <Grid item sm={4}>
+                        <Button variant='outlined' onClick={() => { }} > Invalidate Ballot </Button>
+                    </Grid>}
+                {!updatedRoll.submitted &&
+                    <Grid item sm={4}>
+                        <Button variant='outlined' onClick={() => { }} > Delete </Button>
+                    </Grid>}
+                {updatedRoll?.history &&
+                    <TableContainer component={Paper}>
+                        <Table style={{ width: '100%' }} aria-label="simple table">
+                            <TableHead>
+                                <TableCell> Action </TableCell>
+                                <TableCell align="right"> Actor </TableCell>
+                                <TableCell align="right"> Timestamp </TableCell>
+                            </TableHead>
+                            <TableBody>
+                                {updatedRoll.history.map((history, i) => (
+                                    <TableRow key={i} >
+                                        <TableCell component="th" scope="row">
+                                            {history.action}
+                                        </TableCell>
+                                        <TableCell align="right" >{history.actor}</TableCell>
+                                        <TableCell align="right" >{getDateString(history.timestamp)}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                }
+                <Grid item sm={4}>
+                    <Button variant='outlined' onClick={() => { onClose() }} > Close </Button>
+                </Grid>
+            </Grid>
+        </Container>
     )
 }
 

--- a/frontend/src/components/Election.tsx
+++ b/frontend/src/components/Election.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react"
+import useFetch from "../useFetch";
+import { useParams } from "react-router";
+import React from 'react'
+import { useNavigate } from "react-router";
+// import { Route, Redirect, useRouteMatch, useHistory } from 'react-router-dom';
+import Container from '@material-ui/core/Container';
+import VoterAuth from "./VoterAuth";
+import ElectionHome from "./ElectionHome";
+import EditElection from './EditElection'
+import VotePage from './VotePage'
+import Admin from './Admin'
+import ViewElectionResults from './ViewElectionResults'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import Sidebar from "./Sidebar";
+
+const Election = ({ authSession }) => {
+  const { id } = useParams();
+  const { data, isPending, error, makeRequest: fetchData } = useFetch(`/API/Election/${id}`, 'get')
+
+  useEffect(() => {
+      fetchData()
+  }, [])
+
+  const navigate = useNavigate();
+
+  return (
+    <>
+      {error && <div> {error} </div>}
+      {isPending && <div> Loading Election... </div>}
+      <VoterAuth authSession={authSession} electionData={data} fetchElection={fetchData} />
+      {data?.election &&
+        <>
+          <Sidebar />
+          <Routes>
+            <Route path='/' element={<ElectionHome authSession={authSession} electionData={data} fetchElection={fetchData} />} />
+            <Route path='/vote' element={<VotePage election={data.election} />} />
+            <Route path='/results' element={<ViewElectionResults election={data.election} />} />
+            <Route path='/edit' element={<EditElection authSession={authSession} election={data.election} />} />
+            <Route path='/admin' element={<Admin authSession={authSession} />} />
+          </Routes>
+        </>
+      }
+    </>
+  )
+}
+
+export default Election

--- a/frontend/src/components/ElectionHome.tsx
+++ b/frontend/src/components/ElectionHome.tsx
@@ -22,85 +22,27 @@ import { ThemeProvider } from '@material-ui/styles';
 import TextField from "@material-ui/core/TextField";
 import Box from '@material-ui/core/Box';
 import { Tooltip } from "@material-ui/core";
-const ElectionHome = ({ authSession }) => {
+import VoterAuth from "./VoterAuth";
+const ElectionHome2 = ({ authSession, electionData, fetchElection }) => {
   const { id } = useParams();
-  const [isPending, setIsPending] = useState(true)
-  const [error, setError] = useState(null)
-  const [data, setData] = useState(null)
-  const [voterID, setVoterID] = useState('')
 
-  useEffect(() => {
-    fetchElection()
-  }, [])
-
-  const [rankings, setRankings] = useState([])
   const navigate = useNavigate();
-  console.log(data)
-  const onUpdate = (rankings) => {
-    setRankings(rankings)
-    console.log(rankings)
-  }
-
-  const fetchElection = () => {
-    const url = `/API/Election/${id}/ballot`;
-    const options = {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({})
+  const { data, isPending, error, makeRequest: postData } = useFetch(`/API/Election/${id}/finalize`, 'post')
+  const finalizeElection = async () => {
+    console.log("finalizing election")
+    try {
+      await postData()
+      await fetchElection()
+    } catch (err) {
+      console.log(err)
     }
-    fetch(url, options)
-      .then(res => {
-        if (!res.ok) {
-          setError('Error submitting ballot')
-          throw Error('Could not fetch data')
-        }
-        return res.json();
-      })
-      .then(data => {
-        setData(data);
-        setIsPending(false);
-        setError(null);
-      })
-      .catch(err => {
-        setIsPending(false);
-        setError(err.message);
-      })
-  }
-  const finalizeElection = () => {
-    const url = `/API/Election/${id}/finalize`;
-    const options = {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
-    }
-    fetch(url, options)
-      .then(res => {
-        if (!res.ok) {
-          setError('Error submitting ballot')
-          throw Error('Could not fetch data')
-        }
-        return res.json();
-      })
-      .then((data) =>
-        fetchElection()
-      )
-  }
-
-  const submitVoterID = () => {
-    authSession.setCookie('voter_id', voterID, 1)
-    fetchElection()
   }
 
   const electionStarted = () => {
     const currentTime = new Date()
-    if (!data.election.start_time) {
+    if (!electionData.election.start_time) {
       return true
-    } else if (new Date(data.election.start_time).getTime() < currentTime.getTime()) {
+    } else if (new Date(electionData.election.start_time).getTime() < currentTime.getTime()) {
       return true
     } else {
       return false
@@ -108,9 +50,9 @@ const ElectionHome = ({ authSession }) => {
   }
   const electionEnded = () => {
     const currentTime = new Date()
-    if (!data.election.end_time) {
+    if (!electionData.election.end_time) {
       return false
-    } else if (new Date(data.election.end_time).getTime() < currentTime.getTime()) {
+    } else if (new Date(electionData.election.end_time).getTime() < currentTime.getTime()) {
       return true
     } else {
       return false
@@ -121,54 +63,52 @@ const ElectionHome = ({ authSession }) => {
     <Container >
       <>
         {error && <div> {error} </div>}
-        {isPending && <div> Loading Election... </div>}
-
-        {data && data.voterAuth.authorized_voter && data.election &&
+        {electionData && electionData.voterAuth.authorized_voter && electionData.election &&
           <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
             <Grid container alignItems="center" justify="center" direction="column">
               <Typography align='center' gutterBottom variant="h4" component="h4">
-                {data.election.title}
+                {electionData.election.title}
               </Typography>
               <Typography align='left' gutterBottom component="p">
-                {data.election.description}
+                {electionData.election.description}
               </Typography>
-              {data.election.start_time && !electionStarted() &&
+              {electionData.election.start_time && !electionStarted() &&
                 <Typography align='center' gutterBottom variant="h6" component="h6">
-                  {`Election begins on ${new Date(data.election.start_time).toLocaleDateString()} at ${new Date(data.election.start_time).toLocaleTimeString()} `}
+                  {`Election begins on ${new Date(electionData.election.start_time).toLocaleDateString()} at ${new Date(electionData.election.start_time).toLocaleTimeString()} `}
                 </Typography>
               }
-              {data.election.end_time && electionEnded() &&
+              {electionData.election.end_time && electionEnded() &&
                 <Typography align='center' gutterBottom variant="h6" component="h6">
-                  {`Election ended on ${new Date(data.election.end_time).toLocaleDateString()} at ${new Date(data.election.end_time).toLocaleTimeString()} `}
+                  {`Election ended on ${new Date(electionData.election.end_time).toLocaleDateString()} at ${new Date(electionData.election.end_time).toLocaleTimeString()} `}
                 </Typography>
               }
 
-              {data.voterAuth.has_voted == false && electionStarted() && !electionEnded() &&
+              {electionData.voterAuth.has_voted == false && electionStarted() && !electionEnded() &&
                 <>
-                  {data.election.end_time &&
+                  {electionData.election.end_time &&
                     <Typography align='center' gutterBottom variant="h6" component="h6">
-                      {`Election ends on ${new Date(data.election.end_time).toLocaleDateString()} at ${new Date(data.election.end_time).toLocaleTimeString()} `}
+                      {`Election ends on ${new Date(electionData.election.end_time).toLocaleDateString()} at ${new Date(electionData.election.end_time).toLocaleTimeString()} `}
                     </Typography>}
-                  <Link to={`/Election/${String(data.election.election_id)}/vote`}>
+                  <Link to={`/Election/${String(electionData.election.election_id)}/vote`}>
                     <Typography align='center' gutterBottom variant="h6" component="h6">
                       Vote
                     </Typography>
                   </Link>
                 </>}
 
-              {data.voterAuth.has_voted == true &&
+              {electionData.voterAuth.has_voted == true &&
                 <Typography align='center' gutterBottom variant="h6" component="h6">
                   Ballot Submitted
                 </Typography>}
-              <Link to={`/Election/${data.election.election_id}/results`}>
+              <Link to={`/Election/${electionData.election.election_id}/results`}>
                 <Typography align='center' gutterBottom variant="h6" component="h6">
                   View Results
                 </Typography>
               </Link>
 
-              {data && data.election.state === 'draft' &&
+              {electionData && electionData.election.state === 'draft' &&
                 <>
-                  <Link to={`/Election/${data.election.election_id}/edit`}>
+                  <Link to={`/Election/${electionData.election.election_id}/edit`}>
                     <Typography align='center' gutterBottom variant="h6" component="h6">
                       Edit
                     </Typography>
@@ -178,55 +118,12 @@ const ElectionHome = ({ authSession }) => {
                   </Tooltip>
                 </>
               }
-
-
             </Grid>
           </Box>
-        }
-        {data && !data.voterAuth.authorized_voter && !data.voterAuth.required &&
-          <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
-            <Grid container alignItems="center" justify="center" direction="column">
-              <Typography align='center' gutterBottom variant="h4" component="h4">
-                You are not authorized to vote in this election
-              </Typography>
-            </Grid>
-          </Box>
-        }
-        {data && !data.voterAuth.authorized_voter && data.voterAuth.required && data.voterAuth.required === "Log In" &&
-          <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
-            <Grid container alignItems="center" justify="center" direction="column">
-              <Typography align='center' gutterBottom variant="h4" component="h4">
-                You must log in to access this election
-              </Typography>
-            </Grid>
-          </Box>
-        }
-        {data && !data.voterAuth.authorized_voter && data.voterAuth.required && data.voterAuth.required === "Voter ID" &&
-          <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
-            <Grid container alignItems="center" justify="center" direction="column">
-              <Typography align='center' gutterBottom variant="h4" component="h4">
-                Enter Voter ID
-              </Typography>
-
-              <TextField
-                id="voter-id"
-                name="voterid"
-                label="Voter ID"
-                type="text"
-                value={voterID}
-                onChange={(e) => {
-                  setVoterID(e.target.value)
-                }}
-              />
-
-              <Button variant='outlined' onClick={() => submitVoterID()} > Submit </Button>
-            </Grid>
-          </Box>
-
         }
       </>
     </Container>
   )
 }
 
-export default ElectionHome
+export default ElectionHome2

--- a/frontend/src/components/Elections.tsx
+++ b/frontend/src/components/Elections.tsx
@@ -2,7 +2,7 @@ import ElectionCard from "./ElectionCard"
 import Button from "./Button"
 import useFetch from "../useFetch"
 import { Link } from "react-router-dom"
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Election } from "../../../domain_model/Election"
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -18,7 +18,12 @@ const Elections = ({authSession}) => {
         url = `${url}?filter=${url_params.get('filter')}`
     }
     console.log(`fetch ${url}`)
-    const { data, isPending, error } = useFetch(url)
+    const { data, isPending, error, makeRequest: fetchElections } = useFetch(url,'get')
+
+    useEffect(() => {
+        fetchElections()
+    },[url])
+
     let elections = data as Election[];
     console.log(JSON.stringify(elections));
     return (
@@ -26,7 +31,6 @@ const Elections = ({authSession}) => {
             <main>
                 {error && <div> {error} </div>}
                 {isPending && <Typography align='center' variant="h3" component="h2"> Loading Elections... </Typography>}
-                {/* { elections && <Button color='steelblue' text='New Election' onClick={onNewElection} />} */}
                 {authSession.isLoggedIn() && <Link to='/CreateElection'> <Typography align='center' variant="h4" component="h3"> Create New Election</Typography></Link>}
                 <Container maxWidth="md">
                     <Grid container alignItems="stretch" spacing={4}>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const Sidebar = () => {
+    return (
+        <>
+        {/* TODO: add links to different pages based on user permissions */}
+        </>
+    )
+}
+
+export default Sidebar

--- a/frontend/src/components/ViewElectionResults.tsx
+++ b/frontend/src/components/ViewElectionResults.tsx
@@ -1,13 +1,15 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useParams } from "react-router";
 import useFetch from "../useFetch";
 import Results from './Results';
 import { Grid } from "@material-ui/core";
 import Box from '@material-ui/core/Box';
 
-const ViewElectionResults = () => {
+const ViewElectionResults = ({ election }) => {
     const {id} = useParams();
-    const {data, isPending, error} = useFetch(`/API/ElectionResult/${id}`)
+    const {data, isPending, error, makeRequest: getResults} = useFetch(`/API/ElectionResult/${id}`,'get')
+    useEffect(() => {getResults()},[])
+    
     console.log(data)
     return (
         //Using grid to force results into the center and fill screen on smaller screens.

--- a/frontend/src/components/ViewElectionRolls.tsx
+++ b/frontend/src/components/ViewElectionRolls.tsx
@@ -1,39 +1,26 @@
 import { useEffect, useState } from "react"
-import StarBallot from "./StarBallot";
 import useFetch from "../useFetch";
 import { useParams } from "react-router";
 import React from 'react'
-import { useNavigate } from "react-router";
-import { Ballot } from "../../../domain_model/Ballot";
-import { Vote } from "../../../domain_model/Vote";
-import { Score } from "../../../domain_model/Score";
-import Grid from "@material-ui/core/Grid";
 import Button from "@material-ui/core/Button";
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
 import Container from '@material-ui/core/Container';
-import IconButton from '@material-ui/core/IconButton'
-import ExpandLess from '@material-ui/icons/ExpandLess'
-import ExpandMore from '@material-ui/icons/ExpandMore'
-import ProfilePic from '../images/blank-profile.png'
-import { Link } from "react-router-dom"
-import { createTheme } from '@material-ui/core/styles';
-import { ThemeProvider } from '@material-ui/styles';
-import TextField from "@material-ui/core/TextField";
-import Box from '@material-ui/core/Box';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@material-ui/core";
 import EditElectionRoll from "./EditElectionRoll";
 
 const ViewElectionRolls = () => {
     const { id } = useParams();
-    const { data, isPending, error } = useFetch(`/API/Election/${id}/rolls`)
+    const { data, isPending, error, makeRequest } = useFetch(`/API/Election/${id}/rolls`,'get')
+    useEffect(() => {makeRequest()},[])
     const [isEditing, setIsEditing] = useState(false)
     const [editedRoll, setEditedRoll] = useState(null)
 
-    const onEdit = (roll) => {
+    const onOpen = (roll) => {
         setIsEditing(true)
         setEditedRoll({ ...roll })
-
+    }
+    const onClose = (roll) => {
+        setIsEditing(false)
+        setEditedRoll(null)
     }
     console.log(data)
     return (
@@ -42,7 +29,7 @@ const ViewElectionRolls = () => {
             {isPending && <div> Loading Data... </div>}
             {data && data.electionRoll && !isEditing &&
                 <TableContainer component={Paper}>
-                    <Table style={{ width: '100%'}} aria-label="simple table">
+                    <Table style={{ width: '100%' }} aria-label="simple table">
                         <TableHead>
                             <TableCell> Voter ID </TableCell>
                             <TableCell align="right"> Has Voted </TableCell>
@@ -57,7 +44,7 @@ const ViewElectionRolls = () => {
                                     </TableCell>
                                     <TableCell align="right" >{roll.submitted.toString()}</TableCell>
                                     <TableCell align="right" >{roll.state.toString()}</TableCell>
-                                    <TableCell align="right" ><Button variant='outlined' onClick={() => onEdit(roll)} > View </Button></TableCell>
+                                    <TableCell align="right" ><Button variant='outlined' onClick={() => onOpen(roll)} > View </Button></TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -65,7 +52,7 @@ const ViewElectionRolls = () => {
                 </TableContainer>
             }
             {isEditing && editedRoll &&
-                <EditElectionRoll roll={editedRoll} />
+                <EditElectionRoll roll={editedRoll} onClose={onClose}/>
             }
         </Container>
     )

--- a/frontend/src/components/ViewElectionRolls.tsx
+++ b/frontend/src/components/ViewElectionRolls.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react"
+import StarBallot from "./StarBallot";
+import useFetch from "../useFetch";
+import { useParams } from "react-router";
+import React from 'react'
+import { useNavigate } from "react-router";
+import { Ballot } from "../../../domain_model/Ballot";
+import { Vote } from "../../../domain_model/Vote";
+import { Score } from "../../../domain_model/Score";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import Container from '@material-ui/core/Container';
+import IconButton from '@material-ui/core/IconButton'
+import ExpandLess from '@material-ui/icons/ExpandLess'
+import ExpandMore from '@material-ui/icons/ExpandMore'
+import ProfilePic from '../images/blank-profile.png'
+import { Link } from "react-router-dom"
+import { createTheme } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/styles';
+import TextField from "@material-ui/core/TextField";
+import Box from '@material-ui/core/Box';
+import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@material-ui/core";
+import EditElectionRoll from "./EditElectionRoll";
+
+const ViewElectionRolls = () => {
+    const { id } = useParams();
+    const { data, isPending, error } = useFetch(`/API/Election/${id}/rolls`)
+    const [isEditing, setIsEditing] = useState(false)
+    const [editedRoll, setEditedRoll] = useState(null)
+
+    const onEdit = (roll) => {
+        setIsEditing(true)
+        setEditedRoll({ ...roll })
+
+    }
+    console.log(data)
+    return (
+        <Container >
+            {error && <div> {error} </div>}
+            {isPending && <div> Loading Data... </div>}
+            {data && data.electionRoll && !isEditing &&
+                <TableContainer component={Paper}>
+                    <Table style={{ width: '100%'}} aria-label="simple table">
+                        <TableHead>
+                            <TableCell> Voter ID </TableCell>
+                            <TableCell align="right"> Has Voted </TableCell>
+                            <TableCell align="right"> State </TableCell>
+                            <TableCell align="right"> View </TableCell>
+                        </TableHead>
+                        <TableBody>
+                            {data.electionRoll.map((roll) => (
+                                <TableRow key={roll.voter_id} >
+                                    <TableCell component="th" scope="row">
+                                        {roll.voter_id}
+                                    </TableCell>
+                                    <TableCell align="right" >{roll.submitted.toString()}</TableCell>
+                                    <TableCell align="right" >{roll.state.toString()}</TableCell>
+                                    <TableCell align="right" ><Button variant='outlined' onClick={() => onEdit(roll)} > View </Button></TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            }
+            {isEditing && editedRoll &&
+                <EditElectionRoll roll={editedRoll} />
+            }
+        </Container>
+    )
+}
+
+export default ViewElectionRolls

--- a/frontend/src/components/VoterAuth.tsx
+++ b/frontend/src/components/VoterAuth.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react"
+import StarBallot from "./StarBallot";
+import useFetch from "../useFetch";
+import { useParams } from "react-router";
+import React from 'react'
+import { useNavigate } from "react-router";
+import { Ballot } from "../../../domain_model/Ballot";
+import { Vote } from "../../../domain_model/Vote";
+import { Score } from "../../../domain_model/Score";
+import Grid from "@material-ui/core/Grid";
+import Button from "@material-ui/core/Button";
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import Container from '@material-ui/core/Container';
+import IconButton from '@material-ui/core/IconButton'
+import ExpandLess from '@material-ui/icons/ExpandLess'
+import ExpandMore from '@material-ui/icons/ExpandMore'
+import ProfilePic from '../images/blank-profile.png'
+import { Link } from "react-router-dom"
+import { createTheme } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/styles';
+import TextField from "@material-ui/core/TextField";
+import Box from '@material-ui/core/Box';
+import { Tooltip } from "@material-ui/core";
+const VoterAuth = ({ authSession, electionData, fetchElection }) => {
+  const { id } = useParams();
+  const [voterID, setVoterID] = useState('')
+
+  const navigate = useNavigate();
+
+  const submitVoterID = () => {
+    authSession.setCookie('voter_id', voterID, 1)
+    fetchElection()
+  }
+
+  return (
+    <Container >
+      <>
+        {electionData && !electionData.voterAuth.authorized_voter && !electionData.voterAuth.required &&
+          <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
+            <Grid container alignItems="center" justify="center" direction="column">
+              <Typography align='center' gutterBottom variant="h4" component="h4">
+                You are not authorized to vote in this election
+              </Typography>
+            </Grid>
+          </Box>
+        }
+        {electionData && !electionData.voterAuth.authorized_voter && electionData.voterAuth.required && electionData.voterAuth.required === "Log In" &&
+          <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
+            <Grid container alignItems="center" justify="center" direction="column">
+              <Typography align='center' gutterBottom variant="h4" component="h4">
+                You must log in to access this election
+              </Typography>
+            </Grid>
+          </Box>
+        }
+        {electionData && !electionData.voterAuth.authorized_voter && electionData.voterAuth.required && electionData.voterAuth.required === "Voter ID" &&
+          <Box border={2} sx={{ mt: 5, ml: 0, mr: 0, width: '100%' }}>
+            <Grid container alignItems="center" justify="center" direction="column">
+              <Typography align='center' gutterBottom variant="h4" component="h4">
+                Enter Voter ID
+              </Typography>
+
+              <TextField
+                id="voter-id"
+                name="voterid"
+                label="Voter ID"
+                type="text"
+                value={voterID}
+                onChange={(e) => {
+                  setVoterID(e.target.value)
+                }}
+              />
+
+              <Button variant='outlined' onClick={() => submitVoterID()} > Submit </Button>
+            </Grid>
+          </Box>
+
+        }
+      </>
+    </Container>
+  )
+}
+
+export default VoterAuth

--- a/frontend/src/useFetch.js
+++ b/frontend/src/useFetch.js
@@ -1,33 +1,39 @@
 import { useEffect, useState } from "react";
 
 
-const useFetch = (url,options) => {
-    const [isPending,setIsPending] = useState(true)
-    const [error,setError] = useState(null)
-    const [data,setData] = useState(null)
+const useFetch = (url, method) => {
+    const [isPending, setIsPending] = useState(true)
+    const [error, setError] = useState(null)
+    const [data, setData] = useState(null)
 
-
-    useEffect(() => {
-        setTimeout(() => {
-            fetch(url,options)
-            .then(res => {
-                if(!res.ok) {
-                    throw Error('Could not fetch data')
-                }
-                return res.json();
-            })
-            .then(data=> {
-                setData(data);
-                setIsPending(false);
-                setError(null);
-            })
-            .catch(err => {
-                setIsPending(false);
-                setError(err.message);
-            })
-        },1000);
-    },[url])
-    return {data, isPending, error}
+    const makeRequest = async (data) => {
+        const options = {
+            method: method,
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data)
+        }
+        try {
+            const res = await fetch(url, options)
+            if (!res.ok) {
+                console.log(res)
+                const data = await res.json();
+                throw Error(`Error making request: ${res.status.toString()}: ${data.error}`)
+            }
+            const data = await res.json();
+            setData(data);
+            setIsPending(false);
+            setError(null);
+            return true
+        } catch (err) {
+            setIsPending(false);
+            setError(err.message);
+            return false
+        }
+    }
+    return { data, isPending, error, makeRequest }
 }
 
 export default useFetch;

--- a/frontend/src/useFetch.js
+++ b/frontend/src/useFetch.js
@@ -18,9 +18,13 @@ const useFetch = (url, method) => {
         try {
             const res = await fetch(url, options)
             if (!res.ok) {
-                console.log(res)
-                const data = await res.json();
-                throw Error(`Error making request: ${res.status.toString()}: ${data.error}`)
+                if (res.json.length > 0) {
+                    console.log(res)
+                    const data = await res.json();
+                    throw Error(`Error making request: ${res.status.toString()}: ${data.error}`)
+                } else {
+                    throw Error(`Error making request: ${res.status.toString()}`)
+                }
             }
             const data = await res.json();
             setData(data);


### PR DESCRIPTION
Lots of little changes in this. Will probably have conflicts with Scott's PRs but can resolve that later. Just wanted to create this PR before I start adding even more to it.

-Adds credentialer role which has limited permissions to approve and flag election rolls.
-Adds history and state to election role
-Adds logic for how election role state can change. This is probably not the cleanest implementation so I'm open to other suggestions
-Moved routes of /Election/:id/* from main app to new election component. The new component does a single fetch for election data and flows it into subpages.
-Moved authSession code from main app to its own file
-Updated useFetch to output an async function that can be called to make the request, rather than call it on its own. The reason for that is so we can better control when it is called and can pass the function into subcomponents to be called there. For example, the request to fetch election data can be passed into the VoterAuth component so it can refetch the election data after voter id is entered. The function also returns true if the response is ok, false if not, for cases where we want to check before automatically proceeding with something like navigating to another page.
-Adds /Election/:id/Admin page that shows tables of election rolls and histories. Not fully fleshed out yet.
-Adds placeholder for sidebar menu.