### PR TITLE
Tabulator tests

### DIFF
--- a/backend/src/Tabulators/Approval.test.ts
+++ b/backend/src/Tabulators/Approval.test.ts
@@ -1,0 +1,97 @@
+import { Approval } from './Approval'
+
+describe("Approval Tests", () => {
+    test("Single Winner Test", () => {
+        // Simple test to elect the candidate with most votes
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 2],
+            [0, 0, -1, 0],
+        ]
+        const results = Approval(candidates, votes)
+        expect(results.elected.length).toBe(1);
+        expect(results.elected[0].name).toBe('Dave');
+        expect(results.summaryData.totalScores[0].score).toBe(7)
+        expect(results.summaryData.totalScores[0].index).toBe(3)
+        expect(results.summaryData.totalScores[1].score).toBe(6)
+        expect(results.summaryData.totalScores[1].index).toBe(2)
+        expect(results.summaryData.totalScores[2].score).toBe(3)
+        expect(results.summaryData.totalScores[2].index).toBe(1)
+        expect(results.summaryData.totalScores[3].score).toBe(1)
+        expect(results.summaryData.totalScores[3].index).toBe(0)
+        
+        expect(results.summaryData.nUnderVotes).toBe(1)
+        expect(results.summaryData.nValidVotes).toBe(7)
+        expect(results.summaryData.nInvalidVotes).toBe(2)
+    })
+
+    test("Multi Winner Test", () => {
+        // Simple test to elect the candidate with most votes
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 0, 1],
+        ]
+        const results = Approval(candidates, votes,2)
+        expect(results.elected.length).toBe(2);
+        expect(results.elected[0].name).toBe('Dave');
+        expect(results.elected[1].name).toBe('Carol');
+        expect(results.summaryData.totalScores[0].score).toBe(7)
+        expect(results.summaryData.totalScores[0].index).toBe(3)
+        expect(results.summaryData.totalScores[1].score).toBe(6)
+        expect(results.summaryData.totalScores[1].index).toBe(2)
+        expect(results.summaryData.totalScores[2].score).toBe(3)
+        expect(results.summaryData.totalScores[2].index).toBe(1)
+        expect(results.summaryData.totalScores[3].score).toBe(1)
+        expect(results.summaryData.totalScores[3].index).toBe(0)
+        
+        expect(results.summaryData.nUnderVotes).toBe(0)
+        expect(results.summaryData.nValidVotes).toBe(7)
+        expect(results.summaryData.nInvalidVotes).toBe(0)
+    })
+
+    test("Ties Test", () => {
+        // Tie for second
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 0, 1],
+        ]
+        const results = Approval(candidates, votes)
+        expect(results.elected.length).toBe(1);
+        expect(results.elected[0].name).toBe('Dave');
+        expect(results.summaryData.totalScores[0].score).toBe(7)
+        expect(results.summaryData.totalScores[0].index).toBe(3)
+        expect(results.summaryData.totalScores[1].score).toBe(6)
+        expect([1,2]).toContain(results.summaryData.totalScores[1].index)
+        expect(results.summaryData.totalScores[2].score).toBe(6)
+        expect([1,2]).toContain(results.summaryData.totalScores[2].index)
+        expect(results.summaryData.totalScores[3].score).toBe(1)
+        expect(results.summaryData.totalScores[3].index).toBe(0)
+        
+        expect(results.summaryData.nUnderVotes).toBe(0)
+        expect(results.summaryData.nValidVotes).toBe(7)
+        expect(results.summaryData.nInvalidVotes).toBe(0)
+    })
+})

--- a/backend/src/Tabulators/Approval.test.ts
+++ b/backend/src/Tabulators/Approval.test.ts
@@ -30,7 +30,7 @@ describe("Approval Tests", () => {
         expect(results.summaryData.totalScores[3].index).toBe(0)
         
         expect(results.summaryData.nUnderVotes).toBe(1)
-        expect(results.summaryData.nValidVotes).toBe(7)
+        expect(results.summaryData.nValidVotes).toBe(8)
         expect(results.summaryData.nInvalidVotes).toBe(2)
     })
 

