### PR TITLE
Fix edge case in plurality tabulator

### DIFF
--- a/backend/src/Tabulators/Plurality.ts
+++ b/backend/src/Tabulators/Plurality.ts
@@ -13,24 +13,26 @@ export function Plurality(candidates: string[], votes: ballot[], nWinners = 1, b
     roundResults: [],
     summaryData: summaryData,
   }
-  const sortedScores = summaryData.totalScores.sort((a: totalScore, b: totalScore) => {
+  let sortedScores = summaryData.totalScores.sort((a: totalScore, b: totalScore) => {
     if (a.score > b.score) return -1
     if (a.score < b.score) return 1
     return 0
   })
-  
+
   var remainingCandidates = [...summaryData.candidates]
+  let prevRemainingCount = remainingCandidates.length;
   while (remainingCandidates.length>0) {
-    const topScore = sortedScores[results.elected.length]
-    let scoreWinners = [summaryData.candidates[topScore.index]]
-    for (let i = sortedScores.length-remainingCandidates.length+1; i < sortedScores.length; i++) {
-      if (sortedScores[i].score === topScore.score) {
+    let scoreWinners : candidate[] = []
+    for (let i = 0; i < sortedScores.length; i++) {
+      if (sortedScores[i].score === sortedScores[0].score) {
         scoreWinners.push(summaryData.candidates[sortedScores[i].index])
       }
     }
+
     if (breakTiesRandomly && scoreWinners.length>1) {
       scoreWinners = [scoreWinners[getRandomInt(scoreWinners.length)]]
     }
+
     if ((results.elected.length + results.tied.length + scoreWinners.length)<=nWinners) {
       results.elected.push(...scoreWinners)
     }
@@ -41,8 +43,20 @@ export function Plurality(candidates: string[], votes: ballot[], nWinners = 1, b
       results.other.push(...scoreWinners)
     }
     remainingCandidates = remainingCandidates.filter(c => !scoreWinners.includes(c))
+
+    // NOTE: there's probably a cleaner way to do this filter operation
+    let remainingIndexes : number[] = []
+    for(var i = 0; i < remainingCandidates.length; i++){
+      remainingIndexes.push(remainingCandidates[i].index) 
+    }
+    sortedScores = sortedScores.filter(c => remainingIndexes.includes(c.index))
+
+    if(remainingCandidates.length == prevRemainingCount){
+      throw new Error("Infinite loop detected")
+    }
+    prevRemainingCount  = remainingCandidates.length
   }
-  
+
   return results;
 }
 

--- a/backend/src/Tabulators/testPlurality.js
+++ b/backend/src/Tabulators/testPlurality.js
@@ -1,5 +1,7 @@
 const PluralityResults = require('./PluralityResults')
 
+// TODO: eventually we should make this a proper test class like Star.test.ts, but for now we can just add edge cases as we hit them
+
 const candidates = ['Alice','Bob','Carol','Dave']
 
 const votes = [
@@ -10,6 +12,12 @@ const votes = [
     [0,0,0,1],
 ]
 
-
 const results = PluralityResults(candidates,votes)
 console.log(results)
+
+const votes2 = [
+    [1,0,0,0],
+]
+
+const results2 = PluralityResults(candidates,votes)
+console.log(results2)


### PR DESCRIPTION
I was getting a 500 error when viewing the results for a plurality election. Here's the edge case that was triggered

The election had candidates [A, B, C, D], there was only 1 vote cast, and it was for candidate A. It caused 2 problems with the tabulator

1. sortedScores always selected results.elected.length. In this case it would select A on the first iteration, and then select B on all future iterations. The index should probably have been sortedScores.length - remainingCandidates.length? But that wouldn't have accounted for the second issue
2. The tie breaker would selected a random candidate. This means the candidates aren't always eliminated in the sortedScore order, and this caused an infinite loop where remainingCandidates could have candidates that are never selected in scoreWinners
