### PR TITLE
Enhanced Tables

### DIFF
--- a/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
+++ b/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
@@ -9,6 +9,17 @@ import EditElectionRoll from "./EditElectionRoll";
 import AddElectionRoll from "./AddElectionRoll";
 import PermissionHandler from "../../PermissionHandler";
 import { Typography } from "@mui/material";
+import EnhancedTable, { HeadCell, TableData } from "./../../EnhancedTable";
+
+
+interface Data extends TableData {
+    voter_id: string;
+    email: string;
+    ip: string;
+    precinct: string;
+    has_voted: string;
+    state: string;
+}
 
 const ViewElectionRolls = ({ election, permissions }) => {
     const { id } = useParams();
@@ -18,9 +29,9 @@ const ViewElectionRolls = ({ election, permissions }) => {
     const [addRollPage, setAddRollPage] = useState(false)
     const [editedRoll, setEditedRoll] = useState(null)
 
-    const onOpen = (roll) => {
+    const onOpen = (voter) => {
         setIsEditing(true)
-        setEditedRoll({ ...roll })
+        setEditedRoll(data.electionRoll.find(roll => roll.voter_id === voter.voter_id))
     }
     const onClose = (roll) => {
         setIsEditing(false)
@@ -28,7 +39,81 @@ const ViewElectionRolls = ({ election, permissions }) => {
         setEditedRoll(null)
         fetchRolls()
     }
-    console.log(data)
+
+    const onSendInvites = () => {
+        // sendInvites.makeRequest()
+    }
+
+    const headCells: HeadCell[] = [
+        {
+            id: 'voter_id',
+            numeric: false,
+            disablePadding: false,
+            label: 'Voter ID',
+            filterType: 'search'
+        },
+        {
+            id: 'email',
+            numeric: false,
+            disablePadding: false,
+            label: 'Email',
+            filterType: 'search'
+        },
+        {
+            id: 'has_voted',
+            numeric: false,
+            disablePadding: false,
+            label: 'Has Voted',
+            filterType: 'groups',
+            filterGroups: {
+                'false': true,
+                'true' : true,
+            }
+        },
+        {
+            id: 'state',
+            numeric: false,
+            disablePadding: false,
+            label: 'State',
+            filterType: 'groups',
+            filterGroups: {
+                approved: true,
+                registered : true,
+            }
+        },
+        {
+            id: 'ip',
+            numeric: false,
+            disablePadding: false,
+            label: 'IP',
+            filterType: 'search'
+        },
+        {
+            id: 'precinct',
+            numeric: false,
+            disablePadding: false,
+            label: 'Precinct',
+            filterType: 'search'
+        },
+    ];
+
+    const tableData = React.useMemo(
+        () => {
+            if (data && data.electionRoll) {
+                return data.electionRoll.map(roll => ({
+                    voter_id: roll.voter_id,
+                    email: roll.email || '',
+                    ip: roll.ip_address || '',
+                    precinct: roll.precinct || '',
+                    has_voted: roll.submitted.toString(),
+                    state: roll.state.toString()
+                }))
+            } else {
+                return null
+            }
+        },
+        [data],
+    );
     return (
         <Container >
             <Typography align='center' gutterBottom variant="h4" component="h4">
@@ -43,34 +128,14 @@ const ViewElectionRolls = ({ election, permissions }) => {
                     <PermissionHandler permissions={permissions} requiredPermission={'canAddToElectionRoll'}>
                         <Button variant='outlined' onClick={() => setAddRollPage(true)} > Add Voters </Button>
                     </PermissionHandler>
-                    <TableContainer component={Paper}>
-                        <Table style={{ width: '100%' }} aria-label="simple table">
-                            <TableHead>
-                                <TableCell> Voter ID </TableCell>
-                                <TableCell> Email </TableCell>
-                                <TableCell> IP Address </TableCell>
-                                <TableCell> Precinct </TableCell>
-                                <TableCell> Has Voted </TableCell>
-                                <TableCell> State </TableCell>
-                                <TableCell> View </TableCell>
-                            </TableHead>
-                            <TableBody>
-                                {data.electionRoll.map((roll) => (
-                                    <TableRow key={roll.voter_id} >
-                                        <TableCell component="th" scope="row">
-                                            {roll.voter_id}
-                                        </TableCell>
-                                        <TableCell >{roll.email || ''}</TableCell>
-                                        <TableCell >{roll.ip_address || ''}</TableCell>
-                                        <TableCell >{roll.precinct || ''}</TableCell>
-                                        <TableCell >{roll.submitted.toString()}</TableCell>
-                                        <TableCell >{roll.state.toString()}</TableCell>
-                                        <TableCell ><Button variant='outlined' onClick={() => onOpen(roll)} > View </Button></TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
+                    <Button variant='outlined' onClick={() => onSendInvites()} > Send Invites </Button>
+                    <EnhancedTable
+                        headCells={headCells}
+                        data={tableData}
+                        defaultSortBy="voter_id"
+                        tableTitle="Voters"
+                        handleOnClick={(voter) => onOpen(voter)}
+                    />
                 </>
             }
             {isEditing && editedRoll &&

--- a/frontend/src/components/Elections.tsx
+++ b/frontend/src/components/Elections.tsx
@@ -2,11 +2,15 @@ import useFetch from "../hooks/useFetch"
 import React, { useEffect } from 'react'
 import { Election } from "../../../domain_model/Election"
 import Typography from '@mui/material/Typography';
-import { Box } from "@mui/material"
+import { Box, Container } from "@mui/material"
 import Button from "@mui/material/Button";
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@mui/material";
+import EnhancedTable, { HeadCell } from "./EnhancedTable";
+import { useNavigate } from "react-router"
 
 const Elections = ({ authSession }) => {
+
+    const navigate = useNavigate()
     // const url_params = new URLSearchParams(window.location.search)
     var url = '/API/Elections';
     // if (url_params.has('filter')) {
@@ -42,109 +46,226 @@ const Elections = ({ authSession }) => {
         return string.substring(0, limit)
     }
 
+    const electionsAsOfficialHeadCells: HeadCell[] = [
+        {
+            id: 'title',
+            numeric: false,
+            disablePadding: false,
+            label: 'Election Title',
+            filterType: 'search'
+        },
+        {
+            id: 'roles',
+            numeric: false,
+            disablePadding: false,
+            label: 'Role',
+            filterType: 'search'
+        },
+        {
+            id: 'state',
+            numeric: false,
+            disablePadding: false,
+            label: 'State',
+            filterType: 'groups',
+            filterGroups: {
+                draft: true,
+                finalized: true,
+                open: true,
+                closed: true,
+                archived: false
+            }
+        },
+        {
+            id: 'start_time',
+            numeric: false,
+            disablePadding: false,
+            label: 'Start Time',
+            filterType: 'search',
+        },
+        {
+            id: 'end_time',
+            numeric: false,
+            disablePadding: false,
+            label: 'End Time',
+            filterType: 'search',
+        },
+        {
+            id: 'description',
+            numeric: false,
+            disablePadding: false,
+            label: 'Description',
+            filterType: 'search'
+        },
+    ];
+
+    const electionsAsOfficialData = React.useMemo(
+        () => {
+            if (data && data.elections_as_official) {
+                return data.elections_as_official.map(election => ({
+                    election_id: election.election_id,
+                    title: election.title,
+                    roles: getRoles(election),
+                    state: election.state || '',
+                    start_time: election.start_time ? new Date(election.start_time).toLocaleString() : '',
+                    end_time: election.end_time ? new Date(election.end_time).toLocaleString() : '',
+                    description: limit(election.description, 30) || '',
+                }))
+            } else {
+                return []
+            }
+        },
+        [data],
+    );
+
+    const electionsAsVoterHeadCells: HeadCell[] = [
+        {
+            id: 'title',
+            numeric: false,
+            disablePadding: false,
+            label: 'Election Title',
+            filterType: 'search'
+        },
+        {
+            id: 'state',
+            numeric: false,
+            disablePadding: false,
+            label: 'State',
+            filterType: 'groups',
+            filterGroups: {
+                draft: true,
+                finalized: true,
+                open: true,
+                closed: true,
+                archived: false
+            }
+        },
+        {
+            id: 'start_time',
+            numeric: false,
+            disablePadding: false,
+            label: 'Start Time',
+            filterType: 'search',
+        },
+        {
+            id: 'end_time',
+            numeric: false,
+            disablePadding: false,
+            label: 'End Time',
+            filterType: 'search',
+        },
+        {
+            id: 'description',
+            numeric: false,
+            disablePadding: false,
+            label: 'Description',
+            filterType: 'search'
+        },
+    ];
+
+    const electionsAsVoterData = React.useMemo(
+        () => {
+            if (data && data.elections_as_voter) {
+                return data.elections_as_voter.map(election => ({
+                    election_id: election.election_id,
+                    title: election.title,
+                    state: election.state || '',
+                    start_time: election.start_time ? new Date(election.start_time).toLocaleString() : '',
+                    end_time: election.end_time ? new Date(election.end_time).toLocaleString() : '',
+                    description: limit(election.description, 30) || '',
+                }))
+            } else {
+                return []
+            }
+        },
+        [data],
+    );
+
+    const openElectionsHeadCells: HeadCell[] = [
+        {
+            id: 'title',
+            numeric: false,
+            disablePadding: false,
+            label: 'Election Title',
+            filterType: 'search'
+        },
+        {
+            id: 'start_time',
+            numeric: false,
+            disablePadding: false,
+            label: 'Start Time',
+            filterType: 'search',
+        },
+        {
+            id: 'end_time',
+            numeric: false,
+            disablePadding: false,
+            label: 'End Time',
+            filterType: 'search',
+        },
+        {
+            id: 'description',
+            numeric: false,
+            disablePadding: false,
+            label: 'Description',
+            filterType: 'search'
+        },
+    ];
+
+    const openElectionsData = React.useMemo(
+        () => {
+            if (data && data.open_elections) {
+                return data.open_elections.map(election => ({
+                    election_id: election.election_id,
+                    title: election.title,
+                    start_time: election.start_time ? new Date(election.start_time).toLocaleString() : '',
+                    end_time: election.end_time ? new Date(election.end_time).toLocaleString() : '',
+                    description: limit(election.description, 30) || '',
+                }))
+            } else {
+                return []
+            }
+        },
+        [data],
+    );
+    
     return (
         <Box
             display='flex'
             justifyContent="center"
             alignItems="center"
-            sx={{ width: '100%', pt: 2 }}>
-            <Paper elevation={3} sx={{ p: 3 }} >
+            flexDirection={'column'}
+            sx={{ pt: 2, width: '100%' }}>
                 {isPending && <Typography align='center' variant="h3" component="h2"> Loading Elections... </Typography>}
                 {/****** elections you manage ********/}
-                <Typography variant="h5" component="h5">
-                    Elections you manage
-                </Typography>
-                <TableContainer component={Paper}>
-                    <Table style={{ width: '100%' }} aria-label="simple table">
-                        <TableHead>
-                            <TableCell> Election Title </TableCell>
-                            <TableCell> Role </TableCell>
-                            <TableCell> State </TableCell>
-                            <TableCell> Start Date </TableCell>
-                            <TableCell> End Date </TableCell>
-                            <TableCell> Description </TableCell>
-                            <TableCell> View </TableCell>
-                        </TableHead>
-                        <TableBody>
-                            {data?.elections_as_official?.filter(election => election.state != 'archived').map((election: Election) => (
-                                <TableRow key={election.election_id} >
-                                    <TableCell component="th" scope="row">
-                                        {election.title}
-                                    </TableCell>
-                                    <TableCell >{getRoles(election)}</TableCell>
-                                    <TableCell >{election.state || ''}</TableCell>
-                                    <TableCell > {election.start_time ? new Date(election.start_time).toLocaleString() : ''}</TableCell>
-                                    <TableCell >{election.end_time ? new Date(election.end_time).toLocaleString() : ''}</TableCell>
-                                    <TableCell >{limit(election.description, 30) || ''}</TableCell>
-                                    <TableCell ><Button variant='outlined' href={`/Election/${String(election.election_id)}${authSession.isLoggedIn() ? '/admin' : ''}`} > View </Button></TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+                <Container>
+                    <EnhancedTable
+                        headCells={electionsAsOfficialHeadCells}
+                        data={electionsAsOfficialData}
+                        defaultSortBy="title"
+                        tableTitle="Elections You Manage"
+                        handleOnClick={(election) => navigate(`/Election/${String(election.election_id)}${authSession.isLoggedIn() ? '/admin' : ''}`)}
+                    />
+                </Container>
 
                 {/****** elections we're invited to ********/}
-                <Typography variant="h5" component="h5" sx={{ pt: 2 }}>
-                    Elections as a voter
-                </Typography>
-                <TableContainer component={Paper}>
-                    <Table style={{ width: '100%' }} aria-label="simple table">
-                        <TableHead>
-                            <TableCell> Election Title </TableCell>
-                            <TableCell> State </TableCell>
-                            <TableCell> Start Date </TableCell>
-                            <TableCell> End Date </TableCell>
-                            <TableCell> Description </TableCell>
-                            <TableCell> View </TableCell>
-                        </TableHead>
-                        <TableBody>
-                            {data?.elections_as_voter?.filter(election => election.state != 'archived').map((election: Election) => (
-                                <TableRow key={election.election_id} >
-                                    <TableCell component="th" scope="row">
-                                        {election.title}
-                                    </TableCell>
-                                    <TableCell >{election.state || ''}</TableCell>
-                                    <TableCell > {election.start_time ? new Date(election.start_time).toLocaleString() : ''}</TableCell>
-                                    <TableCell >{election.end_time ? new Date(election.end_time).toLocaleString() : ''}</TableCell>
-                                    <TableCell >{limit(election.description, 30) || ''}</TableCell>
-                                    <TableCell ><Button variant='outlined' href={`/Election/${String(election.election_id)}`} > View </Button></TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+                <Container>
+                    <EnhancedTable
+                        headCells={electionsAsVoterHeadCells}
+                        data={electionsAsVoterData}
+                        defaultSortBy="title"
+                        tableTitle="Elections You Can Vote In"
+                        handleOnClick={(election) => navigate(`/Election/${String(election.election_id)}`)}
+                    /></Container>
 
                 {/****** elections open to all ********/}
-                <Typography variant="h5" component="h5" sx={{ pt: 2 }}>
-                    Open Elections
-                </Typography>
-                <TableContainer component={Paper}>
-                    <Table style={{ width: '100%' }} aria-label="simple table">
-                        <TableHead>
-                            <TableCell> Election Title </TableCell>
-                            <TableCell> State </TableCell>
-                            <TableCell> Start Date </TableCell>
-                            <TableCell> End Date </TableCell>
-                            <TableCell> Description </TableCell>
-                            <TableCell> View </TableCell>
-                        </TableHead>
-                        <TableBody>
-                            {data?.open_elections?.filter(election => election.state != 'archived').map((election: Election) => (
-                                <TableRow key={election.election_id} >
-                                    <TableCell component="th" scope="row">
-                                        {election.title}
-                                    </TableCell>
-                                    <TableCell >{election.state || ''}</TableCell>
-                                    <TableCell > {election.start_time ? new Date(election.start_time).toLocaleString() : ''}</TableCell>
-                                    <TableCell >{election.end_time ? new Date(election.end_time).toLocaleString() : ''}</TableCell>
-                                    <TableCell >{limit(election.description, 30) || ''}</TableCell>
-                                    <TableCell ><Button variant='outlined' href={`/Election/${String(election.election_id)}`} > View </Button></TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
-            </Paper>
+                <Container>
+                    <EnhancedTable
+                        headCells={openElectionsHeadCells}
+                        data={openElectionsData}
+                        defaultSortBy="title"
+                        tableTitle="Open Elections"
+                        handleOnClick={(election) => navigate(`/Election/${String(election.election_id)}`)}
+                    /></Container>
         </Box>
     )
 }

--- a/frontend/src/components/EnhancedTable.tsx
+++ b/frontend/src/components/EnhancedTable.tsx
@@ -1,0 +1,371 @@
+import * as React from 'react';
+import { alpha } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
+import { visuallyHidden } from '@mui/utils';
+import { Checkbox, FormControl, ListItemText, MenuItem, Select, TextField } from '@mui/material';
+
+export interface TableData {
+  [key: string]: string | number
+}
+
+function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
+  }
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
+  }
+  return 0;
+}
+
+type Order = 'asc' | 'desc';
+
+function getComparator<Key extends keyof any>(
+  order: Order,
+  orderBy: Key,
+): (
+  a: { [key in Key]: number | string },
+  b: { [key in Key]: number | string },
+) => number {
+  return order === 'desc'
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}
+
+// Since 2020 all major browsers ensure sort stability with Array.prototype.sort().
+// stableSort() brings sort stability to non-modern browsers (notably IE11). If you
+// only support modern browsers you can replace stableSort(exampleArray, exampleComparator)
+// with exampleArray.slice().sort(exampleComparator)
+function stableSort<T>(array: readonly T[], comparator: (a: T, b: T) => number) {
+  const stabilizedThis = array.map((el, index) => [el, index] as [T, number]);
+  stabilizedThis.sort((a, b) => {
+    const order = comparator(a[0], b[0]);
+    if (order !== 0) {
+      return order;
+    }
+    return a[1] - b[1];
+  });
+  return stabilizedThis.map((el) => el[0]);
+}
+
+type filterTypes = 'search' | 'groups' | null
+
+export interface HeadCell {
+  disablePadding: boolean;
+  id: keyof TableData;
+  label: string;
+  numeric: boolean;
+  filterType?: 'search' | 'groups';
+  filterGroups?: {
+    [key: string]: boolean
+  }
+}
+
+function filterData<T>(array: readonly T[], headCells: HeadCell[], filters: any[]) {
+
+  return array.filter(row => {
+    return headCells.every((col, colInd) => {
+      if (!col.filterType) return true
+      if (col.filterType === 'search') {
+        if (filters[colInd] == '') return true
+        return row[col.id].toLowerCase().includes(filters[colInd].toLowerCase())
+      }
+      if (col.filterType === 'groups') {
+        return filters[colInd][row[col.id]]
+      }
+      return true
+    })
+  })
+}
+
+
+
+
+
+interface EnhancedTableHeadProps {
+  onRequestSort: (event: React.MouseEvent<unknown>, property: keyof TableData) => void;
+  order: Order;
+  orderBy: string;
+  headCells: HeadCell[];
+  filters: any[];
+  setFilters: Function
+}
+
+function EnhancedTableHead(props: EnhancedTableHeadProps) {
+  const { order, orderBy, onRequestSort } =
+    props;
+  const createSortHandler =
+    (property: keyof TableData) => (event: React.MouseEvent<unknown>) => {
+      onRequestSort(event, property);
+    };
+
+  const handleSearchFilterChange = (ind: number, value: string) => {
+    props.setFilters(filters => {
+      let newFilters = [...filters]
+      newFilters[ind] = value
+      return newFilters
+    })
+  }
+
+  const handleGroupFilterChange = (ind: number, group: string, value: boolean) => {
+    props.setFilters(filters => {
+      let newFilters = [...filters]
+      newFilters[ind][group] = value
+      return newFilters
+    })
+  }
+
+  return (
+    <TableHead>
+      <TableRow>
+        {props.headCells.map((headCell, cellInd) => (
+          <TableCell
+            key={headCell.id}
+            align={headCell.numeric ? 'right' : 'left'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
+            sortDirection={orderBy === headCell.id ? order : false}
+          >
+            <TableSortLabel
+              active={orderBy === headCell.id}
+              direction={orderBy === headCell.id ? order : 'asc'}
+              onClick={createSortHandler(headCell.id)}
+            >
+              {headCell.label}
+              {orderBy === headCell.id ? (
+                <Box component="span" sx={visuallyHidden}>
+                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                </Box>
+              ) : null}
+            </TableSortLabel>
+            {headCell.filterType === 'search' &&
+              <TextField
+                sx={{ my: 1, minWidth: 120 }}
+                size="small"
+                value={props.filters[cellInd]}
+                onChange={(e) => handleSearchFilterChange(cellInd, e.target.value)}
+                placeholder='Search'
+              />
+            }
+            {headCell.filterType === 'groups' &&
+              <FormControl
+                sx={{ my: 1, minWidth: 120 }} size="small"
+              >
+                <Select
+                  multiple
+                  value={Object.keys(props.filters[cellInd]).filter(group => headCell.filterGroups[group])}
+                  renderValue={(selected) => selected.join(', ')}
+                >
+                  {Object.keys(headCell.filterGroups).map(group => (
+                    <MenuItem 
+                      onClick={(e) => handleGroupFilterChange(cellInd, group, !props.filters[cellInd][group])}>
+                      <Checkbox
+                        checked={props.filters[cellInd][group] == true}
+
+                      />
+                      <ListItemText primary={group} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            }
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}
+
+interface EnhancedTableToolbarProps {
+  numSelected: number;
+  tableTitle: string;
+}
+
+function EnhancedTableToolbar(props: EnhancedTableToolbarProps) {
+  const { numSelected } = props;
+
+  return (
+    <Toolbar
+      sx={{
+        pl: { sm: 2 },
+        pr: { xs: 1, sm: 1 },
+        ...(numSelected > 0 && {
+          bgcolor: (theme) =>
+            alpha(theme.palette.primary.main, theme.palette.action.activatedOpacity),
+        }),
+      }}
+    >
+
+      <Typography
+        sx={{ flex: '1 1 100%' }}
+        variant="h6"
+        id="tableTitle"
+        component="div"
+      >
+        {props.tableTitle}
+      </Typography>
+    </Toolbar>
+  );
+}
+
+interface EnhancedTableProps {
+  headCells: HeadCell[]
+  data: TableData[]
+  defaultSortBy: Extract<keyof TableData, string>
+  tableTitle: string,
+  handleOnClick: Function
+}
+
+export default function EnhancedTable(props: EnhancedTableProps) {
+  const [order, setOrder] = React.useState<Order>('asc');
+  const [orderBy, setOrderBy] = React.useState<Extract<keyof TableData, string>>(props.defaultSortBy);
+  const [selected, setSelected] = React.useState<readonly string[]>([]);
+  const [page, setPage] = React.useState(0);
+  const [dense, setDense] = React.useState(false);
+  const [rowsPerPage, setRowsPerPage] = React.useState(5);
+  const [filters, setFilters] = React.useState(props.headCells.map(col => {
+    if (!col.filterType) {
+      return null
+    }
+    else if (col.filterType === 'groups') {
+      return col.filterGroups
+    }
+    else if (col.filterType === 'search') {
+      return ''
+    }
+  }))
+
+  const handleRequestSort = (
+    event: React.MouseEvent<unknown>,
+    property: Extract<keyof TableData, string>,
+  ) => {
+    const isAsc = orderBy === property && order === 'asc';
+    setOrder(isAsc ? 'desc' : 'asc');
+    setOrderBy(property);
+  };
+
+  const handleChangePage = (event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleChangeDense = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDense(event.target.checked);
+  };
+
+  const filteredRows = React.useMemo(
+    () => {
+      setPage(0);
+      return filterData(props.data, props.headCells, filters)
+    },
+    [filters, props.data],
+  );
+
+  // Avoid a layout jump when reaching the last page with empty rows.
+  const emptyRows =
+    page > 0 ? Math.max(0, (1 + page) * rowsPerPage - filteredRows.length) : 0;
+
+
+  const visibleRows = React.useMemo(
+    () =>
+      stableSort(filteredRows, getComparator(order, orderBy)).slice(
+        page * rowsPerPage,
+        page * rowsPerPage + rowsPerPage,
+      ),
+    [order, orderBy, page, rowsPerPage, filteredRows],
+  );
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Paper elevation={8} sx={{ width: '100%', mb: 2 }}>
+        <EnhancedTableToolbar numSelected={selected.length} tableTitle={props.tableTitle} />
+        <TableContainer>
+          <Table
+            sx={{ minWidth: 750 }}
+            aria-labelledby="tableTitle"
+            size={dense ? 'small' : 'medium'}
+          >
+            <EnhancedTableHead
+              order={order}
+              orderBy={orderBy}
+              onRequestSort={handleRequestSort}
+              headCells={props.headCells}
+              filters={filters}
+              setFilters={setFilters}
+            />
+            <TableBody>
+              {visibleRows.map((row, index) => {
+                const labelId = `enhanced-table-checkbox-${index}`;
+                return (
+                  <TableRow
+                    hover
+                    onClick={() => props.handleOnClick(row)}
+                    tabIndex={-1}
+                    key={row.name}
+                    sx={{ cursor: 'pointer' }}
+                    
+                  >
+                    {props.headCells.map((col, colInd) => {
+                      if (colInd == 0) {
+                        return <TableCell
+                          component="th"
+                          id={labelId}
+                          scope="row">
+                          {row[col.id]}
+                        </TableCell>
+                      } else {
+                        return <TableCell
+                          align={col.numeric ? 'right' : 'left'} >
+                          {row[col.id]}
+                        </TableCell>
+                      }
+                    }
+                    )}
+                  </TableRow>
+                );
+              })}
+              {emptyRows > 0 && (
+                <TableRow
+                  style={{
+                    height: (dense ? 33 : 53) * emptyRows,
+                  }}
+                >
+                  <TableCell colSpan={6} />
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[5, 10, 25]}
+          component="div"
+          count={filteredRows.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </Paper>
+      <FormControlLabel
+        control={<Switch checked={dense} onChange={handleChangeDense} />}
+        label="Dense padding"
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/EnhancedTable.tsx
+++ b/frontend/src/components/EnhancedTable.tsx
@@ -233,7 +233,7 @@ export default function EnhancedTable(props: EnhancedTableProps) {
   const [orderBy, setOrderBy] = React.useState<Extract<keyof TableData, string>>(props.defaultSortBy);
   const [selected, setSelected] = React.useState<readonly string[]>([]);
   const [page, setPage] = React.useState(0);
-  const [dense, setDense] = React.useState(false);
+  const [dense, setDense] = React.useState(true);
   const [rowsPerPage, setRowsPerPage] = React.useState(5);
   const [filters, setFilters] = React.useState(props.headCells.map(col => {
     if (!col.filterType) {
@@ -362,10 +362,6 @@ export default function EnhancedTable(props: EnhancedTableProps) {
           onRowsPerPageChange={handleChangeRowsPerPage}
         />
       </Paper>
-      <FormControlLabel
-        control={<Switch checked={dense} onChange={handleChangeDense} />}
-        label="Dense padding"
-      />
     </Box>
   );
 }

--- a/frontend/src/components/EnhancedTable.tsx
+++ b/frontend/src/components/EnhancedTable.tsx
@@ -161,13 +161,14 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
             }
             {headCell.filterType === 'groups' &&
               <FormControl
-                sx={{ my: 1, minWidth: 120 }} size="small"
+                sx={{ my: 1, width: 120 }} size="small"
               >
                 <Select
                   multiple
-                  value={Object.keys(props.filters[cellInd]).filter(group => headCell.filterGroups[group])}
+                  value={Object.keys(props.filters[cellInd]).filter(group => props.filters[cellInd][group])}
                   renderValue={(selected) => selected.join(', ')}
                 >
+                  {console.log(Object.keys(props.filters[cellInd]).filter(group => headCell.filterGroups[group]===true))}
                   {Object.keys(headCell.filterGroups).map(group => (
                     <MenuItem 
                       onClick={(e) => handleGroupFilterChange(cellInd, group, !props.filters[cellInd][group])}>


### PR DESCRIPTION
## Description
Adds enhanced tables built largely off of [the MUI example](https://mui.com/material-ui/react-table/#sorting-amp-selecting) but makes it a generalized component. 

This adds the ability to sort the table data, filter it either by a search term or by predefined groups, and adds pagination. 


## Screenshots / Videos (frontend only) 

Desktop/Mobile Before 

https://github.com/Equal-Vote/star-server/assets/41272412/613f66da-2d01-4c56-8aa8-6c21ece973d0


Desktop After

https://github.com/Equal-Vote/star-server/assets/41272412/eb898f1f-c1c2-4e34-81e7-bec0c1a960fd

Mobile After
![image](https://github.com/Equal-Vote/star-server/assets/41272412/669d1933-8a8d-4fce-8300-9f34b0213760)

The example also had a switch for denser padding, curious which one looks better, will pick one before merging.

https://github.com/Equal-Vote/star-server/assets/41272412/2bdd0a35-7de4-459e-90db-d2a8303d1dc5

## Related Issues
none