### PR TITLE
Make useFetch types generic, move API  hooks to one file

### DIFF
--- a/backend/src/Controllers/changeElectionRollController.ts
+++ b/backend/src/Controllers/changeElectionRollController.ts
@@ -13,25 +13,25 @@ const className = "VoterRollState.Controllers";
 const approveElectionRoll = async (req: any, res: any, next: any) => {
     Logger.info(req, `${className}.approveElectionRoll ${req.params.id}`);
     changeElectionRollState(req, ElectionRollState.approved, [ElectionRollState.registered, ElectionRollState.flagged], permissions.canApproveElectionRoll)
-    res.status('200').json()
+    res.status('200').json({})
 }
 
 const flagElectionRoll = async (req: any, res: any, next: any) => {
     Logger.info(req, `${className}.flagElectionRoll ${req.params.id}`);
     changeElectionRollState(req, ElectionRollState.flagged, [ElectionRollState.approved, ElectionRollState.registered, ElectionRollState.invalid], permissions.canFlagElectionRoll)
-    res.status('200').json()
+    res.status('200').json({})
 }
 
 const invalidateElectionRoll = async (req: any, res: any, next: any) => {
     Logger.info(req, `${className}.flagElectionRoll ${req.params.id}`);
     changeElectionRollState(req, ElectionRollState.invalid, [ElectionRollState.flagged], permissions.canInvalidateBallot)
-    res.status('200').json()
+    res.status('200').json({})
 }
 
 const uninvalidateElectionRoll = async (req: any, res: any, next: any) => {
     Logger.info(req, `${className}.flagElectionRoll ${req.params.id}`);
     changeElectionRollState(req, ElectionRollState.flagged, [ElectionRollState.invalid], permissions.canInvalidateBallot)
-    res.status('200').json()
+    res.status('200').json({})
 }
 
 const changeElectionRollState = async (req: any, newState: ElectionRollState, validStates: ElectionRollState[], permission: permission) => {

--- a/backend/src/Controllers/getElectionRollController.ts
+++ b/backend/src/Controllers/getElectionRollController.ts
@@ -26,7 +26,7 @@ const getRollsByElectionID = async (req: any, res: any, next: any) => {
     Logger.debug(req, `Got Election: ${req.params.id}`, electionRoll);
     req.electionRoll = electionRoll
     Logger.info(req, `${className}.returnRolls ${req.params.id}`);
-    res.json({ election: req.election, electionRoll: req.electionRoll });
+    res.json({ election: req.election, electionRoll: electionRoll });
 }
 
 const getByVoterID = async (req: any, res: any, next: any) => {

--- a/frontend/src/components/Election/Admin/AddElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/AddElectionRoll.tsx
@@ -6,15 +6,15 @@ import Button from "@mui/material/Button";
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
 import Container from '@mui/material/Container';
-import useFetch from "../../../hooks/useFetch";
 import Box from '@mui/material/Box';
 import { Checkbox, FormGroup, FormControlLabel } from '@mui/material';
+import { usePostRolls } from "../../../hooks/useAPI";
 
 
 const AddElectionRoll = ({ election, onClose }) => {
 
     const [voterIDList, setVoterIDList] = useState('')
-    const postRoll = useFetch(`/API/Election/${election.election_id}/rolls/`, 'post')
+    const postRoll = usePostRolls(election.election_id)
     const [file, setFile] = useState()
     const fileReader = new FileReader()
     const [enableVoterID, setEnableVoterID] = useState(false)

--- a/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -1,4 +1,3 @@
-import useFetch from "../../../hooks/useFetch";
 import React from 'react'
 import Grid from "@mui/material/Grid";
 import { Box, Divider, Paper } from "@mui/material";
@@ -7,6 +6,7 @@ import { StyledButton } from "../../styles";
 import { Link } from 'react-router-dom';
 import { Election } from '../../../../../domain_model/Election';
 import ShareButton from "../ShareButton";
+import { useArchiveEleciton, useFinalizeEleciton, useSetPublicResults } from "../../../hooks/useAPI";
 const hasPermission = (permissions: string[], requiredPermission: string) => {
     return (permissions && permissions.includes(requiredPermission))
 }
@@ -357,14 +357,14 @@ const ShareSection = ({ election, permissions }: { election: Election, permissio
 }
 
 const AdminHome = ({ election, permissions, fetchElection }: Props) => {
-    const { makeRequest } = useFetch(`/API/Election/${election.election_id}/setPublicResults`, 'post')
+    const { makeRequest } = useSetPublicResults(election.election_id)
     const togglePublicResults = async () => {
         const public_results = !election.settings.public_results
         await makeRequest({ public_results: public_results })
         await fetchElection()
     }
-    const { makeRequest: finalize } = useFetch(`/API/Election/${election.election_id}/finalize`, 'post')
-    const { makeRequest: archive } = useFetch(`/API/Election/${election.election_id}/archive`, 'post')
+    const { makeRequest: finalize } = useFinalizeEleciton(election.election_id)
+    const { makeRequest: archive } = useArchiveEleciton(election.election_id)
     const finalizeElection = async () => {
         console.log("finalizing election")
         try {

--- a/frontend/src/components/Election/Admin/EditElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/EditElectionRoll.tsx
@@ -5,16 +5,16 @@ import Button from "@mui/material/Button";
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@mui/material";
-import useFetch from "../../../hooks/useFetch";
 import PermissionHandler from "../../PermissionHandler";
+import { useApproveRoll, useFlagRoll, useInvalidateRoll, useUnflagRoll } from "../../../hooks/useAPI";
 
 const EditElectionRoll = ({ roll, onClose, fetchRolls, id, permissions }) => {
     const [updatedRoll, setUpdatedRoll] = useState(roll)
 
-    const approve = useFetch(`/API/Election/${id}/rolls/approve`, 'post')
-    const flag = useFetch(`/API/Election/${id}/rolls/flag`, 'post')
-    const unflag = useFetch(`/API/Election/${id}/rolls/unflag`, 'post')
-    const invalidate = useFetch(`/API/Election/${id}/rolls/invalidate`, 'post')
+    const approve = useApproveRoll(id)
+    const flag = useFlagRoll(id)
+    const unflag = useUnflagRoll(id)
+    const invalidate = useInvalidateRoll(id)
 
     const onApprove = async () => {
         if (!await approve.makeRequest({ electionRollEntry: roll })) { return }

--- a/frontend/src/components/Election/Admin/EditRoles.tsx
+++ b/frontend/src/components/Election/Admin/EditRoles.tsx
@@ -5,9 +5,9 @@ import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
-import useFetch from "../../../hooks/useFetch";
 import { useNavigate } from "react-router"
 import PermissionHandler from "../../PermissionHandler";
+import { usePutElectionRoles } from "../../../hooks/useAPI";
 
 const EditRoles = ({ election, permissions }) => {
     const navigate = useNavigate()
@@ -27,7 +27,7 @@ const EditRoles = ({ election, permissions }) => {
         return election.credential_ids.join('\n')
     })
 
-    const putRoles = useFetch(`/API/Election/${election.election_id}/roles/`, 'put')
+    const putRoles = usePutElectionRoles(election.election_id)
 
     const onSubmit = async (e) => {
         e.preventDefault()

--- a/frontend/src/components/Election/Admin/ViewBallot.tsx
+++ b/frontend/src/components/Election/Admin/ViewBallot.tsx
@@ -5,14 +5,14 @@ import Button from "@mui/material/Button";
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@mui/material";
-import useFetch from "../../../hooks/useFetch";
 import PermissionHandler from "../../PermissionHandler";
 import { useParams } from "react-router";
+import { useGetBallot } from "../../../hooks/useAPI";
 
 const ViewBallot = ({ election, ballot, onClose, fetchBallot, permissions }) => {
     const { ballot_id } = useParams();
 
-    const { data, isPending, error, makeRequest: fetchBallots } = useFetch(`/API/Election/${election.election_id}/ballot/${ballot_id}`, 'get')
+    const { data, isPending, error, makeRequest: fetchBallots } = useGetBallot(election.election_id, ballot_id)
 
     useEffect(() => {
         if (ballot_id) {

--- a/frontend/src/components/Election/Admin/ViewBallots.tsx
+++ b/frontend/src/components/Election/Admin/ViewBallots.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react"
-import useFetch from "../../../hooks/useFetch";
 import { useParams } from "react-router";
 import React from 'react'
 import Button from "@mui/material/Button";
@@ -8,10 +7,10 @@ import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow
 import PermissionHandler from "../../PermissionHandler";
 import ViewBallot from "./ViewBallot";
 import { CSVLink } from "react-csv";
+import { useGetBallots } from "../../../hooks/useAPI";
 
 const ViewBallots = ({ election, permissions }) => {
-    const { id } = useParams();
-    const { data, isPending, error, makeRequest: fetchBallots } = useFetch(`/API/Election/${id}/ballots`, 'get')
+    const { data, isPending, error, makeRequest: fetchBallots } = useGetBallots(election.election_id)
     useEffect(() => { fetchBallots() }, [])
     const [isViewing, setIsViewing] = useState(false)
     const [addRollPage, setAddRollPage] = useState(false)

--- a/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
+++ b/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react"
-import useFetch from "../../../hooks/useFetch";
 import { useParams } from "react-router";
 import React from 'react'
 import Button from "@mui/material/Button";
@@ -10,6 +9,7 @@ import AddElectionRoll from "./AddElectionRoll";
 import PermissionHandler from "../../PermissionHandler";
 import { Typography } from "@mui/material";
 import EnhancedTable, { HeadCell, TableData } from "./../../EnhancedTable";
+import { useGetRolls, useSendInvites } from "../../../hooks/useAPI";
 
 
 interface Data extends TableData {
@@ -22,9 +22,8 @@ interface Data extends TableData {
 }
 
 const ViewElectionRolls = ({ election, permissions }) => {
-    const { id } = useParams();
-    const { data, isPending, error, makeRequest: fetchRolls } = useFetch(`/API/Election/${id}/rolls`, 'get')
-    const sendInvites = useFetch(`/API/Election/${id}/sendInvites`, 'post')
+    const { data, isPending, error, makeRequest: fetchRolls } = useGetRolls(election.election_id)
+    const sendInvites = useSendInvites(election.election_id)
     useEffect(() => { fetchRolls() }, [])
     const [isEditing, setIsEditing] = useState(false)
     const [addRollPage, setAddRollPage] = useState(false)
@@ -140,7 +139,7 @@ const ViewElectionRolls = ({ election, permissions }) => {
                 </>
             }
             {isEditing && editedRoll &&
-                <EditElectionRoll roll={editedRoll} onClose={onClose} fetchRolls={fetchRolls} id={id} permissions={permissions} />
+                <EditElectionRoll roll={editedRoll} onClose={onClose} fetchRolls={fetchRolls} id={election.election_id} permissions={permissions} />
             }
             {addRollPage &&
                 <AddElectionRoll election={election} onClose={onClose} />

--- a/frontend/src/components/Election/Election.tsx
+++ b/frontend/src/components/Election/Election.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react"
-import useFetch, { IuseFetch } from "../../hooks/useFetch";
 import { useParams } from "react-router";
 import React from 'react'
 import ElectionHome from "./ElectionHome";
@@ -13,23 +12,15 @@ import { Grid } from "@mui/material";
 import Thanks from "./Voting/Thanks";
 import ViewBallot from "./Admin/ViewBallot";
 import { IAuthSession } from "../../hooks/useAuthSession";
-import { Election as IElection } from '../../../../domain_model/Election';
-import { VoterAuth as IVoterAuth } from '../../../../domain_model/VoterAuth';
+import { useGetElection } from "../../hooks/useAPI";
 
 type Props = {
   authSession: IAuthSession,
 }
 
-interface GetElectionResponse extends IuseFetch {
-  data: null | {
-    election: IElection,
-    voterAuth: IVoterAuth
-  }
-}
-
 const Election = ({ authSession }: Props) => {
   const { id } = useParams();
-  const { data, isPending, error, makeRequest: fetchData }: GetElectionResponse = useFetch(`/API/Election/${id}`, 'get')
+  const { data, isPending, error, makeRequest: fetchData } = useGetElection(id)
   useEffect(() => {
     fetchData()
   }, [])

--- a/frontend/src/components/Election/Results/ViewElectionResults.tsx
+++ b/frontend/src/components/Election/Results/ViewElectionResults.tsx
@@ -1,16 +1,15 @@
 import React, { useEffect, useState } from 'react'
 import { useParams } from "react-router";
-import useFetch from "../../../hooks/useFetch";
 import Results from './Results';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import { Paper, Typography } from "@mui/material";
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { scrollToElement } from '../../util';
+import { useGetResults } from '../../../hooks/useAPI';
 
 const ViewElectionResults = ({ election }) => {
-    const { id } = useParams();
-    const { data, isPending, error, makeRequest: getResults } = useFetch(`/API/ElectionResult/${id}`, 'get')
+    const { data, isPending, error, makeRequest: getResults } = useGetResults(election.election_id)
     const [selectedRaceIndex, setSelectedRaceIndex] = useState((election.races.length == 1)? 0 : -1);
     useEffect(() => { getResults() }, [])
 

--- a/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/frontend/src/components/Election/Voting/VotePage.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react"
 import BallotPageSelector from "./BallotPageSelector";
 import Grid from "@mui/material/Grid";
-import useFetch from "../../../hooks/useFetch";
 import { useParams } from "react-router";
 import React from 'react'
 import CheckBoxOutlineBlankOutlinedIcon from '@mui/icons-material/CheckBoxOutlineBlankOutlined';
@@ -11,6 +10,7 @@ import { Vote } from "../../../../../domain_model/Vote";
 import { Score } from "../../../../../domain_model/Score";
 import { Box, Container, Step, StepLabel, Stepper, SvgIcon } from "@mui/material";
 import Button from "@mui/material/Button";
+import { usePostBallot } from "../../../hooks/useAPI";
 
 // I'm using the icon codes instead of an import because there was padding I couldn't get rid of https://stackoverflow.com/questions/65721218/remove-material-ui-icon-margin
 const INFO_ICON = "M 11 7 h 2 v 2 h -2 Z m 0 4 h 2 v 6 h -2 Z m 1 -9 C 6.48 2 2 6.48 2 12 s 4.48 10 10 10 s 10 -4.48 10 -10 S 17.52 2 12 2 Z m 0 18 c -4.41 0 -8 -3.59 -8 -8 s 3.59 -8 8 -8 s 8 3.59 8 8 s -3.59 8 -8 8 Z"
@@ -64,7 +64,7 @@ const VotePage = ({ election, fetchElection }) => {
   const [pages, setPages] = useState(makePages())
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(0)
-  const { data, isPending, error, makeRequest: postBallot } = useFetch(`/API/Election/${id}/vote`, 'post')
+  const { data, isPending, error, makeRequest: postBallot } = usePostBallot(election.election_id)
   const onUpdate = (pageIndex, newRaceScores) => {
     var newPages = [...pages]
     newPages[pageIndex].candidates.forEach((c,i) => c.score = newRaceScores[i])

--- a/frontend/src/components/ElectionForm/AddElection.tsx
+++ b/frontend/src/components/ElectionForm/AddElection.tsx
@@ -1,18 +1,17 @@
 import React from 'react'
-import useFetch from '../../hooks/useFetch';
 import ElectionForm from "./ElectionForm";
-import Container from '@mui/material/Container';
 import { useNavigate } from "react-router"
 
 import { IAuthSession } from '../../hooks/useAuthSession';
 import { Election } from '../../../../domain_model/Election';
+import { usePostElection } from '../../hooks/useAPI';
 
 
 
 const AddElection = ({ authSession }: {authSession: IAuthSession}) => {
 
     const navigate = useNavigate()
-    const { error, isPending, makeRequest: postElection } = useFetch('/API/Elections', 'post')
+    const { error, isPending, makeRequest: postElection } = usePostElection()
     const onAddElection = async (election: Election) => {
         // calls post election api, throws error if response not ok
         const newElection = await postElection(

--- a/frontend/src/components/ElectionForm/DuplicateElection.tsx
+++ b/frontend/src/components/ElectionForm/DuplicateElection.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { useParams } from "react-router";
-import useFetch from "../../hooks/useFetch";
 import Container from '@mui/material/Container';
 import ElectionForm from "./ElectionForm";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router"
+import { useGetElection, usePostElection } from '../../hooks/useAPI';
 
 const DuplicateElection = ({ authSession }) => {
     const navigate = useNavigate()
@@ -12,8 +12,8 @@ const DuplicateElection = ({ authSession }) => {
 
     const [data, setData] = useState(null);
 
-    let { data: prevData, isPending, error, makeRequest: fetchElection } = useFetch(`/API/Election/${id}`, 'get');
-    const { isPending: postIsPending, error: postError, makeRequest: postElection } = useFetch('/API/Elections', 'post')
+    let { data: prevData, isPending, error, makeRequest: fetchElection } = useGetElection(id);
+    const { isPending: postIsPending, error: postError, makeRequest: postElection } = usePostElection()
     useEffect(() => {
         fetchElection()
     }, [])

--- a/frontend/src/components/ElectionForm/EditElection.tsx
+++ b/frontend/src/components/ElectionForm/EditElection.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import { useParams } from "react-router";
-import useFetch from "../../hooks/useFetch";
 import Container from '@mui/material/Container';
 import ElectionForm from "./ElectionForm";
 import { useNavigate } from "react-router"
+import { useEditElection } from '../../hooks/useAPI';
 
 const EditElection = ({ authSession, election, fetchElection}) => {
     const navigate = useNavigate()
-    const { id } = useParams();
-    const { isPending, error, makeRequest: editElection } = useFetch(`/API/Election/${election.election_id}/edit`,'post')
+    const { isPending, error, makeRequest: editElection } = useEditElection(election.election_id)
     const onEditElection = async (election) => {
         const newElection = await editElection(
             {

--- a/frontend/src/components/ElectionForm/QuickPoll.tsx
+++ b/frontend/src/components/ElectionForm/QuickPoll.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import useFetch from '../../hooks/useFetch';
 import Container from '@mui/material/Container';
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
@@ -11,11 +10,12 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { useCookie } from '../../hooks/useCookie';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import Typography from '@mui/material/Typography';
+import { usePostElection } from '../../hooks/useAPI';
 
 const QuickPoll = ({ authSession }) => {
     const [tempID, setTempID] = useCookie('temp_id', '0')
     const navigate = useNavigate()
-    const { error, isPending, makeRequest: postElection } = useFetch('/API/Elections', 'post')
+    const { error, isPending, makeRequest: postElection } = usePostElection()
     const onSubmitElection = async (election) => {
         // calls post election api, throws error if response not ok
         const newElection = await postElection(

--- a/frontend/src/components/Elections.tsx
+++ b/frontend/src/components/Elections.tsx
@@ -1,4 +1,3 @@
-import useFetch from "../hooks/useFetch"
 import React, { useEffect } from 'react'
 import { Election } from "../../../domain_model/Election"
 import Typography from '@mui/material/Typography';
@@ -7,19 +6,15 @@ import Button from "@mui/material/Button";
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip } from "@mui/material";
 import EnhancedTable, { HeadCell } from "./EnhancedTable";
 import { useNavigate } from "react-router"
+import { useGetElections } from "../hooks/useAPI";
 
 const Elections = ({ authSession }) => {
 
     const navigate = useNavigate()
     // const url_params = new URLSearchParams(window.location.search)
-    var url = '/API/Elections';
-    // if (url_params.has('filter')) {
-    //     url = `${url}?filter=${url_params.get('filter')}`
-    // }
-    const { data, isPending, error, makeRequest: fetchElections } = useFetch(url, 'get')
+    const { data, isPending, error, makeRequest: fetchElections } = useGetElections()
 
     useEffect(() => {
-        console.log(`fetch ${url}`)
         fetchElections()
     }, [])
 

--- a/frontend/src/hooks/useAPI.ts
+++ b/frontend/src/hooks/useAPI.ts
@@ -1,0 +1,83 @@
+import { Election } from "../../../domain_model/Election";
+import { VoterAuth } from '../../../domain_model/VoterAuth';
+import { ElectionRoll } from "../../../domain_model/ElectionRoll";
+import useFetch from "./useFetch";
+import { Ballot } from "../../../domain_model/Ballot";
+
+export const useGetElection = (electionID: string | undefined) => {
+    return useFetch<undefined, { election: Election, voterAuth: VoterAuth }>(`/API/Election/${electionID}`, 'get')
+}
+
+export const useGetElections = () => {
+    return useFetch<undefined, { elections_as_official: Election[] | null, elections_as_voter: Election[] | null, open_elections: Election[] | null }>('/API/Elections', 'get')
+}
+
+export const usePostElection = () => {
+    return useFetch<{ Election: Election }, { election: Election }>('/API/Elections', 'post')
+}
+
+export const useEditElection = (election_id: string | undefined) => {
+    return useFetch<{ Election: Election }, { election: Election }>(`/API/Election/${election_id}/edit`, 'post')
+}
+
+export const useSendInvites = (electionID: string | undefined) => {
+    return useFetch<undefined, {}>(`/API/Election/${electionID}/sendInvites`, 'post')
+}
+
+export const useGetRolls = (electionID: string | undefined) => {
+    return useFetch<undefined, { election: Election, electionRoll: ElectionRoll[] }>(`/API/Election/${electionID}/rolls`, 'get')
+}
+
+export const usePutElectionRoles = (election_id: string) => {
+    return useFetch<{ admin_ids: string[], audit_ids: string[], credential_ids: string[] }, {}>(`/API/Election/${election_id}/roles/`, 'put')
+}
+
+export const usePostRolls = (election_id: string) => {
+    return useFetch<{ electionRoll: ElectionRoll[] }, {}>(`/API/Election/${election_id}/rolls/`, 'post')
+}
+
+export const useSetPublicResults = (election_id: string) => {
+    return useFetch<{ public_results: Boolean }, { election: Election }>(`/API/Election/${election_id}/setPublicResults`, 'post')
+}
+
+export const useFinalizeEleciton = (election_id: string) => {
+    return useFetch<undefined, { election: Election }>(`/API/Election/${election_id}/finalize`, 'post')
+}
+
+export const useArchiveEleciton = (election_id: string) => {
+    return useFetch<undefined, { election: Election }>(`/API/Election/${election_id}/archive`, 'post')
+}
+
+export const useApproveRoll = (election_id: string) => {
+    return useFetch<{ electionRollEntry: ElectionRoll }, {}>(`/API/Election/${election_id}/rolls/approve`, 'post')
+}
+
+export const useFlagRoll = (election_id: string) => {
+    return useFetch<{ electionRollEntry: ElectionRoll }, {}>(`/API/Election/${election_id}/rolls/flag`, 'post')
+}
+
+export const useUnflagRoll = (election_id: string) => {
+    return useFetch<{ electionRollEntry: ElectionRoll }, {}>(`/API/Election/${election_id}/rolls/unflag`, 'post')
+}
+
+export const useInvalidateRoll = (election_id: string) => {
+    return useFetch<{ electionRollEntry: ElectionRoll }, {}>(`/API/Election/${election_id}/rolls/invalidate`, 'post')
+}
+
+export const useGetBallot = (election_id: string, ballot_id: string | undefined) => {
+    return useFetch<undefined, { ballot: Ballot }>(`/API/Election/${election_id}/ballot/${ballot_id}`, 'get')
+}
+
+export const useGetBallots = (election_id: string | undefined) => {
+    return useFetch<undefined, { election: Election, ballots: Ballot[] }>(`/API/Election/${election_id}/ballots`, 'get')
+}
+
+export const useGetResults = (election_id: string | undefined) => {
+    return useFetch<undefined, any>(`/API/ElectionResult/${election_id}`, 'get')
+}
+
+export const usePostBallot = (election_id: string | undefined) => {
+    return useFetch<{ ballot: Ballot }, {ballot: Ballot}>(`/API/Election/${election_id}/vote`, 'post')
+}
+
+

--- a/frontend/src/hooks/useFetch.ts
+++ b/frontend/src/hooks/useFetch.ts
@@ -1,20 +1,25 @@
 import { useState, useContext } from "react";
 import { SnackbarContext } from "../components/SnackbarContext";
 
-export interface IuseFetch { 
-    data?: any
-    isPending: Boolean,
-    error: any,
-    makeRequest: (data?:any) =>  Promise<any>
-}
-
-const useFetch = (url: string, method: 'get'|'post'|'put', successMessage:string|null = null) => {
+// Example usage 
+// Requst type: MyRequest
+// Response type: ApiResponse
+// MyRequestHook = useFetch<MyRequest, ApiResponse>(url, 'get')
+// Where
+// MyRequestHoot type = 
+// {
+//  data: ApiResponse | null, null by default until successful response
+//  isPending: Boolean, true if waiting for request 
+//  error: any | null, null by default until request error 
+//  makeRequest: (MyRequest) => Promise<ApiResponse|false>, if request errors response with false
+// }
+const useFetch = <Message, Response>(url: string, method: 'get' | 'post' | 'put', successMessage: string | null = null) => {
     const [isPending, setIsPending] = useState(false)
     const [error, setError] = useState<any>(null)
-    const [data, setData] = useState<any>(null)
+    const [data, setData] = useState<Response | null>(null)
     const { snack, setSnack } = useContext(SnackbarContext)
 
-    const makeRequest = async (data?: any) => {
+    const makeRequest = async (data?: Message) => {
         const options = {
             method: method,
             headers: {
@@ -48,16 +53,16 @@ const useFetch = (url: string, method: 'get'|'post'|'put', successMessage:string
                     autoHideDuration: 6000,
                 })
             }
-            return data
+            return data as Response
         } catch (err) {
             setSnack({
-                message: err.message,
+                message: err.message ? err.message : 'Unknown error',
                 severity: "error",
                 open: true,
                 autoHideDuration: null
             })
             setIsPending(false);
-            setError(err.message);
+            setError(err.message ? err.message : 'Unknown error');
             return false
         }
     }


### PR DESCRIPTION
## Description
In order to make the front end more type safe this makes the useFetch hook type generic and allows us to specify the expected request body and response types. This PR also moves all api requests to our server to a new file useAPI.ts and defines all the expected types (the election results being the exception and is just type any for now).

This will allow us to have our API defined in one place, minimize redundant code, and clean up our components that use the API hooks.

Hopefully in the future this will also help us write some dedicated tests for these as well.