### PR TITLE
refetch elections on login

### DIFF
--- a/frontend/src/components/Elections.tsx
+++ b/frontend/src/components/Elections.tsx
@@ -17,7 +17,7 @@ const Elections = ({ authSession }) => {
 
     useEffect(() => {
         fetchElections()
-    }, [])
+    }, [authSession.isLoggedIn()])
 
     const userEmail = authSession.getIdField('email')
     const id = authSession.getIdField('sub')


### PR DESCRIPTION
## Description
After logging in from the my elections page, the fetch request will be made before the login logic is finished, so the "election I manage" table will be empty and requires a page refresh. This makes the authSession.isLoggedIn() output a depenency to the fetch elections useEffect hook, so if the login status chages it will make the request again. Two requests are still made, but that shouldn't be an issue.

## Related Issues
#330 