### PR TITLE
Running express app in debug mode in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,23 +1,18 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-        {
-            "name": "Python: Flask",
-            "type": "python",
-            "request": "launch",
-            "module": "flask",
-            "env": {
-                "FLASK_APP": "C:\\Users\\Mike\\Documents\\STAR_Server\\backend\\app.py",
-                "FLASK_ENV": "development"
-            },
-            "args": [
-                "run",
-                "--no-debugger"
-            ],
-            "jinja": true
-        }
+      {
+        "name": "Debug Server",
+        "type": "node",
+        "request": "launch",
+        "runtimeExecutable": "node",
+        "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+  
+        "args": ["src/index.ts"],
+        
+        "cwd": "${workspaceRoot}/backend",
+        "internalConsoleOptions": "openOnSessionStart",
+        "skipFiles": ["<node_internals>/**", "node_modules/**"]
+      }
     ]
-}
+  }


### PR DESCRIPTION
Allows you to add breakpoints in express app and debug code easier in vscode. Removes old code used for python app.
Click the "Debug Server" button to launch server and break on breakpoints and uncaught exceptions.
![image](https://user-images.githubusercontent.com/41272412/224606761-c40871ea-2700-4979-a08a-f1fdc55f86d6.png)