--- a/backend/src/Tabulators/Approval.test.ts
+++ b/backend/src/Tabulators/Approval.test.ts
@@ -84,9 +84,9 @@ describe("Approval Tests", () => {
         expect(results.summaryData.totalScores[0].score).toBe(7)
         expect(results.summaryData.totalScores[0].index).toBe(3)
         expect(results.summaryData.totalScores[1].score).toBe(6)
-        expect([1,2]).toContain(results.summaryData.totalScores[1].index)
+        expect([1,2]).toContain(results.summaryData.totalScores[1].index) // random tiebreaker, second place can either be 1 or 2
         expect(results.summaryData.totalScores[2].score).toBe(6)
-        expect([1,2]).toContain(results.summaryData.totalScores[2].index)
+        expect([1,2]).toContain(results.summaryData.totalScores[2].index) // random tiebreaker, third place can either be 1 or 2
         expect(results.summaryData.totalScores[3].score).toBe(1)
         expect(results.summaryData.totalScores[3].index).toBe(0)
         

--- a/backend/src/Tabulators/Approval.ts
+++ b/backend/src/Tabulators/Approval.ts
@@ -73,7 +73,7 @@ function getSummaryData(candidates: string[], parsedData: IparsedData): approval
     totalScores,
     nValidVotes: parsedData.validVotes.length,
     nInvalidVotes: parsedData.invalidVotes.length,
-    nUnderVotes: parsedData.underVotes.length,
+    nUnderVotes: parsedData.underVotes,
     nBulletVotes: nBulletVotes
   }
 }

--- a/backend/src/Tabulators/IRV.test.ts
+++ b/backend/src/Tabulators/IRV.test.ts
@@ -1,0 +1,61 @@
+// const IRV = require('./IRV.ts')
+import { IRV } from './IRV'
+
+describe("IRV Tests", () => {
+    test("IRV Test", () => {
+        // Simple test to elect the candidate that is the highest scoring and condorcet winner
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [2, 1, 3, 4],
+            [2, 1, 3, 4],
+            [2, 3, 1, 4],
+        ]
+        const results = IRV(candidates, votes)
+        console.log(results.voteCounts)
+        expect(results.elected[0].name).toBe('Alice');
+        // expect(results.runner_up[0].name).toBe('Carmen');
+    })
+    test("Center Squeeze", () => {
+        // Simple test to elect the candidate that is the highest scoring and condorcet winner
+        const candidates = ['Alice', 'Bob', 'Carol']
+
+        const votes = [
+            [1, 2, 3],
+            [1, 2, 3],
+            [3, 2, 1],
+            [3, 2, 1],
+            [2, 1, 3],
+        ]
+        const results = IRV(candidates, votes)
+        console.log(results.voteCounts)
+        expect(results.elected[0].name).toBe('Alice');
+        // expect(results.runner_up[0].name).toBe('Carmen');
+    })
+    test("Exhausted Ballots", () => {
+        // Simple test to elect the candidate that is the highest scoring and condorcet winner
+        const candidates = ['Alice', 'Bob', 'Carol']
+
+        const votes = [
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3],
+            [3, 2, 1],
+            [3, 2, 1],
+            [3, 2, 1],
+            [3, 2, 1],
+            [2, 1, 1],
+            [2, 1, 0],
+            [0, 1, 0],
+        ]
+        const results = IRV(candidates, votes)
+        console.log(results)
+        console.log(results.exhaustedVoteCounts)
+        console.log(results.overVoteCounts)
+        expect(results.elected[0].name).toBe('Alice');
+        // expect(results.runner_up[0].name).toBe('Carmen');
+    })
+})

