### PR TITLE
Add instructions for certificate auto-renewal

### DIFF
--- a/docs/keycloak_deployment.md
+++ b/docs/keycloak_deployment.md
@@ -99,7 +99,19 @@ Follow the steps [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/SSL-
 
 Keep track of the fullchain.pem and privkey.pem files, you'll need these later when running keycloak
 
-3. Update permissions
+3. Automate certificate renewal
+
+The [guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/SSL-on-amazon-linux-2.html#letsencrypt) also covers certificate renewal. You add a certificate rewewal command to your cron, and then restart system ctl
+
+The only change we make is to add a post-hook so that keycloak will restart and use the new ceritifcate. You may need to reference "docker container ls" and replace c17... accordingly to restart your corresponding container
+
+```
+39    1,13       *       *       * root certbot renew --no-self-upgrade --post-hook "docker restart c17de7f51dbc"
+```
+
+This command will run at 1:39 am/pm everyday (as recommended by certbot), but it'll only renew the certificate if it expires within 30 days
+
+4. Update permissions
 
 ```
 sudo chmod 755 /etc/letsencrypt/live/auth.star.vote/fullchain.pem


### PR DESCRIPTION
I've renewed the certificate and also setup auto-renewal so that we won't need to do this anymore

I updated the documentation since I added a post-hook that was specific to our setup

![image](https://user-images.githubusercontent.com/9289903/217470216-094f3785-7b21-48eb-a6b0-9c5e1d0aa80e.png)
