### PR TITLE
Moving frontend keycloak url to env variable 

### DIFF
--- a/frontend/sample.env
+++ b/frontend/sample.env
@@ -1,3 +1,3 @@
 # Fix for https://stackoverflow.com/questions/70374005/invalid-options-object-dev-server-has-been-initialized-using-an-options-object
 DANGEROUSLY_DISABLE_HOST_CHECK=true
-REACT_APP_KEYCLOAK_URL='https://auth.star.vote:8443/realms/STAR%20Voting%20Dev/protocol/openid-connect'
+REACT_APP_KEYCLOAK_URL=https://auth.star.vote:8443/realms/STAR%20Voting%20Dev/protocol/openid-connect

--- a/frontend/sample.env
+++ b/frontend/sample.env
@@ -1,2 +1,3 @@
 # Fix for https://stackoverflow.com/questions/70374005/invalid-options-object-dev-server-has-been-initialized-using-an-options-object
 DANGEROUSLY_DISABLE_HOST_CHECK=true
+REACT_APP_KEYCLOAK_URL='https://auth.star.vote:8443/realms/STAR%20Voting%20Dev/protocol/openid-connect'

--- a/frontend/src/hooks/useAuthSession.js
+++ b/frontend/src/hooks/useAuthSession.js
@@ -1,12 +1,7 @@
 import { useState, useEffect } from "react";
 import { useCookie } from "./useCookie";
 import jwt_decode from 'jwt-decode'
-let keycloakBaseUrl = 'https://auth.star.vote:8443/realms/STAR%20Voting%20Dev/protocol/openid-connect';
-// if (prodEndpoints.includes(window.location.origin)) {
-//     keycloakBaseUrl = 'https://auth.star.vote:8443/realms/STAR%20Voting/protocol/openid-connect';
-// } else {
-//     keycloakBaseUrl = 'https://auth.star.vote:8443/realms/STAR%20Voting%20Dev/protocol/openid-connect';
-// }
+let keycloakBaseUrl = process.env.REACT_APP_KEYCLOAK_URL;
 
 const keycloakAuthConfig = {
     clientId: 'star_vote_web',


### PR DESCRIPTION
Figured out that you can use env variables in react apps that get embedded at build time. Figured the keycloak url would be a good use for that.
Variables have to start with "REACT_APP_" which is why I can't use the existing KEYCLOAK_URL variable used in the backend.
Worked locally, creating PR to test in heroku.