### PR TITLE
New score tiebreaker protocol

### DIFF
--- a/backend/src/Tabulators/ITabulators.ts
+++ b/backend/src/Tabulators/ITabulators.ts
@@ -16,6 +16,11 @@ export interface totalScore {
     index: number,
     score: number,
 }
+
+export interface fiveStarCount {
+    candidate: candidate,
+    counts: number
+}
 export interface summaryData {
     candidates: candidate[],
     totalScores: totalScore[],

--- a/backend/src/Tabulators/Star.ts
+++ b/backend/src/Tabulators/Star.ts
@@ -2,6 +2,14 @@ import { ballot, candidate, fiveStarCount, results, roundResults, summaryData, t
 
 import { IparsedData } from './ParseData'
 const ParseData = require("./ParseData");
+declare namespace Intl {
+  class ListFormat {
+    constructor(locales?: string | string[], options?: {});
+    public format: (items: string[]) => string;
+  }
+}
+// converts list of strings to string with correct grammar ([a,b,c] => 'a, b, and c')
+const formatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
 
 export function Star(candidates: string[], votes: ballot[], nWinners = 1, breakTiesRandomly = true, enablefiveStarTiebreaker = true) {
   // Determines STAR winners for given election
@@ -189,14 +197,14 @@ export function runStarRound(summaryData: summaryData, remainingCandidates: cand
       continue scoreLoop
     }
     // Multiple candidates have top score, proceed to score tiebreaker
-    roundResults.logs.push(`${scoreWinners.map(c => c.name).join(', ')} advance to score tiebreaker.`)
+    roundResults.logs.push(`${formatter.format(scoreWinners.map(c => c.name))} advance to score tiebreaker.`)
     let tiedCandidates = scoreWinners
     tieLoop: while (tiedCandidates.length > 1) {
       // Get candidates with the most head to head losses
       let headToHeadLosers = getHeadToHeadLosers(summaryData, tiedCandidates)
       if (headToHeadLosers.length < tiedCandidates.length) {
         // Some candidates have more head to head losses than others, remove them from the tied candidate pool
-        roundResults.logs.push(`${headToHeadLosers.map(c => c.name).join(', ')} removed from score tiebreaker with the most losses.`)
+        roundResults.logs.push(`${formatter.format(headToHeadLosers.map(c => c.name))} removed from score tiebreaker with the most losses.`)
         tiedCandidates = tiedCandidates.filter(c => !headToHeadLosers.includes(c))
         continue tieLoop
       }
@@ -208,7 +216,7 @@ export function runStarRound(summaryData: summaryData, remainingCandidates: cand
         continue scoreLoop
       }
       // Proceed to five star tiebreaker
-      roundResults.logs.push(`${tiedCandidates.map(c => c.name).join(', ')} have same number of losses, advance to five star tiebreaker.`)
+      roundResults.logs.push(`${formatter.format(tiedCandidates.map(c => c.name))} have same number of losses, advance to five star tiebreaker.`)
       let fiveStarCounts = getFiveStarCounts(summaryData, tiedCandidates)
       if (nCandidatesNeeded === 2 && fiveStarCounts[1].counts > fiveStarCounts[2].counts) {
         // Two candidates needed and first two have more five star counts than the rest, advance them both to runoff
@@ -228,7 +236,7 @@ export function runStarRound(summaryData: summaryData, remainingCandidates: cand
       let fiveStarLosers = getFiveStarLosers(fiveStarCounts)
       if (fiveStarLosers.length < tiedCandidates.length) {
         // Some candidates have fewer five star votes than others, remove them from the tie breaker pool
-        roundResults.logs.push(`${fiveStarLosers.map(c => c.name).join(', ')} removed from score tiebreaker with the least five star votes.`)
+        roundResults.logs.push(`${formatter.format(fiveStarLosers.map(c => c.name))} removed from score tiebreaker with the least five star votes.`)
         tiedCandidates = tiedCandidates.filter(c => !fiveStarLosers.includes(c))
         continue tieLoop
       }

--- a/backend/src/Tabulators/Star.ts
+++ b/backend/src/Tabulators/Star.ts
@@ -10,7 +10,7 @@ export function Star(candidates: string[], votes: ballot[], nWinners = 1, breakT
   // votes: Array of votes, size nVoters x Candidates
   // nWiners: Number of winners in election, defaulted to 1
   // breakTiesRandomly: In the event of a true tie, should a winner be selected at random, defaulted to true
-  // enablefiveStarTiebreaker: In the event of a true tie, should the five-star tiebreaker be used (select candidate with the most 5 star votes), defaulted to true
+  // enablefiveStarTiebreaker: In the event of a true tie in the runoff round, should the five-star tiebreaker be used (select candidate with the most 5 star votes), defaulted to true
 
   // Parse the votes for valid, invalid, and undervotes, and identifies bullet votes
   const parsedData = ParseData(votes)
@@ -204,7 +204,7 @@ export function runStarRound(summaryData: summaryData, remainingCandidates: cand
       if (nCandidatesNeeded === 2 && tiedCandidates.length === 2) {
         // Tie between two candidates, but both can advance to runoff
         runoffCandidates.push(...tiedCandidates)
-        roundResults.logs.push(`${tiedCandidates[0].name} and ${tiedCandidates[1].name} advance to the runoff round.`)
+        roundResults.logs.push(`${tiedCandidates[0].name} and ${tiedCandidates[1].name} win score tiebreaker and advance to the runoff round.`)
         continue scoreLoop
       }
       // Proceed to five star tiebreaker


### PR DESCRIPTION
We have updated our score tiebreaker protocol again, flowchart [here](https://docs.google.com/drawings/d/1L-tIDY6-8OeKGzW0w1eh2EUjlHbarEcsfvhsegMT8qg/edit?usp=sharing).

Before we would look for any weak Condorcet winner, if none existed we'd look for a candidate with the most five star votes, if none existed we'd pick a random winner.

Now we eliminate candidates with the most head to head losses until one can advance. If that doesn't work we look for a candidate with the most five star votes. If that doesn't work we eliminate candidates with the least five star votes. Finally if that doesn't work we pick a random winner. 

While more complex this should let us select better winners, cover most weird edge cases, and avoid random winners more often. 