### PR TITLE
Remove ballot info pages, misc bug fixes

### DIFF
--- a/backend/src/Models/ElectionRolls.ts
+++ b/backend/src/Models/ElectionRolls.ts
@@ -79,6 +79,7 @@ export default class ElectionRollDB implements IElectionRollStore {
 
         return this._postgresClient
             .selectFrom(tableName)
+            .where('election_id', '=', 'election_id')
             .where((eb) => {
                 const ors: Expression<boolean>[] = []
 

--- a/backend/src/Models/ElectionRolls.ts
+++ b/backend/src/Models/ElectionRolls.ts
@@ -75,11 +75,11 @@ export default class ElectionRollDB implements IElectionRollStore {
     }
 
     getElectionRoll(election_id: string, voter_id: string | null, email: string | null, ip_address: string | null, ctx: ILoggingContext): Promise<ElectionRoll[] | null> {
-        Logger.debug(ctx, `${tableName}.get election:${election_id}, voter:${voter_id}`);
+        Logger.debug(ctx, `${tableName}.get election:${election_id}, voter:${voter_id}, email:${email}, ip_address:${ip_address}`);
 
         return this._postgresClient
             .selectFrom(tableName)
-            .where('election_id', '=', 'election_id')
+            .where('election_id', '=', election_id)
             .where((eb) => {
                 const ors: Expression<boolean>[] = []
 

--- a/backend/src/Models/ElectionRolls.ts
+++ b/backend/src/Models/ElectionRolls.ts
@@ -75,7 +75,7 @@ export default class ElectionRollDB implements IElectionRollStore {
     }
 
     getElectionRoll(election_id: string, voter_id: string | null, email: string | null, ip_address: string | null, ctx: ILoggingContext): Promise<ElectionRoll[] | null> {
-        Logger.debug(ctx, `${tableName}.get election:${election_id}, voter:${voter_id}, email:${email}, ip_address:${ip_address}`);
+        Logger.debug(ctx, `${tableName}.get election:${election_id}, voter:${voter_id}`);
 
         return this._postgresClient
             .selectFrom(tableName)

--- a/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/frontend/src/components/Election/Voting/VotePage.tsx
@@ -47,19 +47,20 @@ const VotePage = ({ election, fetchElection }) => {
     }))
 
     // determine where to add info pages
-    for(var i = 0; i < pages.length; i++){
-      if(pages[i].type != "ballot") continue;
+    // commented out for now in case we want to return to this
+    // for(var i = 0; i < pages.length; i++){
+    //   if(pages[i].type != "ballot") continue;
 
-      // check if page is the first race with the voting method
-      var info_exists = pages.some((p) => p.type == 'info' && p.voting_method == pages[i].voting_method);
-      if(info_exists) continue;
+    //   // check if page is the first race with the voting method
+    //   var info_exists = pages.some((p) => p.type == 'info' && p.voting_method == pages[i].voting_method);
+    //   if(info_exists) continue;
       
-      // add info page for method
-      pages.splice(i, 0, {
-        type: "info",
-        voting_method: pages[i].voting_method
-      })
-    }
+    //   // add info page for method
+    //   pages.splice(i, 0, {
+    //     type: "info",
+    //     voting_method: pages[i].voting_method
+    //   })
+    // }
 
     return pages
   }
@@ -76,14 +77,17 @@ const VotePage = ({ election, fetchElection }) => {
   }
   const submit = async () => {
     var candidateScores = pages.filter((p) => p.type == "ballot").map((p) => p.candidates)
-    const sortFunc = (a: Score, b: Score) => {
-      return Number(a.candidate_id) - Number(b.candidate_id);
-    }
+    // create arrays of candidate IDs for each race. Ballots will be sorted into this order
+    const candidateIDs = election.races.map(race => race.candidates.map(candidate => candidate.candidate_id))
+
+    // takes voter's scores and resorts them back into the order in the election.race objects
     const votes: Vote[] =
       election.races.map((race, race_index) => (
         {
           race_id: race.race_id,
-          scores: candidateScores[race_index].map(c => ({candidate_id: c.candidate_id, score: c.score} as Score)).sort(sortFunc)
+          scores: candidateScores[race_index].map(c => ({candidate_id: c.candidate_id, score: c.score} as Score)).sort((a: Score, b: Score) => {
+            return candidateIDs[race_index].indexOf(a.candidate_id) - candidateIDs[race_index].indexOf(b.candidate_id)
+          })
         }))
     const ballot: Ballot = {
       ballot_id: '0', //Defaults to zero but is assigned ballot id by server when submitted
@@ -97,7 +101,7 @@ const VotePage = ({ election, fetchElection }) => {
       return
     }
     navigate(`/Election/${id}/thanks`)
-  }          
+  }        
   return (
     <Container disableGutters={true} maxWidth="sm">
       <BallotPageSelector


### PR DESCRIPTION
## Description
Three updates
- Comments out the info pages on the ballot for now
- Fixes bug for unshuffling candidates that immerged when we added candidate UUIDs
- Fixed bug when fetching roll for elections that just use email or IP. Wasn't checking for election ID so would find one with used email or IP and mark it as already voted.
