### PR TITLE
Fix scores order

### DIFF
--- a/frontend/src/components/Election/Results/Results.js
+++ b/frontend/src/components/Election/Results/Results.js
@@ -210,10 +210,10 @@ function PluralityResultsViewer({ results }) {
             <th className='matrix'> Votes </th>
           </tr>
 
-          {results.summaryData.candidates.map((c, n) => (
+          {results.summaryData.totalScores.map((totalScore, n) => (
             <>
-              <tr className='matrix' key={`h${n}`} >{c.name}
-                <td> {results.summaryData.totalScores[n].score} </td>
+              <tr className='matrix' key={`h${n}`} >{results.summaryData.candidates[totalScore.index].name}
+                <td> {totalScore.score} </td>
               </tr>
 
             </>
@@ -234,10 +234,10 @@ function ApprovalResultsViewer({ results }) {
             <th className='matrix'> Votes </th>
           </tr>
 
-          {results.summaryData.candidates.map((c, n) => (
+          {results.summaryData.totalScores.map((totalScore,n) => (
             <>
-              <tr className='matrix' key={`h${n}`} >{c.name}
-                <td> {results.summaryData.totalScores[n].score} </td>
+              <tr className='matrix' key={`h${n}`} >{results.summaryData.candidates[totalScore.index].name}
+                <td> {totalScore.score} </td>
               </tr>
 
             </>


### PR DESCRIPTION
## Description
How the approval and plurality scores were displayed was incorrect. The scores array is sorted by score while and candidates array is in its original order. Since the scores array includes the candidate indexes, this gets the index of the candidate and retrieves the candidate name from the candidate array.

## Screenshots / Videos (frontend only) 
Before: 
![image](https://github.com/Equal-Vote/star-server/assets/41272412/433f446a-1bc0-4e24-a7a3-f440c0b7c12c)

After:
![image](https://github.com/Equal-Vote/star-server/assets/41272412/dc542b1e-6e67-4c2e-ae61-96864dfaa45c)

## Related Issues

none