### PR TITLE
More plurality and approval bug fixes, Ranked Robin name fix

### DIFF
--- a/backend/src/Controllers/getElectionResultsController.ts
+++ b/backend/src/Controllers/getElectionResultsController.ts
@@ -42,8 +42,10 @@ const getElectionResults = async (req: any, res: any, next: any) => {
         const voting_method = election.races[race_index].voting_method
 
         if (!VotingMethods[voting_method]) {
-            throw new Error('Invalid Voting Method')
+            throw new Error(`Invalid Voting Method: ${voting_method}`)
         }
+        const msg = `Tabulating results for ${voting_method} election`
+        Logger.info(req, msg);
         results[race_index] = VotingMethods[voting_method](candidateNames, cvr, num_winners)
     }
     res.json(

--- a/backend/src/Tabulators/Approval.ts
+++ b/backend/src/Tabulators/Approval.ts
@@ -16,7 +16,7 @@ export function Approval(candidates: string[], votes: ballot[], nWinners = 1, br
   const sortedScores = summaryData.totalScores.sort((a: totalScore, b: totalScore) => {
     if (a.score > b.score) return -1
     if (a.score < b.score) return 1
-    return 0
+    return 0.5 - Math.random()
   })
   
   var remainingCandidates = [...summaryData.candidates]
@@ -29,7 +29,7 @@ export function Approval(candidates: string[], votes: ballot[], nWinners = 1, br
       }
     }
     if (breakTiesRandomly && scoreWinners.length>1) {
-      scoreWinners = [scoreWinners[getRandomInt(scoreWinners.length)]]
+      scoreWinners = [scoreWinners[0]]
     }
     if ((results.elected.length + results.tied.length + scoreWinners.length)<=nWinners) {
       results.elected.push(...scoreWinners)

--- a/backend/src/Tabulators/Plurality.ts
+++ b/backend/src/Tabulators/Plurality.ts
@@ -16,9 +16,8 @@ export function Plurality(candidates: string[], votes: ballot[], nWinners = 1, b
   const sortedScores = summaryData.totalScores.sort((a: totalScore, b: totalScore) => {
     if (a.score > b.score) return -1
     if (a.score < b.score) return 1
-    return 0
+    return 0.5 - Math.random()
   })
-  
   var remainingCandidates = [...summaryData.candidates]
   while (remainingCandidates.length>0) {
     const topScore = sortedScores[results.elected.length + results.tied.length + results.other.length]
@@ -29,7 +28,7 @@ export function Plurality(candidates: string[], votes: ballot[], nWinners = 1, b
       }
     }
     if (breakTiesRandomly && scoreWinners.length>1) {
-      scoreWinners = [scoreWinners[getRandomInt(scoreWinners.length)]]
+      scoreWinners = [scoreWinners[0]]
     }
     if ((results.elected.length + results.tied.length + scoreWinners.length)<=nWinners) {
       results.elected.push(...scoreWinners)

--- a/backend/src/Tabulators/RankedRobin.ts
+++ b/backend/src/Tabulators/RankedRobin.ts
@@ -57,7 +57,7 @@ export function RankedRobin(candidates: string[], votes: ballot[], nWinners = 1,
 }
 
 function getRankedRobinBallotValidity(ballot: ballot) {
-  const minScore = 1
+  const minScore = 0
   const maxScore = ballot.length
   let isUnderVote = true
   for (let i = 0; i < ballot.length; i++) {

--- a/frontend/src/components/Election/Voting/BallotSelector.js
+++ b/frontend/src/components/Election/Voting/BallotSelector.js
@@ -29,7 +29,7 @@ export default function BallotSelector({
         onUpdate={onUpdate}
         />
     }
-    {(race.voting_method == 'Ranked-Robin' || race.voting_method == "IRV") && 
+    {(race.voting_method == 'RankedRobin' || race.voting_method == "IRV") && 
       <RankedBallotView
         race={race}
         candidates={candidates}

--- a/frontend/src/components/Election/Voting/RankedBallotView.js
+++ b/frontend/src/components/Election/Voting/RankedBallotView.js
@@ -24,7 +24,7 @@ export default function RankedBallotView({
       <Typography align='left' component="li">
         Rank the candidates in order of preference.
       </Typography>
-      { race.voting_method === 'Ranked-Robin' &&
+      { race.voting_method === 'RankedRobin' &&
         <Typography align='left' component="li">
           Equal ranks are allowed
         </Typography>
@@ -42,7 +42,7 @@ export default function RankedBallotView({
 
   const footer = (
     <>
-    { race.voting_method === 'Ranked-Robin' &&
+    { race.voting_method === 'RankedRobin' &&
       <Typography align='left' component="li">
         Candidates are compared in 1-on-1 match-ups.<br/>
         A candidates wins a match-up if they are ranked

--- a/frontend/src/components/ElectionForm/Races.tsx
+++ b/frontend/src/components/ElectionForm/Races.tsx
@@ -271,7 +271,7 @@ export default function Races({ election, applyElectionUpdate, getStyle, setPage
                                             <MenuItem key="IRV" value="IRV">
                                                 IRV
                                             </MenuItem>
-                                            <MenuItem key="Ranked-Robin" value="Ranked-Robin">
+                                            <MenuItem key="Ranked-Robin" value="RankedRobin">
                                                 Ranked-Robin
                                             </MenuItem>
                                             <MenuItem key="Approval" value="Approval">


### PR DESCRIPTION
Plurality and Approval are still buggy regarding ties. This randomizes the order of tied candidates and grabs the first tied candidate if random tiebreakers are enabled. Won't work if random tiebreakers are not enabled so it will need to be refactored some time in the future, but this temp fix will work in the meantime.

Changed Ranked Robin validity check to count 0 as valid. It already checks for 0 ranks later in the code and considers them as last place ranks.

Also changed Ranked-Robin to RankedRobin in the frontend. The '-' doesn't work with the VotingMethodSelector in the backend.