### PR TITLE
sets up the Mock ServiceLocator

### DIFF
--- a/backend/src/ServiceLocator.ts
+++ b/backend/src/ServiceLocator.ts
@@ -55,4 +55,4 @@ function electionRollDb():ElectionRollDB {
 }
 
 
-export  default { postgres, ballotsDb, electionsDb, electionRollDb };
+export  default { ballotsDb, electionsDb, electionRollDb };

--- a/backend/src/__mocks__/ServiceLocator.ts
+++ b/backend/src/__mocks__/ServiceLocator.ts
@@ -1,0 +1,32 @@
+import Logger from "../Services/Logging/Logger";
+import BallotsDB from "../Models/__mocks__/Ballots";
+import ElectionsDB from "../Models/__mocks__/Elections";
+import ElectionRollDB from "../Models/__mocks__/ElectionRolls";
+
+var _ballotsDb:BallotsDB;
+var _electionsDb:ElectionsDB;
+var _electionRollDb:ElectionRollDB;
+
+function ballotsDb():BallotsDB {
+    if (_ballotsDb == null){
+        _ballotsDb = new BallotsDB();
+    }
+    return _ballotsDb;
+}
+
+function electionsDb():ElectionsDB {
+    if (_electionsDb == null){
+        _electionsDb = new ElectionsDB();
+    }
+    return _electionsDb;
+}
+
+function electionRollDb():ElectionRollDB {
+    if (_electionRollDb == null){
+        _electionRollDb = new ElectionRollDB();
+    }
+    return _electionRollDb;
+}
+
+
+export  default { ballotsDb, electionsDb, electionRollDb };

--- a/backend/src/test/createElection.test.ts
+++ b/backend/src/test/createElection.test.ts
@@ -7,11 +7,9 @@ import { TestHelper } from "./TestHelper";
 
 const th = new TestHelper();
 
-// Mocks databases for testing app
-// Uses mocks defined in ./../Models/__Mocks__/
-jest.mock("./../Models/Ballots");
-jest.mock("./../Models/Elections");
-jest.mock("./../Models/ElectionRolls");
+// Uses the mock service locator in place of the production one
+// Which users mock databases
+jest.mock("./../ServiceLocator");
 
 afterEach(() => {
   jest.clearAllMocks();

--- a/backend/src/test/editElection.test.ts
+++ b/backend/src/test/editElection.test.ts
@@ -6,12 +6,9 @@ import testInputs from './testInputs';
 
 const th = new TestHelper();
 
-// Mocks databases for testing app
-// Uses mocks defined in ./../Models/__Mocks__/
-jest.mock('./../Models/Ballots')
-jest.mock('./../Models/Elections')
-jest.mock('./../Models/ElectionRolls')
-
+// Uses the mock service locator in place of the production one
+// Which users mock databases
+jest.mock("./../ServiceLocator");
 
 afterEach(() => {
     jest.clearAllMocks();

--- a/backend/src/test/emailRoll.test.ts
+++ b/backend/src/test/emailRoll.test.ts
@@ -3,11 +3,9 @@ const request = require("supertest");
 import { TestHelper } from "./TestHelper";
 import testInputs from "./testInputs";
 
-// Mocks databases for testing app
-// Uses mocks defined in ./../Models/__Mocks__/
-jest.mock("./../Models/Ballots");
-jest.mock("./../Models/Elections");
-jest.mock("./../Models/ElectionRolls");
+// Uses the mock service locator in place of the production one
+// Which users mock databases
+jest.mock("./../ServiceLocator");
 
 const th = new TestHelper();
 

--- a/backend/src/test/idRoll.test.ts
+++ b/backend/src/test/idRoll.test.ts
@@ -4,11 +4,9 @@ import { TestHelper } from './TestHelper';
 import testInputs from './testInputs';
 
 
-// Mocks databases for testing app
-// Uses mocks defined in ./../Models/__Mocks__/
-jest.mock('./../Models/Ballots')
-jest.mock('./../Models/Elections')
-jest.mock('./../Models/ElectionRolls')
+// Uses the mock service locator in place of the production one
+// Which users mock databases
+jest.mock("./../ServiceLocator");
 
 const th = new TestHelper();
 

--- a/backend/src/test/register.test.ts
+++ b/backend/src/test/register.test.ts
@@ -7,11 +7,9 @@ import testInputs from './testInputs';
 
 const app = makeApp()
 
-// Mocks databases for testing app
-// Uses mocks defined in ./../Models/__Mocks__/
-jest.mock('./../Models/Ballots')
-jest.mock('./../Models/Elections')
-jest.mock('./../Models/ElectionRolls')
+// Uses the mock service locator in place of the production one
+// Which users mock databases
+jest.mock("./../ServiceLocator");
 
 var logger = new TestLoggerImpl().setup();
 


### PR DESCRIPTION
This sets up a Mock for the Service Locator, rather than mocking each databases individually.  This will be required for updating the mock-databases to handle atomic transactions across multiple tables.