### PR TITLE
Adding confirmation dialog provider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { Alert, Box, CssBaseline, Snackbar } from '@mui/material'
 import { useAuthSession } from './hooks/useAuthSession'
 import { Isnack, SnackbarContext } from './components/SnackbarContext'
 import Footer from './components/Footer'
+import { ConfirmDialogProvider } from './components/ConfirmationDialogProvider'
 const App = () => {
   const authSession = useAuthSession()
   const [snack, setSnack] = useState({
@@ -32,6 +33,7 @@ const App = () => {
   return (
     <Router>
       <ThemeProvider theme={theme}>
+        <ConfirmDialogProvider>
         <SnackbarContext.Provider value={{ snack, setSnack }}>
           <Snackbar open={snack.open} autoHideDuration={snack.autoHideDuration} onClose={handleClose} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
             <Alert severity={snack.severity} onClose={handleClose}>
@@ -59,6 +61,7 @@ const App = () => {
             <Footer />
           </Box>
         </SnackbarContext.Provider>
+        </ConfirmDialogProvider>
       </ThemeProvider>
     </Router>
   );

--- a/frontend/src/components/ConfirmationDialogProvider.tsx
+++ b/frontend/src/components/ConfirmationDialogProvider.tsx
@@ -1,0 +1,84 @@
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useRef,
+    useState,
+} from 'react';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material'
+import { StyledButton } from './styles';
+// Built from this example buth with MUI dialogs: https://akashhamirwasia.com/blog/building-expressive-confirm-dialog-api-in-react/
+// Uses a context provider to allow any component to access a confirm dialog component using the useConfirm hook
+// Example: 
+// import useConfirm from '../../ConfirmationDialogProvider';
+// const confirm = useConfirm()
+// const confirmed = await confirm(
+//      {
+//          title: 'Confirm This Action', 
+//          message: "Are you sure you want to do this?"
+//      })
+
+interface ConfirmData {
+    title: string
+    message: string
+}
+
+type confirmContext = (data: ConfirmData) => Promise<boolean>
+
+const ConfirmDialog = createContext<confirmContext>(null);
+
+export function ConfirmDialogProvider({ children }) {
+
+
+    const [state, setState] = useState({ isOpen: false, title: '', message: '' });
+    const fn = useRef((choice: boolean) => { });
+
+    const confirm = useCallback(
+        (data: ConfirmData) => {
+            return new Promise((resolve: (value: boolean) => void) => {
+                setState({ ...data, isOpen: true });
+                fn.current = (choice) => {
+                    resolve(choice);
+                    setState({ isOpen: false, title: '', message: '' });
+                };
+            });
+        },
+        [setState]
+    );
+
+    return (
+        <ConfirmDialog.Provider value={confirm}>
+            {children}
+            <Dialog
+                open={state.isOpen}
+                fullWidth
+            >
+                <DialogTitle>{state.title}</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>{state.message}</DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <StyledButton
+                        type='button'
+                        variant="contained"
+                        width="100%"
+                        fullWidth={false}
+                        onClick={() => fn.current(false)}>
+                        Cancel
+                    </StyledButton>
+                    <StyledButton
+                        type='button'
+                        variant="contained"
+                        fullWidth={false}
+                        onClick={() => fn.current(true)}>
+                        Yes
+                    </StyledButton>
+                </DialogActions>
+            </Dialog>
+        </ConfirmDialog.Provider>
+    );
+}
+
+export default function useConfirm() {
+    return useContext(ConfirmDialog);
+}

--- a/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -8,6 +8,7 @@ import { Election } from '../../../../../domain_model/Election';
 import ShareButton from "../ShareButton";
 import { useArchiveEleciton, useFinalizeEleciton, useSetPublicResults } from "../../../hooks/useAPI";
 import { formatDate } from '../../util';
+import useConfirm from '../../ConfirmationDialogProvider';
 const hasPermission = (permissions: string[], requiredPermission: string) => {
     return (permissions && permissions.includes(requiredPermission))
 }
@@ -367,8 +368,17 @@ const AdminHome = ({ election, permissions, fetchElection }: Props) => {
     }
     const { makeRequest: finalize } = useFinalizeEleciton(election.election_id)
     const { makeRequest: archive } = useArchiveEleciton(election.election_id)
+
+    const confirm = useConfirm()
+
     const finalizeElection = async () => {
         console.log("finalizing election")
+        const confirmed = await confirm(
+            {
+                title: 'Confirm Finalize Election', 
+                message: "Are you sure you want to finalize your election? Once finalized you won't be able to edit it."
+            })
+        if (!confirmed) return
         try {
             await finalize()
             await fetchElection()
@@ -379,14 +389,18 @@ const AdminHome = ({ election, permissions, fetchElection }: Props) => {
 
     const archiveElection = async () => {
         console.log("archiving election")
-        if (window.confirm('Are you sure you wish to archive this election? This action cannot be undone')){
-            console.log('confirmed')
-            try {
-                await archive()
-                await fetchElection()
-            } catch (err) {
-                console.log(err)
-            }
+        const confirmed = await confirm(
+            {
+                title: 'Confirm Archive Election', 
+                message: "Are you sure you wish to archive this election? This action cannot be undone."
+            })
+        if (!confirmed) return
+        console.log('confirmed')
+        try {
+            await archive()
+            await fetchElection()
+        } catch (err) {
+            console.log(err)
         }
     }
 


### PR DESCRIPTION
## Description
Made this as part of a larger task. Creates a context provider and hook for accessing confirmation dialog. The current dialog is just the MUI dialog, we can update the styling using #344. Basically, it adds a single dialog component at the top level of the app and uses a context provider to allow other components to open it, update the title and message, and get the response.

Built based on this tutorial https://akashhamirwasia.com/blog/building-expressive-confirm-dialog-api-in-react/ 
Uses some useRef and useCallback optimizations that are explained in there.

## Screenshots / Videos (frontend only) 
![image](https://github.com/Equal-Vote/star-server/assets/41272412/7aa9093f-1b65-41bf-9a6c-ede0b15c2232)
![image](https://github.com/Equal-Vote/star-server/assets/41272412/44382abd-8548-4a45-9bf0-9ca70e873dbe)

## Related Issues
