### PR TITLE
changing ballot_id and election_id to be Uids

### DIFF
--- a/backend/src/Controllers/ballots.controllers.ts
+++ b/backend/src/Controllers/ballots.controllers.ts
@@ -3,6 +3,7 @@ import { reqIdSuffix } from "../IRequest";
 import Logger from "../Services/Logging/Logger";
 import ServiceLocator from "../ServiceLocator";
 import { responseErr } from '../Util';
+import { randomUUID } from 'crypto';
 
 var BallotModel =  ServiceLocator.ballotsDb();
 const className = 'Ballots.Controllers';
@@ -52,6 +53,7 @@ const returnBallots = async (req: any, res: any, next: any) => {
 const submitBallot = async (req: any, res: any, next: any) => {
 
     const inputBallot = req.body.ballot;
+    inputBallot.ballot_id = randomUUID();
     const validationErr = ballotValidation(inputBallot);
     if (validationErr){
         Logger.info(req, "Invalid Ballot: "+ validationErr);

--- a/backend/src/Controllers/controllerUtils.ts
+++ b/backend/src/Controllers/controllerUtils.ts
@@ -5,6 +5,7 @@ import { BadRequest, InternalServerError, Unauthorized } from "@curveball/http-e
 import { Request, Response } from 'express';
 import { roles } from "../../../domain_model/roles";
 import { hasPermission, permission, permissions } from '../../../domain_model/permissions';
+import { randomUUID } from "crypto";
 var jwt = require('jsonwebtoken')
 
 export function expectUserFromRequest(req:IRequest ):any {
@@ -17,6 +18,7 @@ export function expectUserFromRequest(req:IRequest ):any {
 
 export function expectValidElectionFromRequest(req:IRequest):Election {
     const inputElection = req.body.Election;
+    inputElection.election_id = randomUUID();
     const validationErr = electionValidation(inputElection);
     if (validationErr) {
         Logger.info(req, "Invalid Election: " + validationErr, inputElection);

--- a/backend/src/Models/Ballots.ts
+++ b/backend/src/Models/Ballots.ts
@@ -1,4 +1,5 @@
 import { Ballot } from '../../../domain_model/Ballot';
+import { Uid } from '../../../domain_model/Uid';
 import { ILoggingContext } from '../Services/Logging/ILogger';
 import Logger from '../Services/Logging/Logger';
 const className = 'BallotsDB';
@@ -19,7 +20,7 @@ export default class BallotsDB {
         Logger.debug(appInitContext, "BallotsDB.init");
         var query = `
         CREATE TABLE IF NOT EXISTS ${this._tableName} (
-            ballot_id       SERIAL PRIMARY KEY,
+            ballot_id       VARCHAR PRIMARY KEY,
             election_id     VARCHAR,
             user_id         VARCHAR,
             status          VARCHAR,
@@ -47,19 +48,21 @@ export default class BallotsDB {
 
     submitBallot(ballot: Ballot, ctx:ILoggingContext, reason:String): Promise<Ballot> {
         Logger.debug(ctx, `${className}.submit`, ballot);
-        var sqlString = `INSERT INTO ${this._tableName} (election_id,user_id,status,date_submitted,ip_address,votes,history)
+        var sqlString = `INSERT INTO ${this._tableName} (ballot_id,election_id,user_id,status,date_submitted,ip_address,votes,history)
         VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING ballot_id;`;
         Logger.debug(ctx, sqlString);
         var p = this._postgresClient.query({
             rowMode: 'array',
             text: sqlString,
-            values: [ballot.election_id,
-            ballot.user_id,
-            ballot.status,
-            ballot.date_submitted,
-            ballot.ip_address,
-            JSON.stringify(ballot.votes),
-            JSON.stringify(ballot.history)]
+            values: [
+                ballot.ballot_id,
+                ballot.election_id,
+                ballot.user_id,
+                ballot.status,
+                ballot.date_submitted,
+                ballot.ip_address,
+                JSON.stringify(ballot.votes),
+                JSON.stringify(ballot.history)]
         });
 
         return p.then((res: any) => {
@@ -110,7 +113,7 @@ export default class BallotsDB {
         });
     }
 
-    delete(ballot_id: string,  ctx:ILoggingContext, reason:string): Promise<boolean> {
+    delete(ballot_id: Uid,  ctx:ILoggingContext, reason:string): Promise<boolean> {
         Logger.debug(ctx, `${className}.delete ${ballot_id}`);
         var sqlString = `DELETE FROM ${this._tableName} WHERE ballot_id = $1`;
         Logger.debug(ctx, sqlString);

--- a/backend/src/Models/Elections.ts
+++ b/backend/src/Models/Elections.ts
@@ -1,4 +1,5 @@
 import { Election } from '../../../domain_model/Election';
+import { Uid } from '../../../domain_model/Uid';
 import { ILoggingContext } from '../Services/Logging/ILogger';
 import Logger from '../Services/Logging/Logger';
 const className = 'ElectionsDB';
@@ -19,11 +20,11 @@ export default class ElectionsDB {
         Logger.debug(appInitContext, "-> ElectionsDB.init")
         var query = `
         CREATE TABLE IF NOT EXISTS ${this._tableName} (
-            election_id  SERIAL PRIMARY KEY,
+            election_id  VARCHAR PRIMARY KEY,
             title       VARCHAR,
             description TEXT,
             frontend_url VARCHAR,
-            start_time    VARCHAR, 
+            start_time    VARCHAR,
             end_time      VARCHAR, 
             support_email VARCHAR,
             owner_id      VARCHAR,
@@ -54,25 +55,28 @@ export default class ElectionsDB {
 
     createElection(election: Election, ctx:ILoggingContext, reason:string): Promise<Election> {
         Logger.debug(ctx, `${className}.createElection`, election);
-        var sqlString = `INSERT INTO ${this._tableName} (title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,credential_ids,state,races,settings)
+        var sqlString = `INSERT INTO ${this._tableName} (election_id, title,description,frontend_url,start_time,end_time,support_email,owner_id,audit_ids,admin_ids,credential_ids,state,races,settings)
         VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,$13) RETURNING *;`;
         Logger.debug(ctx, sqlString);
         
         var p = this._postgresClient.query({
             text: sqlString,
-            values: [election.title,
-            election.description,
-            election.frontend_url,
-            election.start_time,
-            election.end_time,
-            election.support_email,
-            election.owner_id,
-            JSON.stringify(election.audit_ids),
-            JSON.stringify(election.admin_ids),
-            JSON.stringify(election.credential_ids),
-            election.state,
-            JSON.stringify(election.races),
-            JSON.stringify(election.settings)]
+            values: [
+                election.election_id,
+                election.title,
+                election.description,
+                election.frontend_url,
+                election.start_time,
+                election.end_time,
+                election.support_email,
+                election.owner_id,
+                JSON.stringify(election.audit_ids),
+                JSON.stringify(election.admin_ids),
+                JSON.stringify(election.credential_ids),
+                election.state,
+                JSON.stringify(election.races),
+                JSON.stringify(election.settings)
+            ]
         });
 
         return p.then((res: any) => {
@@ -146,7 +150,7 @@ export default class ElectionsDB {
         });
     }
 
-    getElectionByID(election_id: string, ctx:ILoggingContext): Promise<Election | null> {
+    getElectionByID(election_id: Uid, ctx:ILoggingContext): Promise<Election | null> {
         Logger.debug(ctx, `${className}.getElectionByID ${election_id}`);
         var sqlString = `SELECT * FROM ${this._tableName} WHERE election_id = $1`;
         Logger.debug(ctx, sqlString);
@@ -165,7 +169,7 @@ export default class ElectionsDB {
         });
     }
 
-    delete(election_id: string, ctx:ILoggingContext, reason: string): Promise<boolean> {
+    delete(election_id: Uid, ctx:ILoggingContext, reason: string): Promise<boolean> {
         Logger.debug(ctx, `${className}.delete ${election_id}`);
         var sqlString = `DELETE FROM ${this._tableName} WHERE election_id = $1`;
         Logger.debug(ctx, sqlString);

--- a/backend/src/Models/__mocks__/Ballots.ts
+++ b/backend/src/Models/__mocks__/Ballots.ts
@@ -1,16 +1,14 @@
 import { Ballot } from '../../../../domain_model/Ballot';
+import { Uid } from '../../../../domain_model/Uid';
 
 export default class BallotsDB {
 
     ballots: Ballot[] = [];
-    nextId = 0;
 
     constructor() {
     }
     submitBallot(ballot: Ballot): Promise<Ballot>{
         var copy = JSON.parse(JSON.stringify(ballot));
-        copy.ballot_id = this.nextId;
-        this.nextId++;
         this.ballots.push(copy)
         return Promise.resolve(JSON.parse(JSON.stringify(copy)));
     }
@@ -22,7 +20,7 @@ export default class BallotsDB {
         var resBallots = JSON.parse(JSON.stringify(ballots));
         return Promise.resolve(resBallots)
     }
-    delete(ballot_id: number): Promise<Ballot | null> {
+    delete(ballot_id: Uid): Promise<Ballot | null> {
         const ballot = this.ballots.find(ballot => ballot.ballot_id===ballot_id)
         if (!ballot){
             return Promise.resolve(null)

--- a/backend/src/Models/__mocks__/Elections.ts
+++ b/backend/src/Models/__mocks__/Elections.ts
@@ -1,11 +1,11 @@
 import { Election } from '../../../../domain_model/Election';
+import { Uid } from '../../../../domain_model/Uid';
 import { ILoggingContext } from '../../Services/Logging/ILogger';
 import Logger from '../../Services/Logging/Logger';
 
 export default class ElectionsDB {
 
     elections: Election[] = [];
-    nextId = 0;
 
     constructor() {
     }
@@ -13,8 +13,6 @@ export default class ElectionsDB {
     createElection(election: Election, ctx:ILoggingContext): Promise<Election>{
         Logger.debug(ctx, "Election Mock Creates Election: ", election);
         var copy = JSON.parse(JSON.stringify(election));
-        copy.election_id = this.nextId;
-        this.nextId++;
         this.elections.push(copy);
         var res = JSON.parse(JSON.stringify(copy));
         return Promise.resolve(res);
@@ -47,7 +45,7 @@ export default class ElectionsDB {
         return Promise.resolve(elections)
     }
 
-    getElectionByID(election_id: number, ctx:ILoggingContext): Promise<Election | null>{
+    getElectionByID(election_id: Uid, ctx:ILoggingContext): Promise<Election | null>{
         Logger.debug(ctx, `Mock Election DB getElection ${election_id}`);
         const election = this.elections.find(election => {
             return election.election_id==election_id;
@@ -60,7 +58,7 @@ export default class ElectionsDB {
         return Promise.resolve(election)
     }
 
-    delete(election_id: number, ctx:ILoggingContext): Promise<Election | null> {
+    delete(election_id: Uid, ctx:ILoggingContext): Promise<Election | null> {
         const election = this.elections.find(election => election.election_id==election_id)
         if (!election){
             return Promise.resolve(null)

--- a/backend/src/test/TestHelper.ts
+++ b/backend/src/test/TestHelper.ts
@@ -1,5 +1,6 @@
 import { Ballot } from "../../../domain_model/Ballot";
 import { Election } from "../../../domain_model/Election";
+import { Uid } from "../../../domain_model/Uid";
 import { VoterAuth } from "../../../domain_model/VoterAuth";
 import makeApp from "../app";
 import Logger from "../Services/Logging/Logger";
@@ -99,7 +100,7 @@ export class TestHelper {
     }
 
     async fetchElectionById(
-        electionId: string | number,
+        electionId: Uid,
         userToken: string | null
     ): Promise<ElectionResponse> {
         const res = await this.getRequest(
@@ -110,7 +111,7 @@ export class TestHelper {
     }
 
     async submitBallot(
-        electionId: string | number,
+        electionId: Uid,
         ballot: Ballot,
         userToken: string | null
     ): Promise<any> {
@@ -122,7 +123,7 @@ export class TestHelper {
     }
 
     async requestBallot(
-        electionId: string | number,
+        electionId: Uid,
         userToken: string | null
     ): Promise<BallotResponse> {
         const res = await this.postRequest(
@@ -143,7 +144,7 @@ export class TestHelper {
     }
 
     async requestBallotWithId(
-        electionId: string | number,
+        electionId: Uid,
         userToken: string | null,
         voterId: string | null
     ): Promise<BallotResponse> {
@@ -167,7 +168,7 @@ export class TestHelper {
     }
 
     async submitBallotWithId(
-        electionId: string | number,
+        electionId: Uid,
         ballot: Ballot,
         userToken: string | null,
         voterId: string | null

--- a/backend/src/test/editElection.test.ts
+++ b/backend/src/test/editElection.test.ts
@@ -24,7 +24,7 @@ const setupInitialElection = async () => {
     return response.election.election_id;
 }
 
-const fetchElectionById = async (electionId:number):Promise<Election> => {
+const fetchElectionById = async (electionId:string):Promise<Election> => {
     const response = await th.fetchElectionById(electionId, testInputs.user1token);
     expect(response.election).toBeTruthy();
     return response.election;
@@ -36,8 +36,10 @@ describe("Edit Election", () => {
         test("responds with 200 status", async () => {
             const electionId = await setupInitialElection();
             console.log("electionId = "+electionId);
+            const election1Copy = { ...testInputs.Election1, election_id:electionId};
+            //election1Copy.election_id = electionId;
 
-            const response = await th.editElection(testInputs.Election1, [], testInputs.user1token);
+            const response = await th.editElection(election1Copy, [], testInputs.user1token);
             expect(response.statusCode).toBe(200);
             th.testComplete();
         })
@@ -64,8 +66,9 @@ describe("Edit Election", () => {
 
     describe("User is not owner", () => {
         test("responds with 401 status", async () => {
-            const ID = await setupInitialElection()
-            const response = await th.editElection(testInputs.Election1, [], testInputs.user2token);
+            const ID = await setupInitialElection();
+            const election1Copy = { ...testInputs.Election1, election_id:ID};
+            const response = await th.editElection(election1Copy, [], testInputs.user2token);
             expect(response.statusCode).toBe(401);
             th.testComplete();
         })

--- a/backend/src/test/emailRoll.test.ts
+++ b/backend/src/test/emailRoll.test.ts
@@ -20,7 +20,7 @@ describe("Email Roll", () => {
     beforeAll(() => {
         jest.clearAllMocks();
     });
-    var electionId = 0;
+    var electionId = "";
     test("Create election, responds 200", async () => {
         const response = await th.createElection(
             testInputs.EmailRollElection,

--- a/backend/src/test/idRoll.test.ts
+++ b/backend/src/test/idRoll.test.ts
@@ -22,7 +22,7 @@ describe("ID Roll", () => {
     beforeAll(() => {
         jest.resetAllMocks();
     });
-    var ID = 0;
+    var ID = "";
     test("Create election, responds 200", async () => {
         const response = await th.createElection(testInputs.IDRollElection,  testInputs.IDRoll, testInputs.user1token);
 

--- a/backend/src/test/testInputs.ts
+++ b/backend/src/test/testInputs.ts
@@ -26,7 +26,7 @@ export default {
      }, "privateKey"),
     
      Election1 : {
-         election_id: 0,
+         election_id: "0",
          title: 'Election 1',
          state: 'draft',
          frontend_url: '',
@@ -39,7 +39,7 @@ export default {
      } as Election,
 
      IncompleteElection : {
-        election_id: 0,
+        election_id: "0",
         title: 'Election 1',
         state: 'draft',
         frontend_url: '',
@@ -47,7 +47,7 @@ export default {
     } as Election,
     
     EmailRollElection : {
-        election_id: 0,
+        election_id: "0",
         title: 'Election 1',
         state: 'open',
         frontend_url: '',
@@ -86,7 +86,7 @@ export default {
         'Bob@email.com'
     ],
     Ballot1: {
-        ballot_id: 0,
+        ballot_id: "0",
         election_id: "7",
         status: 'Submitted',
         date_submitted: Date.now(),
@@ -110,7 +110,7 @@ export default {
     } as Ballot,
 
     IDRollElection : {
-        election_id: 0,
+        election_id: "0",
         title: 'Election 1',
         state: 'open',
         frontend_url: '',
@@ -148,7 +148,7 @@ export default {
         'BobID'
     ],
     Ballot2: {
-        ballot_id: 0,
+        ballot_id: "0",
         election_id: "8",
         status: 'Submitted',
         date_submitted: Date.now(),

--- a/domain_model/Ballot.ts
+++ b/domain_model/Ballot.ts
@@ -2,7 +2,7 @@ import { Uid } from "./Uid";
 import { Vote } from "./Vote";
 
 export interface Ballot {
-    ballot_id:  number; //ID if ballot
+    ballot_id:  Uid; //ID if ballot
     election_id: Uid; //ID of election ballot is cast in
     user_id?: Uid; //ID of user who cast ballot TODO: replace with voter ID
     status: string; //Status of string (saved, submitted)
@@ -26,10 +26,10 @@ export function ballotValidation(obj:Ballot): string | null {
     }
     //TODO - currently some disagreement on the type of the Election Id...
     //technically Uid expects a string, but the DB currently using numbers
-    if (typeof obj.election_id !== 'string' && typeof obj.election_id !== 'number'){
+    if (!obj.election_id || typeof obj.election_id !== 'string'){
         return "Invalid Election ID";
     }
-    if (typeof obj.ballot_id !== 'number'){
+    if (!obj.ballot_id || typeof obj.ballot_id !== 'string'){
         return "Invalid Ballot ID";
     }
     if (!obj.votes){

--- a/domain_model/Election.ts
+++ b/domain_model/Election.ts
@@ -3,7 +3,7 @@ import { Race } from "./Race";
 import { Uid } from "./Uid";
 
 export interface Election {
-    election_id:    number; // identifier assigned by the system
+    election_id:    Uid; // identifier assigned by the system
     title:          string; // one-line election title
     description?:   string; // mark-up text describing the election
     frontend_url:   string; // base URL for the frontend
@@ -24,7 +24,8 @@ export function electionValidation(obj:Election): string | null {
   if (!obj){
     return "Election is null";
   }
-  if (typeof obj.election_id !== 'number'){
+  const election_id = obj.election_id;
+  if (!election_id || typeof election_id !== 'string'){
       return "Invalid Election ID";
   }
   if (typeof obj.title !== 'string'){


### PR DESCRIPTION
Updates ballot_id and election_id to be uuids (universally unique ids).  This means they can be generate by different processes without coordination.

THIS WILL BREAK production data, and should be accompanied by a wipe of the prod database.  (theoretically we could run a migration, but since we don't have any needed data yet, just nuke it)