### PR TITLE
Editing election roles page improvements

### DIFF
--- a/frontend/src/components/Election/Admin/Admin.tsx
+++ b/frontend/src/components/Election/Admin/Admin.tsx
@@ -11,7 +11,7 @@ const Admin = ({ authSession, election, permissions, fetchElection }) => {
             <Routes>
                 <Route path='/' element={<AdminHome election={election} permissions={permissions} fetchElection={fetchElection}/>} />
                 <Route path='/voters' element={<ViewElectionRolls election={election} permissions={permissions} />} />
-                <Route path='/roles' element={<EditRoles election={election} permissions={permissions} />} />
+                <Route path='/roles' element={<EditRoles election={election} permissions={permissions} fetchElection={fetchElection} />} />
                 <Route path='/ballots' element={<ViewBallots election={election} permissions={permissions} />} />
             </Routes>
         </Container>

--- a/frontend/src/components/Election/Admin/EditRoles.tsx
+++ b/frontend/src/components/Election/Admin/EditRoles.tsx
@@ -2,15 +2,20 @@ import { useState } from "react"
 import React from 'react'
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
-import { useNavigate } from "react-router"
 import PermissionHandler from "../../PermissionHandler";
 import { usePutElectionRoles } from "../../../hooks/useAPI";
+import { Election } from "../../../../../domain_model/Election";
+import { StyledButton } from "../../styles";
 
-const EditRoles = ({ election, permissions }) => {
-    const navigate = useNavigate()
+type Props = {
+    election: Election,
+    permissions: string[],
+    fetchElection: Function,
+}
+
+const EditRoles = ({ election, permissions, fetchElection }: Props) => {
 
     const [adminList, setAdminList] = useState(() => {
         if (election.admin_ids === null) return ''
@@ -37,11 +42,9 @@ const EditRoles = ({ election, permissions }) => {
             const credential_ids = credentialList == '' ? null : credentialList.split('\n')
 
             const newRoles = await putRoles.makeRequest({ admin_ids, audit_ids, credential_ids })
-            console.log(newRoles)
-            if (!newRoles) {
-                throw Error("Error submitting rolls");
+            if (newRoles) {
+                fetchElection()
             }
-            navigate(`/Election/${election.election_id}/admin`)
         } catch (error) {
             console.log(error)
         }
@@ -51,53 +54,73 @@ const EditRoles = ({ election, permissions }) => {
         <form onSubmit={onSubmit}>
             <Container maxWidth='sm'>
                 <Grid container direction="column" >
-                    <Grid item>
+                    <Grid item sx={{ p: 2 }}>
                         <TextField
                             id="admin-list"
                             name="admin-list"
                             label="Admin List"
+                            InputLabelProps={{
+                                shrink: true
+                            }}
                             multiline
+                            minRows={3}
                             fullWidth
                             type="text"
                             value={adminList}
                             onChange={(e) => setAdminList(e.target.value)}
                             helperText="Emails of election admins, one email per line"
+                            placeholder={"admin1@email.com\nadmin2@email.com\nadmin3@email.com"}
                         />
                     </Grid>
-                    <Grid item>
+                    <Grid item sx={{ p: 2 }}>
                         <TextField
                             id="auditor-list"
                             name="id-list"
                             label="Auditor List"
+                            InputLabelProps={{
+                                shrink: true
+                            }}
                             multiline
+                            minRows={3}
                             fullWidth
                             type="text"
                             value={auditorList}
                             onChange={(e) => setAuditorList(e.target.value)}
-                            helperText="Emails of election audotors, one email per line"
+                            helperText="Emails of election auditors, one email per line"
+                            placeholder={"auditor1@email.com\nauditor2@email.com\nauditor3@email.com"}
                         />
                     </Grid>
-                    <Grid item>
+                    <Grid item sx={{ p: 2 }}>
                         <TextField
                             id="credentialer-list"
                             name="credentialer-list"
                             label="Credentialer List"
+                            InputLabelProps={{
+                                shrink: true
+                            }}
                             multiline
+                            minRows={3}
                             fullWidth
                             type="text"
                             value={credentialList}
                             onChange={(e) => setCredentialList(e.target.value)}
-                            helperText="Emails of election audotors, one email per line"
+                            helperText="Emails of election credentialers, one email per line"
+                            placeholder={"credentialer1@email.com\ncredentialer2@email.com\ncredentialer3@email.com"}
                         />
                     </Grid>
 
-                    <PermissionHandler permissions={permissions} requiredPermission={'canEditElectionRoles'}>
-                        <input
-                            type='submit'
-                            value='Submit'
-                            className='btn btn-block'
-                            disabled={putRoles.isPending} />
-                    </PermissionHandler>
+                    <Grid item sx={{ p: 2 }}>
+                        <PermissionHandler permissions={permissions} requiredPermission={'canEditElectionRoles'}>
+                            <StyledButton
+                                type='submit'
+                                variant='contained'
+                                disabled={putRoles.isPending}>
+                                <Typography align='center' variant="body2" fontWeight={'bold'}>
+                                    Submit
+                                </Typography>
+                            </StyledButton>
+                        </PermissionHandler>
+                    </Grid>
                 </Grid>
             </Container>
         </form>

--- a/frontend/src/hooks/useAPI.ts
+++ b/frontend/src/hooks/useAPI.ts
@@ -41,7 +41,10 @@ export const useGetRolls = (electionID: string | undefined) => {
 }
 
 export const usePutElectionRoles = (election_id: string) => {
-    return useFetch<{ admin_ids: string[], audit_ids: string[], credential_ids: string[] }, {}>(`/API/Election/${election_id}/roles/`, 'put')
+    return useFetch<{ admin_ids: string[], audit_ids: string[], credential_ids: string[] }, {}>(
+        `/API/Election/${election_id}/roles/`, 
+        'put',
+        'Election Roles Saved!',)
 }
 
 export const usePostRolls = (election_id: string) => {


### PR DESCRIPTION
## Description
Improves the edit election roles page
- Adds snack pop up on success
- No longer redirect on success
- Fetch latest election on success
- Adds padding to form and styled submit button
- Multiline placeholder emails to make it clear you can enter multiple emails. I'm iffy on this change, looking for feedback.

## Screenshots / Videos (frontend only) 

![image](https://github.com/Equal-Vote/star-server/assets/41272412/bd3be429-ccc3-4669-80fa-9da275532953)

Mobile view with success snack
![image](https://github.com/Equal-Vote/star-server/assets/41272412/84b689cc-35e3-48fe-b086-13a58efa18e6)


## Related Issues
Addresses some issues raised in #330 