### PR TITLE
Event queue batch size switched to team size

### DIFF
--- a/backend/src/Services/EventQueue/PGBossEventQueue.ts
+++ b/backend/src/Services/EventQueue/PGBossEventQueue.ts
@@ -26,7 +26,7 @@ export default class PGBossEventQueue implements IEventQueue {
     }
 
     public subscribe(queue:QueueName, handler:EventHandler):void {
-        const options = { newJobCheckInterval: 500, batchSize: 5 };
+        const options = { newJobCheckInterval: 500, teamSize: 5 };
         this._boss.work(queue, options, handler);
     }
 


### PR DESCRIPTION
Minor change to use teamSize instead of batchSize. This will still run 5 jobs in a polling period but uses one job per handler instead of passing an array of jobs to the handler.