--- a/backend/src/Tabulators/IRV.test.ts
+++ b/backend/src/Tabulators/IRV.test.ts
@@ -52,9 +52,9 @@ describe("IRV Tests", () => {
             [3, 2, 1],
             [3, 2, 1],
             [3, 2, 1],
-            [2, 1, 1],//overvote
-            [3, 2, 0],//no first rank
-            [2, 1, 2],//second round overvote
+            [2, 1, 1],//first round overvote & exhausted
+            [3, 2, 0],//no first rank, not exhausted
+            [2, 1, 2],//second round overvote & exhausted
             [0, 1, 0],//second round exhausted vote
         ]
         const results = IRV(candidates, votes)

--- a/backend/src/Tabulators/IRV.test.ts
+++ b/backend/src/Tabulators/IRV.test.ts
@@ -1,25 +1,29 @@
-// const IRV = require('./IRV.ts')
 import { IRV } from './IRV'
 
 describe("IRV Tests", () => {
-    test("IRV Test", () => {
-        // Simple test to elect the candidate that is the highest scoring and condorcet winner
+    test("First round majority", () => {
+        // Simple test to elect the candidate with most votes in first round
         const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
 
         const votes = [
             [1, 2, 3, 4],
             [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
             [2, 1, 3, 4],
             [2, 1, 3, 4],
             [2, 3, 1, 4],
+            [2, 3, 4, 1],
         ]
         const results = IRV(candidates, votes)
-        console.log(results.voteCounts)
         expect(results.elected[0].name).toBe('Alice');
-        // expect(results.runner_up[0].name).toBe('Carmen');
+        expect(results.voteCounts.length).toBe(1);  //only single round
+        expect(results.voteCounts[0]).toStrictEqual([5,2,1,1]);  
+        
     })
-    test("Center Squeeze", () => {
-        // Simple test to elect the candidate that is the highest scoring and condorcet winner
+    test("2 round test", () => {
+        // Majority can't be found in first round
         const candidates = ['Alice', 'Bob', 'Carol']
 
         const votes = [
@@ -30,12 +34,13 @@ describe("IRV Tests", () => {
             [2, 1, 3],
         ]
         const results = IRV(candidates, votes)
-        console.log(results.voteCounts)
         expect(results.elected[0].name).toBe('Alice');
-        // expect(results.runner_up[0].name).toBe('Carmen');
+        expect(results.voteCounts.length).toBe(2);  //Two rounds
+        expect(results.voteCounts[0]).toStrictEqual([2,1,2]);  
+        expect(results.voteCounts[1]).toStrictEqual([3,0,2]); 
     })
     test("Exhausted Ballots", () => {
-        // Simple test to elect the candidate that is the highest scoring and condorcet winner
+        // Exhaust ballot if no remaining candidates
         const candidates = ['Alice', 'Bob', 'Carol']
 
         const votes = [
@@ -47,15 +52,17 @@ describe("IRV Tests", () => {
             [3, 2, 1],
             [3, 2, 1],
             [3, 2, 1],
-            [2, 1, 1],
-            [2, 1, 0],
-            [0, 1, 0],
+            [2, 1, 1],//overvote
+            [3, 2, 0],//no first rank
+            [2, 1, 2],//second round overvote
+            [0, 1, 0],//second round exhausted vote
         ]
         const results = IRV(candidates, votes)
-        console.log(results)
-        console.log(results.exhaustedVoteCounts)
-        console.log(results.overVoteCounts)
         expect(results.elected[0].name).toBe('Alice');
-        // expect(results.runner_up[0].name).toBe('Carmen');
+        expect(results.voteCounts.length).toBe(2);  //Two rounds
+        expect(results.voteCounts[0]).toStrictEqual([4,3,4]);  
+        expect(results.voteCounts[1]).toStrictEqual([5,0,4]);  
+        expect(results.overVoteCounts).toStrictEqual([1,2]);   
+        expect(results.exhaustedVoteCounts).toStrictEqual([1,3]); 
     })
 })

--- a/backend/src/Tabulators/IRV.ts
+++ b/backend/src/Tabulators/IRV.ts
@@ -195,7 +195,7 @@ function getSummaryData(candidates: string[], parsedData: IparsedData): irvSumma
         pairwiseMatrix,
         nValidVotes: parsedData.validVotes.length,
         nInvalidVotes: parsedData.invalidVotes.length,
-        nUnderVotes: parsedData.underVotes.length,
+        nUnderVotes: parsedData.underVotes,
         nBulletVotes: nBulletVotes
     }
 }

--- a/backend/src/Tabulators/ParseData.ts
+++ b/backend/src/Tabulators/ParseData.ts
@@ -4,7 +4,7 @@ import { ballot, voter } from "./ITabulators";
 export interface IparsedData {
     scores: ballot[],
     invalidVotes: voter[],
-    underVotes: voter[],
+    underVotes: number,
     validVotes: voter[]
 } 
 function getStarBallotValidity(ballot: ballot) {
@@ -26,7 +26,7 @@ module.exports = function ParseData(data: ballot[], validityCheck = getStarBallo
     // Initialize arrays
     const scores: ballot[] = [];
     const validVotes: voter[] = [];
-    const underVotes: voter[]  = [];
+    let underVotes: number = 0;
     const invalidVotes: voter[]  = [];
     // Parse each row of data into voter, undervote, and score arrays
     data.forEach((row, n) => {
@@ -36,7 +36,9 @@ module.exports = function ParseData(data: ballot[], validityCheck = getStarBallo
             invalidVotes.push(voter)
         }
         else if (ballotValidity.isUnderVote) {
-            underVotes.push(voter)
+            underVotes += 1
+            scores.push(row)
+            validVotes.push(voter);
         }
         else {
             scores.push(row)

--- a/backend/src/Tabulators/Plurality.test.ts
+++ b/backend/src/Tabulators/Plurality.test.ts
@@ -95,9 +95,9 @@ describe("Plurality Tests", () => {
         expect(results.summaryData.totalScores[0].score).toBe(5)
         expect(results.summaryData.totalScores[0].index).toBe(3)
         expect(results.summaryData.totalScores[1].score).toBe(3)
-        expect([1,2]).toContain(results.summaryData.totalScores[1].index)
+        expect([1,2]).toContain(results.summaryData.totalScores[1].index)// random tiebreaker, second place can either be 1 or 2
         expect(results.summaryData.totalScores[2].score).toBe(3)
-        expect([1,2]).toContain(results.summaryData.totalScores[2].index)
+        expect([1,2]).toContain(results.summaryData.totalScores[2].index)// random tiebreaker, third place can either be 1 or 2
         expect(results.summaryData.totalScores[3].score).toBe(0)
         expect(results.summaryData.totalScores[3].index).toBe(0)
         

--- a/backend/src/Tabulators/Plurality.test.ts
+++ b/backend/src/Tabulators/Plurality.test.ts
@@ -54,9 +54,10 @@ describe("Plurality Tests", () => {
             [0, 0, 0, 1],
             [0, 0, 0, 1],
         ]
-        const results = Plurality(candidates, votes)
-        expect(results.elected.length).toBe(1);
+        const results = Plurality(candidates, votes,2)
+        expect(results.elected.length).toBe(2);
         expect(results.elected[0].name).toBe('Dave');
+        expect(results.elected[1].name).toBe('Carol');
         expect(results.summaryData.totalScores[0].score).toBe(5)
         expect(results.summaryData.totalScores[0].index).toBe(3)
         expect(results.summaryData.totalScores[1].score).toBe(3)

--- a/backend/src/Tabulators/Plurality.test.ts
+++ b/backend/src/Tabulators/Plurality.test.ts
@@ -1,0 +1,107 @@
+import { Plurality } from './Plurality'
+
+describe("Plurality Tests", () => {
+    test("Single Winner Test", () => {
+        // Simple test to elect the candidate with most votes
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 2],
+            [0, 0, -1, 0],
+            [1, 0, 0, 1],
+        ]
+        const results = Plurality(candidates, votes)
+        expect(results.elected.length).toBe(1);
+        expect(results.elected[0].name).toBe('Dave');
+        expect(results.summaryData.totalScores[0].score).toBe(5)
+        expect(results.summaryData.totalScores[0].index).toBe(3)
+        expect(results.summaryData.totalScores[1].score).toBe(3)
+        expect(results.summaryData.totalScores[1].index).toBe(2)
+        expect(results.summaryData.totalScores[2].score).toBe(2)
+        expect(results.summaryData.totalScores[2].index).toBe(1)
+        expect(results.summaryData.totalScores[3].score).toBe(0)
+        expect(results.summaryData.totalScores[3].index).toBe(0)
+        
+        expect(results.summaryData.nUnderVotes).toBe(1)
+        expect(results.summaryData.nValidVotes).toBe(10)
+        expect(results.summaryData.nInvalidVotes).toBe(3)
+    })
+
+    test("Multi Winner Test", () => {
+        // Simple test to elect the candidate with most votes
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+        ]
+        const results = Plurality(candidates, votes)
+        expect(results.elected.length).toBe(1);
+        expect(results.elected[0].name).toBe('Dave');
+        expect(results.summaryData.totalScores[0].score).toBe(5)
+        expect(results.summaryData.totalScores[0].index).toBe(3)
+        expect(results.summaryData.totalScores[1].score).toBe(3)
+        expect(results.summaryData.totalScores[1].index).toBe(2)
+        expect(results.summaryData.totalScores[2].score).toBe(2)
+        expect(results.summaryData.totalScores[2].index).toBe(1)
+        expect(results.summaryData.totalScores[3].score).toBe(0)
+        expect(results.summaryData.totalScores[3].index).toBe(0)
+        
+        expect(results.summaryData.nUnderVotes).toBe(0)
+        expect(results.summaryData.nValidVotes).toBe(10)
+        expect(results.summaryData.nInvalidVotes).toBe(0)
+    })
+
+    test("Ties Test", () => {
+        // Tie for second
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 0, 1],
+        ]
+        const results = Plurality(candidates, votes)
+        expect(results.elected.length).toBe(1);
+        expect(results.elected[0].name).toBe('Dave');
+        expect(results.summaryData.totalScores[0].score).toBe(5)
+        expect(results.summaryData.totalScores[0].index).toBe(3)
+        expect(results.summaryData.totalScores[1].score).toBe(3)
+        expect([1,2]).toContain(results.summaryData.totalScores[1].index)
+        expect(results.summaryData.totalScores[2].score).toBe(3)
+        expect([1,2]).toContain(results.summaryData.totalScores[2].index)
+        expect(results.summaryData.totalScores[3].score).toBe(0)
+        expect(results.summaryData.totalScores[3].index).toBe(0)
+        
+        expect(results.summaryData.nUnderVotes).toBe(0)
+        expect(results.summaryData.nValidVotes).toBe(11)
+        expect(results.summaryData.nInvalidVotes).toBe(0)
+    })
+})

--- a/backend/src/Tabulators/Plurality.test.ts
+++ b/backend/src/Tabulators/Plurality.test.ts
@@ -34,7 +34,7 @@ describe("Plurality Tests", () => {
         expect(results.summaryData.totalScores[3].index).toBe(0)
         
         expect(results.summaryData.nUnderVotes).toBe(1)
-        expect(results.summaryData.nValidVotes).toBe(10)
+        expect(results.summaryData.nValidVotes).toBe(11)
         expect(results.summaryData.nInvalidVotes).toBe(3)
     })
 

--- a/backend/src/Tabulators/Plurality.ts
+++ b/backend/src/Tabulators/Plurality.ts
@@ -64,7 +64,7 @@ function getSummaryData(candidates: string[], parsedData: IparsedData): pluralit
     totalScores,
     nValidVotes: parsedData.validVotes.length,
     nInvalidVotes: parsedData.invalidVotes.length,
-    nUnderVotes: parsedData.underVotes.length,
+    nUnderVotes: parsedData.underVotes,
   }
 }
 

--- a/backend/src/Tabulators/RankedRobin.test.ts
+++ b/backend/src/Tabulators/RankedRobin.test.ts
@@ -40,7 +40,7 @@ describe("Ranked Robin Tests", () => {
         expect(results.summaryData.totalScores[3].score).toBe(0); 
 
         expect(results.summaryData.nUnderVotes).toBe(1)
-        expect(results.summaryData.nValidVotes).toBe(9)
+        expect(results.summaryData.nValidVotes).toBe(10)
         expect(results.summaryData.nInvalidVotes).toBe(2)
     })    
     test("Muilti winner test", () => {

--- a/backend/src/Tabulators/RankedRobin.test.ts
+++ b/backend/src/Tabulators/RankedRobin.test.ts
@@ -1,0 +1,106 @@
+import { RankedRobin } from './RankedRobin'
+
+describe("Ranked Robin Tests", () => {
+    test("Single winner test", () => {
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 2, 3, 0],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 1, 2, 3],
+            [1, 1, 2, 3],
+            [2, 1, 3, 4],
+            [2, 1, 3, 4],
+            [2, 3, 1, 4],
+            [2, 3, 4, 1],
+            [0, 0, 0, 0],
+            [2, 3, 4, -1],
+            [2, 3, 5, 1],
+        ]
+        const results = RankedRobin(candidates, votes)
+        expect(results.elected[0].name).toBe('Alice');
+        expect(results.elected.length).toBe(1);
+        expect(results.summaryData.preferenceMatrix[0]).toStrictEqual([0,5,8,8]);  
+        expect(results.summaryData.preferenceMatrix[1]).toStrictEqual([2,0,8,8]);  
+        expect(results.summaryData.preferenceMatrix[2]).toStrictEqual([1,1,0,8]);  
+        expect(results.summaryData.preferenceMatrix[3]).toStrictEqual([1,1,1,0]);  
+        expect(results.summaryData.pairwiseMatrix[0]).toStrictEqual([0,1,1,1]);  
+        expect(results.summaryData.pairwiseMatrix[1]).toStrictEqual([0,0,1,1]);  
+        expect(results.summaryData.pairwiseMatrix[2]).toStrictEqual([0,0,0,1]);  
+        expect(results.summaryData.pairwiseMatrix[3]).toStrictEqual([0,0,0,0]);  
+        
+        expect(results.summaryData.totalScores[0].index).toBe(0);  
+        expect(results.summaryData.totalScores[0].score).toBe(3);  
+        expect(results.summaryData.totalScores[1].index).toBe(1);  
+        expect(results.summaryData.totalScores[1].score).toBe(2);  
+        expect(results.summaryData.totalScores[2].index).toBe(2);  
+        expect(results.summaryData.totalScores[2].score).toBe(1);  
+        expect(results.summaryData.totalScores[3].index).toBe(3);  
+        expect(results.summaryData.totalScores[3].score).toBe(0); 
+
+        expect(results.summaryData.nUnderVotes).toBe(1)
+        expect(results.summaryData.nValidVotes).toBe(9)
+        expect(results.summaryData.nInvalidVotes).toBe(2)
+    })    
+    test("Muilti winner test", () => {
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 2, 3, 0],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 1, 2, 3],
+            [1, 1, 2, 3],
+            [2, 1, 3, 4],
+            [2, 1, 3, 4],
+            [2, 3, 1, 4],
+            [2, 3, 4, 1],
+        ]
+        const results = RankedRobin(candidates, votes,2)
+        expect(results.elected.length).toBe(2);
+        expect(results.elected[0].name).toBe('Alice');
+        expect(results.elected[1].name).toBe('Bob');
+
+        expect(results.summaryData.nUnderVotes).toBe(0)
+        expect(results.summaryData.nValidVotes).toBe(9)
+        expect(results.summaryData.nInvalidVotes).toBe(0)
+    })
+    test("Ties", () => {
+        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+
+        const votes = [
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+            [2, 1, 3, 4],
+            [2, 1, 3, 4],
+            [2, 1, 3, 4],
+        ]
+        const results = RankedRobin(candidates, votes)
+        expect(['Alice','Bob']).toContain(results.elected[0].name)
+        expect(results.elected.length).toBe(1);
+        expect(results.summaryData.preferenceMatrix[0]).toStrictEqual([0,3,6,6]);  
+        expect(results.summaryData.preferenceMatrix[1]).toStrictEqual([3,0,6,6]);  
+        expect(results.summaryData.preferenceMatrix[2]).toStrictEqual([0,0,0,6]);  
+        expect(results.summaryData.preferenceMatrix[3]).toStrictEqual([0,0,0,0]);  
+        expect(results.summaryData.pairwiseMatrix[0]).toStrictEqual([0,0,1,1]);  
+        expect(results.summaryData.pairwiseMatrix[1]).toStrictEqual([0,0,1,1]);  
+        expect(results.summaryData.pairwiseMatrix[2]).toStrictEqual([0,0,0,1]);  
+        expect(results.summaryData.pairwiseMatrix[3]).toStrictEqual([0,0,0,0]);  
+        
+        expect(results.summaryData.totalScores[0].index).toBe(0);  
+        expect(results.summaryData.totalScores[0].score).toBe(2);  
+        expect(results.summaryData.totalScores[1].index).toBe(1);  
+        expect(results.summaryData.totalScores[1].score).toBe(2);  
+        expect(results.summaryData.totalScores[2].index).toBe(2);  
+        expect(results.summaryData.totalScores[2].score).toBe(1);  
+        expect(results.summaryData.totalScores[3].index).toBe(3);  
+        expect(results.summaryData.totalScores[3].score).toBe(0); 
+
+        expect(results.summaryData.nUnderVotes).toBe(0)
+        expect(results.summaryData.nValidVotes).toBe(6)
+        expect(results.summaryData.nInvalidVotes).toBe(0)
+    })
+
+})

--- a/backend/src/Tabulators/RankedRobin.ts
+++ b/backend/src/Tabulators/RankedRobin.ts
@@ -143,7 +143,7 @@ function getSummaryData(candidates: string[], parsedData: IparsedData): rankedRo
     pairwiseMatrix,
     nValidVotes: parsedData.validVotes.length,
     nInvalidVotes: parsedData.invalidVotes.length,
-    nUnderVotes: parsedData.underVotes.length,
+    nUnderVotes: parsedData.underVotes,
     nBulletVotes: nBulletVotes
   }
 }

--- a/backend/src/Tabulators/Star.test.ts
+++ b/backend/src/Tabulators/Star.test.ts
@@ -101,7 +101,7 @@ describe("STAR Tests", () => {
             [0, 0, 5],
         ]
         const results = Star(candidates, votes, 1, false, false)
-        expect(results.summaryData.nValidVotes).toBe(6);
+        expect(results.summaryData.nValidVotes).toBe(8);
         expect(results.summaryData.nInvalidVotes).toBe(2);
         expect(results.summaryData.nUnderVotes).toBe(2);
         expect(results.summaryData.nBulletVotes).toBe(3);

--- a/backend/src/Tabulators/Star.ts
+++ b/backend/src/Tabulators/Star.ts
@@ -131,7 +131,7 @@ function getSummaryData(candidates: string[], parsedData: IparsedData): summaryD
     pairwiseMatrix,
     nValidVotes: parsedData.validVotes.length,
     nInvalidVotes: parsedData.invalidVotes.length,
-    nUnderVotes: parsedData.underVotes.length,
+    nUnderVotes: parsedData.underVotes,
     nBulletVotes: nBulletVotes
   }
 }


### PR DESCRIPTION
Adding basic tests for approval, plurality, ranked robin, and IRV. 

There's probably some edge cases I missed but this adds the framework to add more later.