### PR TITLE
Permission Handling, thanks for voting page, edit roles page

### DIFF
--- a/backend/src/Controllers/editElectionController.ts
+++ b/backend/src/Controllers/editElectionController.ts
@@ -39,7 +39,7 @@ const editElection = async (req: any, res: any, next: any) => {
     req.election = updatedElection
     Logger.debug(req, `editElection succeeds for ${updatedElection.election_id}`);
 
-    res.json({ election: req.election, voterAuth: { authorized_voter: req.authorized_voter, has_voted: req.has_voted, roles: req.user_auth.roles } })
+    res.json({ election: req.election, voterAuth: { authorized_voter: req.authorized_voter, has_voted: req.has_voted, roles: req.user_auth.roles, permissions: req.user_auth.permissions  } })
 }
 
 module.exports = {

--- a/backend/src/Controllers/editElectionRolesController.ts
+++ b/backend/src/Controllers/editElectionRolesController.ts
@@ -1,0 +1,41 @@
+import { electionValidation } from '../../../domain_model/Election';
+import ServiceLocator from '../ServiceLocator';
+import Logger from '../Services/Logging/Logger';
+import { responseErr } from '../Util';
+import { expectPermission } from "./controllerUtils";
+import { permissions } from '../../../domain_model/permissions';
+import { BadRequest } from "@curveball/http-errors";
+
+var ElectionsModel = ServiceLocator.electionsDb();
+
+
+const editElectionRoles = async (req: any, res: any, next: any) => {
+
+    const inputElection = req.body.Election;
+    Logger.info(req, `editElectionRoles: ${req.election.election_id}`)
+    expectPermission(req.user_auth.roles, permissions.canEditElectionRoles)
+    // TODO: should this only be allowed in draft??
+    // if (inputElection.state !== 'draft') {
+    //     Logger.info(req, `Election is not editable, state=${inputElection.state}`);
+    //     throw new BadRequest("Election is not editable")
+    // }
+    
+    var failMsg = "Failed to update Election roles";
+    req.election.admin_ids = req.body.admin_ids
+    req.election.audit_ids = req.body.audit_ids
+    req.election.credential_ids = req.body.credential_ids
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Update election roles`);
+    if (!updatedElection) {
+        Logger.info(req, failMsg);
+        throw new BadRequest(failMsg)
+    }
+
+    req.election = updatedElection
+    Logger.debug(req, `editElectionRoles succeeds for ${updatedElection.election_id}`);
+
+    res.status('200').json({election: req.election})
+}
+
+module.exports = {
+    editElectionRoles
+}

--- a/backend/src/Controllers/elections.controllers.ts
+++ b/backend/src/Controllers/elections.controllers.ts
@@ -4,6 +4,7 @@ import Logger from '../Services/Logging/Logger';
 import { responseErr } from '../Util';
 import { IRequest } from '../IRequest';
 import { roles } from "../../../domain_model/roles"
+import { getPermissions } from '../../../domain_model/permissions';
 
 
 var ElectionsModel =  ServiceLocator.electionsDb();
@@ -77,6 +78,7 @@ const electionPostAuthMiddleware = async (req: any, res: any, next: any) => {
             req.user_auth.roles.push(roles.credentialer)
           }
         }
+        req.user_auth.permissions = getPermissions(req.user_auth.roles)
         Logger.debug(req, `done with electionPostAuthMiddleware...`);
         Logger.debug(req,req.user_auth);
         return next();
@@ -133,7 +135,7 @@ const returnElection = async (req: any, res: any, next: any) => {
     Logger.info(req, `${className}.returnElection ${req.params.id}`)
     var election = req.election;
     removeHiddenFields(election, req.electionRollEntry);
-    res.json({ election: election, voterAuth: { authorized_voter: req.authorized_voter, has_voted: req.has_voted, roles: req.user_auth.roles} })
+    res.json({ election: election, voterAuth: { authorized_voter: req.authorized_voter, has_voted: req.has_voted, roles: req.user_auth.roles, permissions: req.user_auth.permissions } })
 }
 
 module.exports = {

--- a/backend/src/Routes/elections.routes.js
+++ b/backend/src/Routes/elections.routes.js
@@ -18,6 +18,7 @@ const { getBallotsByElectionID } = require('../Controllers/getBallotsByElectionI
 const { editElection } = require('../Controllers/editElectionController')
 const { getSandboxResults } = require('../Controllers/sandboxController')
 const { getElections } = require('../Controllers/getElectionsController')
+const { editElectionRoles } = require('../Controllers/editElectionRolesController')
 const { permissions } = require('../../../domain_model/permissions');
 const { ElectionRollState } = require('../../../domain_model/ElectionRoll');
 const asyncHandler = require('express-async-handler')
@@ -45,6 +46,7 @@ router.get('/Elections', asyncHandler(getElections))
 router.post('/Elections/', asyncHandler(createElectionController.createElectionController))
 
 router.post('/Election/:id/edit', asyncHandler(editElection))
+router.put('/Election/:id/roles', asyncHandler(editElectionRoles))
 router.get('/ElectionResult/:id', asyncHandler(getElectionResults))
 router.post('/Election/:id/vote', asyncHandler(castVoteController))
 router.post('/Election/:id/finalize',asyncHandler(finalizeElection))

--- a/domain_model/permissions.ts
+++ b/domain_model/permissions.ts
@@ -28,3 +28,16 @@ export const permissions = {
 export const hasPermission = (roles:roles[],permission:permission) => {
   return roles.some( (role) => permission.includes(role))
 }
+
+export const getPermissions = (roles:roles[]) => {
+  //Will likely rework permissions and roles in the future so that each role has list of permissions instead
+  //This is a temp workaround to get all permissions to send to frontend so it can control what users can see/do
+  const userPermissions:any = []
+  let p: keyof typeof permissions
+  for(p in permissions ){
+    if (roles.some( (role) => permissions[p].includes(role))){
+      userPermissions.push(p)
+    }
+  }
+  return userPermissions
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,9 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@date-io/date-fns": "^1.3.13",
+        "@emotion/react": "^11.10.4",
+        "@emotion/styled": "^11.10.4",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/pickers": "^3.3.10",
+        "@mui/icons-material": "^5.10.9",
+        "@mui/material": "^5.10.10",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
@@ -1804,10 +1808,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "license": "MIT",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.0.tgz",
+      "integrity": "sha512-NDYdls71fTXoU8TZHfbBWg7DiZfNzClcKui/+kyi6ppD2L1qnWW3VV6CjtaBXSUGGhiTWJ6ereOIkUvenif66Q==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2111,9 +2116,178 @@
         "date-fns": "^2.0.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz",
+      "integrity": "sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.1",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.1.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.1.3"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
+      "integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.5.tgz",
+      "integrity": "sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -2746,6 +2920,262 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-alpha.103",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.103.tgz",
+      "integrity": "sha512-fJIyB2df3CHn7D26WHnutnY7vew6aytTlhmRJz6GX7ag19zU2GcOUhJAzY5qwWcrXKnlYgzimhEjaEnuiUWU4g==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.9",
+        "@popperjs/core": "^2.11.6",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/base/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "5.10.11",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.11.tgz",
+      "integrity": "sha512-u5ff+UCFDHcR8MoQ8tuJR4c35vt7T/ki3aMEE2O3XQoGs8KJSrBiisFpFKyldg9/W2NSyoZxN+kxEGIfRxh+9Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.9.tgz",
+      "integrity": "sha512-sqClXdEM39WKQJOQ0ZCPTptaZgqwibhj2EFV9N0v7BU1PO8y4OcX/a2wIQHn4fNuDjIZktJIBrmU23h7aqlGgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "5.10.11",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.11.tgz",
+      "integrity": "sha512-KJ0wPCTbv6sFzwA3dgg0gowdfF+SRl7D510J9l6Nl/KFX0EawcewQudqKY4slYGFXniKa5PykqokpaWXsCCPqg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/base": "5.0.0-alpha.103",
+        "@mui/core-downloads-tracker": "^5.10.11",
+        "@mui/system": "^5.10.10",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.9",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.10.9.tgz",
+      "integrity": "sha512-BN7/CnsVPVyBaQpDTij4uV2xGYHHHhOgpdxeYLlIu+TqnsVM7wUeF+37kXvHovxM6xmL5qoaVUD98gDC0IZnHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/utils": "^5.10.9",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.10.8",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.8.tgz",
+      "integrity": "sha512-w+y8WI18EJV6zM/q41ug19cE70JTeO6sWFsQ7tgePQFpy6ToCVPh0YLrtqxUZXSoMStW5FMw0t9fHTFAqPbngw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/cache": "^11.10.3",
+        "csstype": "^3.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.10.10",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.10.tgz",
+      "integrity": "sha512-TXwtKN0adKpBrZmO+eilQWoPf2veh050HLYrN78Kps9OhlvO70v/2Kya0+mORFhu9yhpAwjHXO8JII/R4a5ZLA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/private-theming": "^5.10.9",
+        "@mui/styled-engine": "^5.10.8",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.9",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==",
+      "peerDependencies": {
+        "@types/react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.9.tgz",
+      "integrity": "sha512-2tdHWrq3+WCy+G6TIIaFx3cg7PorXZ71P375ExuX61od1NOAJP1mK90VxQ8N4aqnj2vmO3AQDkV4oV2Ktvt4bA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2833,6 +3263,15 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3521,9 +3960,18 @@
         "@types/react": "^17"
       }
     },
+    "node_modules/@types/react-is": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.4",
-      "license": "MIT",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -5042,8 +5490,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -5782,8 +6231,9 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
-      "version": "3.0.10",
-      "license": "MIT"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7304,6 +7754,11 @@
       "funding": {
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -12344,8 +12799,9 @@
       }
     },
     "node_modules/react-transition-group": {
-      "version": "4.4.2",
-      "license": "BSD-3-Clause",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -12439,8 +12895,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "license": "MIT"
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -13422,6 +13879,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -16192,9 +16654,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.3",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.0.tgz",
+      "integrity": "sha512-NDYdls71fTXoU8TZHfbBWg7DiZfNzClcKui/+kyi6ppD2L1qnWW3VV6CjtaBXSUGGhiTWJ6ereOIkUvenif66Q==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/runtime-corejs3": {
@@ -16364,8 +16828,142 @@
         "@date-io/core": "^1.3.13"
       }
     },
+    "@emotion/babel-plugin": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz",
+      "integrity": "sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.1",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.1.3"
+      },
+      "dependencies": {
+        "@emotion/hash": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+          "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+        }
+      }
+    },
+    "@emotion/cache": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+      "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.1.3"
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0"
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "@emotion/react": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
+      "integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+      "requires": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "@emotion/hash": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+          "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "@emotion/styled": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.5.tgz",
+      "integrity": "sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      }
+    },
+    "@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
+    "@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "requires": {}
+    },
+    "@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",
@@ -16805,6 +17403,128 @@
         "react-is": "^16.8.0 || ^17.0.0"
       }
     },
+    "@mui/base": {
+      "version": "5.0.0-alpha.103",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.103.tgz",
+      "integrity": "sha512-fJIyB2df3CHn7D26WHnutnY7vew6aytTlhmRJz6GX7ag19zU2GcOUhJAzY5qwWcrXKnlYgzimhEjaEnuiUWU4g==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.9",
+        "@popperjs/core": "^2.11.6",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "@mui/core-downloads-tracker": {
+      "version": "5.10.11",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.11.tgz",
+      "integrity": "sha512-u5ff+UCFDHcR8MoQ8tuJR4c35vt7T/ki3aMEE2O3XQoGs8KJSrBiisFpFKyldg9/W2NSyoZxN+kxEGIfRxh+9Q=="
+    },
+    "@mui/icons-material": {
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.9.tgz",
+      "integrity": "sha512-sqClXdEM39WKQJOQ0ZCPTptaZgqwibhj2EFV9N0v7BU1PO8y4OcX/a2wIQHn4fNuDjIZktJIBrmU23h7aqlGgg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0"
+      }
+    },
+    "@mui/material": {
+      "version": "5.10.11",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.10.11.tgz",
+      "integrity": "sha512-KJ0wPCTbv6sFzwA3dgg0gowdfF+SRl7D510J9l6Nl/KFX0EawcewQudqKY4slYGFXniKa5PykqokpaWXsCCPqg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/base": "5.0.0-alpha.103",
+        "@mui/core-downloads-tracker": "^5.10.11",
+        "@mui/system": "^5.10.10",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.9",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "@mui/private-theming": {
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.10.9.tgz",
+      "integrity": "sha512-BN7/CnsVPVyBaQpDTij4uV2xGYHHHhOgpdxeYLlIu+TqnsVM7wUeF+37kXvHovxM6xmL5qoaVUD98gDC0IZnHg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/utils": "^5.10.9",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/styled-engine": {
+      "version": "5.10.8",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.10.8.tgz",
+      "integrity": "sha512-w+y8WI18EJV6zM/q41ug19cE70JTeO6sWFsQ7tgePQFpy6ToCVPh0YLrtqxUZXSoMStW5FMw0t9fHTFAqPbngw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@emotion/cache": "^11.10.3",
+        "csstype": "^3.1.1",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/system": {
+      "version": "5.10.10",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.10.10.tgz",
+      "integrity": "sha512-TXwtKN0adKpBrZmO+eilQWoPf2veh050HLYrN78Kps9OhlvO70v/2Kya0+mORFhu9yhpAwjHXO8JII/R4a5ZLA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@mui/private-theming": "^5.10.9",
+        "@mui/styled-engine": "^5.10.8",
+        "@mui/types": "^7.2.0",
+        "@mui/utils": "^5.10.9",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.1",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==",
+      "requires": {}
+    },
+    "@mui/utils": {
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.9.tgz",
+      "integrity": "sha512-2tdHWrq3+WCy+G6TIIaFx3cg7PorXZ71P375ExuX61od1NOAJP1mK90VxQ8N4aqnj2vmO3AQDkV4oV2Ktvt4bA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -16850,6 +17570,11 @@
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
         }
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -17359,8 +18084,18 @@
         "@types/react": "^17"
       }
     },
+    "@types/react-is": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
-      "version": "4.4.4",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "requires": {
         "@types/react": "*"
       }
@@ -18472,7 +19207,9 @@
       }
     },
     "clsx": {
-      "version": "1.1.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "co": {
       "version": "4.6.0",
@@ -18992,7 +19729,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.10"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -20124,6 +20863,11 @@
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "5.0.0",
@@ -23586,7 +24330,9 @@
       }
     },
     "react-transition-group": {
-      "version": "4.4.2",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -23659,7 +24405,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9"
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -24375,6 +25123,11 @@
         "browserslist": "^4.16.6",
         "postcss-selector-parser": "^6.0.4"
       }
+    },
+    "stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/frontend/src/components/Election/Admin/Admin.tsx
+++ b/frontend/src/components/Election/Admin/Admin.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import Container from '@mui/material/Container';
 import ViewElectionRolls from "./ViewElectionRolls";
-const Admin = ({ authSession, election}) => {
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import EditRoles from './EditRoles';
+const Admin = ({ authSession, election, permissions }) => {
     return (
-        <Container >
-            <ViewElectionRolls election={election}/>
+        <Container>
+            <Routes>
+                <Route path='/rolls' element={<ViewElectionRolls election={election} permissions={permissions} />} />
+                <Route path='/roles' element={<EditRoles election={election} permissions={permissions} />} />
+            </Routes>
         </Container>
     )
 }

--- a/frontend/src/components/Election/Admin/EditElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/EditElectionRoll.tsx
@@ -6,29 +6,30 @@ import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@material-ui/core";
 import useFetch from "../../../hooks/useFetch";
+import PermissionHandler from "../../PermissionHandler";
 
-const EditElectionRoll = ({ roll, onClose, fetchRolls, id}) => {
+const EditElectionRoll = ({ roll, onClose, fetchRolls, id, permissions }) => {
     const [updatedRoll, setUpdatedRoll] = useState(roll)
 
-    const approve = useFetch(`/API/Election/${id}/rolls/approve`,'post')
-    const flag = useFetch(`/API/Election/${id}/rolls/flag`,'post')
-    const unflag = useFetch(`/API/Election/${id}/rolls/unflag`,'post')
-    const invalidate = useFetch(`/API/Election/${id}/rolls/invalidate`,'post')
+    const approve = useFetch(`/API/Election/${id}/rolls/approve`, 'post')
+    const flag = useFetch(`/API/Election/${id}/rolls/flag`, 'post')
+    const unflag = useFetch(`/API/Election/${id}/rolls/unflag`, 'post')
+    const invalidate = useFetch(`/API/Election/${id}/rolls/invalidate`, 'post')
 
     const onApprove = async () => {
-        if (!await approve.makeRequest({electionRollEntry: roll})) {return}
+        if (!await approve.makeRequest({ electionRollEntry: roll })) { return }
         await fetchRolls()
     }
     const onFlag = async () => {
-        if (!await flag.makeRequest({electionRollEntry: roll})) {return}
+        if (!await flag.makeRequest({ electionRollEntry: roll })) { return }
         await fetchRolls()
     }
     const onUnflag = async () => {
-        if (!await unflag.makeRequest({electionRollEntry: roll})) {return}
+        if (!await unflag.makeRequest({ electionRollEntry: roll })) { return }
         await fetchRolls()
     }
     const onInvalidate = async () => {
-        if (!await invalidate.makeRequest({electionRollEntry: roll})) {return}
+        if (!await invalidate.makeRequest({ electionRollEntry: roll })) { return }
         await fetchRolls()
     }
 
@@ -41,10 +42,10 @@ const EditElectionRoll = ({ roll, onClose, fetchRolls, id}) => {
         <Container>
             {(approve.isPending || flag.isPending || unflag.isPending || invalidate.isPending) &&
                 <div> Sending Request... </div>}
-            {approve.error &&  <div> {approve.error} </div>}
-            {flag.error &&  <div> {flag.error} </div>}
-            {unflag.error &&  <div> {unflag.error} </div>}
-            {invalidate.error &&  <div> {invalidate.error} </div>}
+            {approve.error && <div> {approve.error} </div>}
+            {flag.error && <div> {flag.error} </div>}
+            {unflag.error && <div> {unflag.error} </div>}
+            {invalidate.error && <div> {invalidate.error} </div>}
             <Grid container direction="column" >
                 <Grid item sm={12}>
                     <Typography align='left' gutterBottom variant="h6" component="h6">
@@ -58,19 +59,28 @@ const EditElectionRoll = ({ roll, onClose, fetchRolls, id}) => {
                 </Grid>
                 {updatedRoll.state === 'registered' &&
                     <Grid item sm={4}>
-                        <Button variant='outlined' onClick={() => { onApprove() }} > Approve </Button>
+                        <PermissionHandler permissions={permissions} requiredPermission={'canApproveElectionRoll'}>
+                            <Button variant='outlined' onClick={() => { onApprove() }} > Approve </Button>
+                        </PermissionHandler>
                     </Grid>}
                 {updatedRoll.state !== 'flagged' &&
                     <Grid item sm={4}>
-                        <Button variant='outlined' onClick={() => { onFlag() }} > Flag </Button>
+
+                        <PermissionHandler permissions={permissions} requiredPermission={'canFlagElectionRoll'}>
+                            <Button variant='outlined' onClick={() => { onFlag() }} > Flag </Button>
+                        </PermissionHandler>
                     </Grid>}
                 {updatedRoll.state === 'flagged' &&
                     <Grid item sm={4}>
-                        <Button variant='outlined' onClick={() => { onUnflag() }} > Unflag </Button>
+                        <PermissionHandler permissions={permissions} requiredPermission={'canUnflagElectionRoll'}>
+                            <Button variant='outlined' onClick={() => { onUnflag() }} > Unflag </Button>
+                        </PermissionHandler>
                     </Grid>}
                 {updatedRoll.state === 'flagged' &&
                     <Grid item sm={4}>
-                        <Button variant='outlined' onClick={() => { onInvalidate() }} > Invalidate </Button>
+                        <PermissionHandler permissions={permissions} requiredPermission={'canInvalidateElectionRoll'}>
+                            <Button variant='outlined' onClick={() => { onInvalidate() }} > Invalidate </Button>
+                        </PermissionHandler>
                     </Grid>}
                 {updatedRoll?.history &&
                     <TableContainer component={Paper}>

--- a/frontend/src/components/Election/Admin/EditRoles.tsx
+++ b/frontend/src/components/Election/Admin/EditRoles.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react"
+import React from 'react'
+import Grid from "@mui/material/Grid";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import useFetch from "../../../hooks/useFetch";
+import { useNavigate } from "react-router"
+import PermissionHandler from "../../PermissionHandler";
+
+const EditRoles = ({ election, permissions }) => {
+    const navigate = useNavigate()
+
+    const [adminList, setAdminList] = useState(() => {
+        if (election.admin_ids === null) return ''
+        return election.admin_ids.join('\n')
+    })
+
+    const [auditorList, setAuditorList] = useState(() => {
+        if (election.audit_ids === null) return ''
+        return election.audit_ids.join('\n')
+    })
+
+    const [credentialList, setCredentialList] = useState(() => {
+        if (election.credential_ids === null) return ''
+        return election.credential_ids.join('\n')
+    })
+
+    const putRoles = useFetch(`/API/Election/${election.election_id}/roles/`, 'put')
+
+    const onSubmit = async (e) => {
+        e.preventDefault()
+        try {
+            const admin_ids = adminList == '' ? null : adminList.split('\n')
+            const audit_ids = auditorList == '' ? null : auditorList.split('\n')
+            const credential_ids = credentialList == '' ? null : credentialList.split('\n')
+
+            const newRoles = await putRoles.makeRequest({ admin_ids, audit_ids, credential_ids })
+            console.log(newRoles)
+            if (!newRoles) {
+                throw Error("Error submitting rolls");
+            }
+            navigate(`/Election/${election.election_id}`)
+        } catch (error) {
+            console.log(error)
+        }
+    }
+
+    return (
+        <form onSubmit={onSubmit}>
+            <Container maxWidth='sm'>
+                <Grid container direction="column" >
+                    <Grid item>
+                        <TextField
+                            id="admin-list"
+                            name="admin-list"
+                            label="Admin List"
+                            multiline
+                            fullWidth
+                            type="text"
+                            value={adminList}
+                            onChange={(e) => setAdminList(e.target.value)}
+                            helperText="Emails of election admins, one email per line"
+                        />
+                    </Grid>
+                    <Grid item>
+                        <TextField
+                            id="auditor-list"
+                            name="id-list"
+                            label="Auditor List"
+                            multiline
+                            fullWidth
+                            type="text"
+                            value={auditorList}
+                            onChange={(e) => setAuditorList(e.target.value)}
+                            helperText="Emails of election audotors, one email per line"
+                        />
+                    </Grid>
+                    <Grid item>
+                        <TextField
+                            id="credentialer-list"
+                            name="credentialer-list"
+                            label="Credentialer List"
+                            multiline
+                            fullWidth
+                            type="text"
+                            value={credentialList}
+                            onChange={(e) => setCredentialList(e.target.value)}
+                            helperText="Emails of election audotors, one email per line"
+                        />
+                    </Grid>
+
+                    <PermissionHandler permissions={permissions} requiredPermission={'canEditElectionRoles'}>
+                        <input
+                            type='submit'
+                            value='Submit'
+                            className='btn btn-block'
+                            disabled={putRoles.isPending} />
+                    </PermissionHandler>
+                </Grid>
+            </Container>
+        </form>
+    )
+}
+
+export default EditRoles

--- a/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
+++ b/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
@@ -7,8 +7,9 @@ import Container from '@mui/material/Container';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@material-ui/core";
 import EditElectionRoll from "./EditElectionRoll";
 import AddElectionRoll from "./AddElectionRoll";
+import PermissionHandler from "../../PermissionHandler";
 
-const ViewElectionRolls = ({election}) => {
+const ViewElectionRolls = ({election,permissions}) => {
     const { id } = useParams();
     const { data, isPending, error, makeRequest: fetchRolls } = useFetch(`/API/Election/${id}/rolls`,'get')
     useEffect(() => {fetchRolls()},[])
@@ -33,7 +34,9 @@ const ViewElectionRolls = ({election}) => {
             {isPending && <div> Loading Data... </div>}
             {data && data.electionRoll && !isEditing && !addRollPage &&
                 <>
-                <Button variant='outlined' onClick={() => setAddRollPage(true)} > Add Rolls </Button>
+                <PermissionHandler permissions={permissions} requiredPermission={'canAddToElectionRoll'}>
+                    <Button variant='outlined' onClick={() => setAddRollPage(true)} > Add Rolls </Button>
+                </PermissionHandler>
                 <TableContainer component={Paper}>
                     <Table style={{ width: '100%' }} aria-label="simple table">
                         <TableHead>
@@ -61,7 +64,7 @@ const ViewElectionRolls = ({election}) => {
                 </>
             }
             {isEditing && editedRoll &&
-                <EditElectionRoll roll={editedRoll} onClose={onClose} fetchRolls = {fetchRolls} id={id}/>
+                <EditElectionRoll roll={editedRoll} onClose={onClose} fetchRolls = {fetchRolls} id={id} permissions={permissions}/>
             }
             {addRollPage &&
                 <AddElectionRoll election = {election} onClose={onClose} />

--- a/frontend/src/components/Election/Election.tsx
+++ b/frontend/src/components/Election/Election.tsx
@@ -14,6 +14,7 @@ import ViewElectionResults from './Results/ViewElectionResults'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Sidebar from "./Sidebar";
 import { Grid } from "@mui/material";
+import Thanks from "./Voting/Thanks";
 
 const Election = ({ authSession }) => {
   const { id } = useParams();
@@ -39,9 +40,10 @@ const Election = ({ authSession }) => {
             <Routes>
               <Route path='/' element={<ElectionHome authSession={authSession} electionData={data} fetchElection={fetchData} />} />
               <Route path='/vote' element={<VotePage election={data.election} fetchElection={fetchData}/>} />
+              <Route path='/thanks' element={<Thanks election={data.election} />} />
               <Route path='/results' element={<ViewElectionResults election={data.election} />} />
               <Route path='/edit' element={<EditElection authSession={authSession} election={data.election} />} />
-              <Route path='/admin' element={<Admin authSession={authSession} election={data.election} />} />
+              <Route path='/admin/*' element={<Admin authSession={authSession} election={data.election} permissions={data.voterAuth.permissions} />} />
             </Routes>
           </Grid>
         </Grid >

--- a/frontend/src/components/Election/ElectionHome.tsx
+++ b/frontend/src/components/Election/ElectionHome.tsx
@@ -59,7 +59,7 @@ const ElectionHome2 = ({ authSession, electionData, fetchElection }) => {
           <Paper elevation={3} sx={{ width: 600 }} >
 
             <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <ShareButton />
+              <ShareButton url={`${window.location.origin}/Election/${electionData.election.election_id}`}/>
             </div>
             <Typography align='center' gutterBottom variant="h4" component="h4">
               {electionData.election.title}

--- a/frontend/src/components/Election/ShareButton.tsx
+++ b/frontend/src/components/Election/ShareButton.tsx
@@ -15,7 +15,7 @@ import RedditIcon from "@mui/icons-material/Reddit"
 import LinkIcon from "@mui/icons-material/Link"
 import { IconButton, Menu, Tooltip, Typography } from "@mui/material";
 
-export default function ShareButton() {
+export default function ShareButton({url}) {
     const [anchorElNav, setAnchorElNav] = useState(null)
 
     const handleOpenNavMenu = (event) => {
@@ -29,7 +29,7 @@ export default function ShareButton() {
     const handleShare = e => {
         e.preventDefault()
 
-        const ahref = window.location.href
+        const ahref = url
         const encodedAhref = encodeURIComponent(ahref)
         var link
 

--- a/frontend/src/components/Election/Sidebar.tsx
+++ b/frontend/src/components/Election/Sidebar.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import { Button, Grid } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { Paper } from '@mui/material';
+import PermissionHandler from '../PermissionHandler';
 
 const ListItem = ({ text, link }) => {
     return (
@@ -32,8 +33,17 @@ export default function Sidebar({ electionData }) {
                         <Grid direction="column" >
                             <ListItem text='Home' link={`/Election/${id}/`} />
                             {electionData.election.state === 'draft' &&
-                                <ListItem text='Edit Election' link={`/Election/${id}/edit`} />}
-                            <ListItem text='Voter Rolls' link={`/Election/${id}/admin`} />
+                                <>
+                                    <PermissionHandler permissions={electionData.voterAuth.permissions} requiredPermission={'canEditElectionRoles'}>
+                                        <ListItem text='Edit Election Roles' link={`/Election/${id}/admin/roles`} />
+                                    </PermissionHandler>
+                                    <PermissionHandler permissions={electionData.voterAuth.permissions} requiredPermission={'canEditElection'}>
+                                        <ListItem text='Edit Election' link={`/Election/${id}/edit`} />
+                                    </PermissionHandler>
+                                </>}
+                            <PermissionHandler permissions={electionData.voterAuth.permissions} requiredPermission={'canViewElectionRoll'}>
+                                <ListItem text='Voter Rolls' link={`/Election/${id}/admin/rolls`} />
+                            </PermissionHandler>
                         </Grid>
                     </Paper>
                 </Box>

--- a/frontend/src/components/Election/Voting/Thanks.tsx
+++ b/frontend/src/components/Election/Voting/Thanks.tsx
@@ -1,0 +1,62 @@
+import useFetch from "../../../hooks/useFetch";
+import { useParams } from "react-router";
+import React from 'react'
+import Grid from "@mui/material/Grid";
+import Button from "@mui/material/Button";
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import { Link } from "react-router-dom"
+import Box from '@mui/material/Box';
+import { IconButton, Paper, Tooltip } from "@mui/material";
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ShareButton from "../ShareButton";
+
+const Thanks = ({ election }) => {
+    const { id } = useParams();
+
+
+    return (
+        <>
+            {election &&
+                <Box
+                    display='flex'
+                    justifyContent="center"
+                    alignItems="center"
+                    sx={{ width: '100%' }}>
+                    <Paper elevation={3} sx={{ width: 600 }} >
+
+                        <Typography align='center' gutterBottom variant="h3" component="h3">
+                            Balot Submitted
+                        </Typography>
+                        <Typography align='center' gutterBottom variant="h4" component="h4">
+                            Thank you for voting!
+                        </Typography>
+
+                        {election.state === 'open' && election.end_time &&
+                            < Typography align='center' gutterBottom variant="h6" component="h6">
+                                {`Election ends on ${new Date(election.end_time).toLocaleDateString()} at ${new Date(election.end_time).toLocaleTimeString()} `}
+                            </Typography>
+                        }
+
+                        <div style={{ display: 'flex', justifyContent: 'center' }}>
+                            Share:
+                        </div>
+                        <div style={{ display: 'flex', justifyContent: 'center' }}>
+                            <ShareButton url={`${window.location.origin}/Election/${election.election_id}`}/>
+                        </div>
+                        {(election.state === 'open' || election.state === 'closed') &&
+                            <div style={{ display: 'flex', justifyContent: 'center' }}>
+                                <Button variant='outlined' href={`/Election/${election.election_id}/results`} >
+                                    View Results
+                                </Button>
+                            </div>
+                        }
+
+                    </Paper>
+                </Box>
+            }
+        </>
+    )
+}
+
+export default Thanks

--- a/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/frontend/src/components/Election/Voting/VotePage.tsx
@@ -43,8 +43,7 @@ const VotePage = ({ election, fetchElection }) => {
     if (!(await postBallot({ ballot: ballot }))) {
       return
     }
-    await fetchElection() // refetch election to update voter auth
-    navigate(`/Election/${id}`)
+    navigate(`/Election/${id}/thanks`)
   }
   console.log(scores)
   return (

--- a/frontend/src/components/PermissionHandler.tsx
+++ b/frontend/src/components/PermissionHandler.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+type PermissionHandlerProps = {
+    permissions: string[],
+    requiredPermission: string,
+    children: any
+}
+
+const PermissionHandler = ({permissions,requiredPermission,children}:PermissionHandlerProps) => {
+    if (permissions && permissions.includes(requiredPermission)){
+        return children
+    }
+    return <></>
+}
+
+export default PermissionHandler


### PR DESCRIPTION
Along with voter_auth data the backend will now send user permissions. Created a component "PermissionHandler" that only renders a component if user has required permissions and moved some of our components into permissions handlers. 

Created an edit roles page so election owner can add credentialers, admins, and auditors. 

Added a simple "thanks for voting page" instead of routing back to home page. This page will have links to share and link to results page. Page could use some more styling in the future and maybe a "learn more about star voting" or "donate to equal vote" links.