### PR TITLE
Voting method radio button and results page crop fix

### DIFF
--- a/frontend/src/components/Election/Results/MatrixViewer.js
+++ b/frontend/src/components/Election/Results/MatrixViewer.js
@@ -15,7 +15,7 @@ function CellViewer({ cell }) {
 export default function MatrixViewer({ results }) {
   return (
     <Paper elevation={0} sx={{ width:'100%' }}>
-      <TableContainer sx={{ maxHeight: 600, maxWidth: {xs:400, sm: 500, md: 600}}}>
+      <TableContainer sx={{ maxHeight: 600, maxWidth: {xs:300, sm: 500, md: 600, lg: 1000}}}>
         <Table stickyHeader aria-label="sticky table">
           <TableHead>
             <TableRow>

--- a/frontend/src/components/Election/Results/Results.js
+++ b/frontend/src/components/Election/Results/Results.js
@@ -1,10 +1,11 @@
-import { Grid } from "@mui/material";
+import { Grid, Paper } from "@mui/material";
 import React from "react";
 import MatrixViewer from "./MatrixViewer";
 import IconButton from '@mui/material/IconButton'
 import ExpandLess from '@mui/icons-material/ExpandLess'
 import ExpandMore from '@mui/icons-material/ExpandMore'
 import { useState } from 'react'
+import { TableContainer, Table, TableHead, TableRow, TableCell, TableBody } from "@mui/material";
 // import Grid from "@mui/material/Grid";
 
 function CandidateViewer({ candidate, runoffScore }) {
@@ -216,44 +217,97 @@ function IRVResultsViewer({ results }) {
     <div className="resultViewer">
       <h2>Detailed Results</h2>
 
-      <table className='matrix'>
-        <thead className='matrix'>
-          <tr>
-            <th className='matrix'> Candidate</th>
-            {results.voteCounts.map((roundVoteCounts, i) => <th className='matrix'> {`Round ${i + 1}`}</th>)}
-          </tr>
+      <Paper elevation={0} sx={{ width: '100%' }}>
+        <TableContainer sx={{ maxHeight: 600, maxWidth: { xs: 300, sm: 500, md: 600, lg: 1000 } }}>
 
-          {results.summaryData.candidates.map((c, n) => (
-            <tr className='matrix' key={`h${n}`} >{c.name}
-              {results.voteCounts.map((roundVoteCounts, i) =>
-                <td> {roundVoteCounts[n]} </td>
-              )}
-            </tr>
-          ))}
-          <tr>
-            <tr className='matrix'> Exhausted Ballots</tr>
-            {results.exhaustedVoteCounts.map((exhaustedVoteCount, i) => <td className='matrix'> {exhaustedVoteCount} </td>)}
-          </tr>
 
-        </thead>
-      </table>
-      <table className='matrix'>
-        <thead className='matrix'>
-          <tr>
-            <th className='matrix'> Candidate</th>
-            <th className='matrix'> # of wins head to head wins</th>
-          </tr>
+          <Table size='small' stickyHeader aria-label="sticky table">
+            <TableHead>
+              <TableRow>
+                <TableCell
+                  style={{
+                    position: 'sticky',
+                    left: 0,
+                    background: 'white',
+                    zIndex: 900,
+                    minWidth: 100
+                  }}
+                  align='left'
+                  key={``}> Candidate </TableCell>
+                {results.voteCounts.map((roundVoteCounts, i) =>
+                  <TableCell
+                    align='right'
+                    style={{
+                      minWidth: 100,
+                      zIndex: 800,
+                    }}
+                  >
+                    {`Round ${i + 1}`}
+                  </TableCell>)}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {results.summaryData.candidates.map((c, n) => (
 
-          {results.summaryData.candidates.map((c, n) => (
-            <>
-              <tr className='matrix' key={`h${n}`} >{c.name}
-                <td> {results.summaryData.totalScores[n].score} </td>
-              </tr>
+                <TableRow >
+                  <TableCell
+                    align="left"
+                    style={{
+                      position: 'sticky',
+                      left: 0,
+                      background: 'white',
+                      zIndex: 700,
+                    }}>
+                    {c.name}
+                  </TableCell>
+                  {results.voteCounts.map((roundVoteCounts, i) =>
+                    <TableCell
+                      align="right">
+                      {roundVoteCounts[n]}
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))}
+              <TableRow >
+                <TableCell
+                  align="left"
+                  style={{
+                    position: 'sticky',
+                    left: 0,
+                    background: 'white',
+                    zIndex: 700,
+                  }}> Exhausted Ballots</TableCell>
+                {results.exhaustedVoteCounts.map((exhaustedVoteCount, i) => <TableCell align="right"> {exhaustedVoteCount} </TableCell>)}
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
 
-            </>
-          ))}
-        </thead>
-      </table>
+      <Paper elevation={0} sx={{ my: 1, width: '100%' }}>
+        <TableContainer sx={{ maxHeight: 600, maxWidth: { xs: 300 } }}>
+
+          <Table size='small'>
+            <TableHead>
+              <TableRow>
+                <TableCell className='matrix'> Candidate</TableCell>
+                <TableCell className='matrix'> # of wins head to head wins</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {results.summaryData.candidates.map((c, n) => (
+                <TableRow >
+                  <TableCell>
+                    {c.name}
+                  </TableCell>
+                  <TableCell> {results.summaryData.totalScores[n].score} </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+        </TableContainer>
+      </Paper>
       <Grid container alignItems="center" >
         <Grid item xs={1}>
           {!viewMatrix &&

--- a/frontend/src/components/ElectionForm/Races.tsx
+++ b/frontend/src/components/ElectionForm/Races.tsx
@@ -259,32 +259,32 @@ export default function Races({ election, applyElectionUpdate, getStyle, setPage
                                     >
                                         <FormControlLabel value="STAR" control={<Radio />} label="STAR" sx={{ mb: 0, pb: 0 }} />
                                         <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                            Score-Than-Automatic-Runoff, recommended by the Equal Vote Coalition
+                                            Score candidates 0-5, single winner or multi-winner
                                         </FormHelperText>
 
                                         <FormControlLabel value="STAR_PR" control={<Radio />} label="Proportional STAR" />
                                         <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                            A proportional multiwinner version of STAR voting
+                                            Score candidates 0-5, proportional multi-winner
                                         </FormHelperText>
 
                                         <FormControlLabel value="RankedRobin" control={<Radio />} label="Ranked Robin" />
                                         <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                            Ranked method, candidate that wins the most head to head matchups wins
+                                            Rank candidates in order of preference, single winner or multi-winner
                                         </FormHelperText>
 
                                         <FormControlLabel value="Approval" control={<Radio />} label="Approval" />
                                         <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                            Candidate with the highest approval wins
+                                            Mark all candidates you approve of, single winner or multi-winner
                                         </FormHelperText>
                                         
                                         <FormControlLabel value="Plurality" control={<Radio />} label="Plurality" />
                                         <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                            Choose one only voting, candidate with most votes wins. Not recommended with more than 2 candidates.
+                                            Mark one candidate only. Not recommended with more than 2 candidates.
                                         </FormHelperText>
                                         
                                         <FormControlLabel value="IRV" control={<Radio />} label="Ranked Choice" />
                                         <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                            Eliminate candidates until majority winner is found. Only recommended for educational purposes.
+                                            Rank candidates in order of preference, single winner, only recommended for educational purposes
                                         </FormHelperText>
                                     </RadioGroup>
                                 </FormControl>

--- a/frontend/src/components/ElectionForm/Races.tsx
+++ b/frontend/src/components/ElectionForm/Races.tsx
@@ -5,10 +5,11 @@ import AddCandidate from "./AddCandidate"
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
 import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import Typography from '@mui/material/Typography';
-import { Box, FormHelperText, InputLabel } from "@mui/material"
+import { Box, Checkbox, FormGroup, FormHelperText, FormLabel, InputLabel, Radio, RadioGroup, Tooltip } from "@mui/material"
 import { StyledButton } from '../styles';
 
 export default function Races({ election, applyElectionUpdate, getStyle, setPageNumber, submitText, onSubmit }) {
@@ -115,7 +116,7 @@ export default function Races({ election, applyElectionUpdate, getStyle, setPage
     }
 
     const onEditCandidate = (race_index, candidate: Candidate, index) => {
-        setErrors({ ...errors, candidates: '', raceNumWinners: ''})
+        setErrors({ ...errors, candidates: '', raceNumWinners: '' })
         applyElectionUpdate(election => {
             election.races[race_index].candidates[index] = candidate
             const candidates = election.races[openRace].candidates
@@ -244,42 +245,51 @@ export default function Races({ election, applyElectionUpdate, getStyle, setPage
                                     {errors.raceNumWinners}
                                 </FormHelperText>
                             </Grid>
-                            <Grid item xs={12} sx={{ m: 0, p: 1 }}>
-                                <Box sx={{ minWidth: 120 }}>
-                                    <FormControl fullWidth sx={{
-                                        m: 0,
-                                        boxShadow: 2,
-                                    }}>
-                                        <InputLabel >
-                                            Voting Method
-                                        </InputLabel>
-                                        <Select
-                                            name="Voting Method"
-                                            label="Voting Method"
-                                            value={election.races[race_index].voting_method}
-                                            onChange={(e) => applyElectionUpdate(election => { election.races[race_index].voting_method = e.target.value })}
-                                        >
-                                            <MenuItem key="STAR" value="STAR">
-                                                STAR
-                                            </MenuItem>
-                                            <MenuItem key="STAR_PR" value="STAR_PR">
-                                                STAR-PR
-                                            </MenuItem>
-                                            <MenuItem key="Plurality" value="Plurality">
-                                                Plurality
-                                            </MenuItem>
-                                            <MenuItem key="IRV" value="IRV">
-                                                IRV
-                                            </MenuItem>
-                                            <MenuItem key="Ranked-Robin" value="RankedRobin">
-                                                Ranked-Robin
-                                            </MenuItem>
-                                            <MenuItem key="Approval" value="Approval">
-                                                Approval
-                                            </MenuItem>
-                                        </Select>
-                                    </FormControl>
-                                </Box>
+
+                            <Grid item xs={12} sx={{ m: 0, my: 1, p: 1 }}>
+                                <FormControl component="fieldset" variant="standard">
+                                    <FormLabel id="voter-access">
+                                        Voting Method
+                                    </FormLabel>
+                                    <RadioGroup
+                                        aria-labelledby="voting-method-radio-group"
+                                        name="voter-access-radio-buttons-group"
+                                        value={election.races[race_index].voting_method}
+                                        onChange={(e) => applyElectionUpdate(election => { election.races[race_index].voting_method = e.target.value })}
+                                    >
+                                        <FormControlLabel value="STAR" control={<Radio />} label="STAR" sx={{ mb: 0, pb: 0 }} />
+                                        <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                            Score-Than-Automatic-Runoff, recommended by the Equal Vote Coalition
+                                        </FormHelperText>
+
+                                        <FormControlLabel value="STAR_PR" control={<Radio />} label="Proportional STAR" />
+                                        <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                            A proportional multiwinner version of STAR voting
+                                        </FormHelperText>
+
+                                        <FormControlLabel value="RankedRobin" control={<Radio />} label="Ranked Robin" />
+                                        <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                            Ranked method, candidate that wins the most head to head matchups wins
+                                        </FormHelperText>
+
+                                        <FormControlLabel value="Approval" control={<Radio />} label="Approval" />
+                                        <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                            Candidate with the highest approval wins
+                                        </FormHelperText>
+                                        
+                                        <FormControlLabel value="Plurality" control={<Radio />} label="Plurality" />
+                                        <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                            Choose one only voting, candidate with most votes wins. Not recommended with more than 2 candidates.
+                                        </FormHelperText>
+                                        
+                                        <FormControlLabel value="IRV" control={<Radio />} label="Ranked Choice" />
+                                        <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                            Eliminate candidates until majority winner is found. Only recommended for educational purposes.
+                                        </FormHelperText>
+                                    </RadioGroup>
+                                </FormControl>
+
+
                             </Grid>
                             <Grid item xs={12} sx={{ m: 0, p: 1 }}>
                                 <Typography gutterBottom variant="h6" component="h6">


### PR DESCRIPTION
Uses radio buttons for selecting voting method
https://files.slack.com/files-pri/T9TFU145P-F04VB54EJQY/image.png

Fixes issue with the edges of the results page getting cropped on mobile. I switched to using the MUI table component and set a max table width based on screen size. So now if the table is too big it creates a scrollable table that fits on the screen.

Original view:
![image](https://user-images.githubusercontent.com/41272412/226201469-7a49d5fc-fc3a-4ba7-9eef-54506ed1aee8.png)

Fixed view:
![image](https://user-images.githubusercontent.com/41272412/226202912-63750f3d-0ca4-4bc6-8e72-1a504afacc49.png)
