### PR TITLE
About goes to About page now instead of Starvoting.org

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,8 @@ nav_order: 1
 We're developing a 2.0 version for the STAR.vote website. Visit https://star-vote.herokuapp.com/ to see the latest build
 
 If you new here and want to make a contribution, head over to [Set up star.vote locally](setup_locally.html) to get started!
+
+---
+## Volunteer List: Name | Slack 
+Arend Peter Castelein | @Arend Peter
+Simeon Cekov | @Simeon Cekov

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { Alert, Box, CssBaseline, Snackbar } from '@mui/material'
 import { useAuthSession } from './hooks/useAuthSession'
 import { Isnack, SnackbarContext } from './components/SnackbarContext'
 import Footer from './components/Footer'
+import About from './components/About'
 const App = () => {
   const authSession = useAuthSession()
   const [snack, setSnack] = useState({
@@ -47,6 +48,7 @@ const App = () => {
               }}>
               <Routes>
                 <Route path='/' element={<LandingPage authSession={authSession} />} />
+                <Route path='/About' element={<About/>}/>
                 <Route path='/Elections' element={<Elections authSession={authSession} />} />
                 <Route path='/Login' element={<Login />} />
                 <Route path='/Debug' element={<DebugPage authSession={authSession} />} />

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const About = () => {
+  return (
+    <>
+      <div>About</div>
+      <div>Star voting is the Star of voting</div>
+    </>
+  )
+}
+
+export default About

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -72,7 +72,7 @@ const Header = ({ authSession }) => {
                     >
                         <MenuItem
                             component={Link}
-                            href='https://www.starvoting.us'
+                            href='/About'
                             target="_blank">
                             About
                         </MenuItem>
@@ -117,7 +117,7 @@ const Header = ({ authSession }) => {
                 {/**** DESKTOP OPTIONS ****/}
                 <Box
                     sx={{ flexGrow: 100, flexWrap: 'wrap', display: { xs: 'none', md: 'flex' }, gap: 2, rowGap: 0 }}>
-                    <Button color='inherit' href='https://www.starvoting.us' target="_blank">
+                    <Button color='inherit' href='/About' target="_blank">
                         <Typography variant={navVariant} sx={{ fontWeight: 'bold' }} color={headerTextColor}>
                             About
                         </Typography>


### PR DESCRIPTION
## Description
I updated the About button such that instead of going to the Star.org website, it goes to an About page. I added some placeholder text (figure out what should go here)

## Screenshots / Videos (frontend only) 

> Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

## Related Issues

> For example, add ``fixes #10`` to close issue #10