### PR TITLE
Random candidate order and voter instruction confirmations

### DIFF
--- a/domain_model/ElectionSettings.ts
+++ b/domain_model/ElectionSettings.ts
@@ -23,4 +23,5 @@ export interface ElectionSettings {
     public_results?:	    boolean; //		allows public to view results
     time_zone?:           string; // Time zone for displaying election start/end times 
     random_candidate_order?: boolean; // Randomize order of candidates on the ballot
+    require_instruction_confirmation?: boolean // Require voter to confirm that they've read the instructions in order to vote
   }

--- a/domain_model/ElectionSettings.ts
+++ b/domain_model/ElectionSettings.ts
@@ -22,4 +22,5 @@ export interface ElectionSettings {
     ballot_updates?:	    boolean; //		allows voters to update their ballots before election ends
     public_results?:	    boolean; //		allows public to view results
     time_zone?:           string; // Time zone for displaying election start/end times 
+    random_candidate_order?: boolean; // Randomize order of candidates on the ballot
   }

--- a/frontend/src/components/Election/Election.tsx
+++ b/frontend/src/components/Election/Election.tsx
@@ -31,7 +31,7 @@ const TempWrapper = ({ authSession }: Props) => {
       <Grid xs={12} sm={8}>
         <Routes>
           <Route path='/' element={<ElectionHome authSession={authSession} electionData={data} fetchElection={refreshElection} />} />
-          <Route path='/vote' element={<VotePage election={data.election} fetchElection={refreshElection} />} />
+          <Route path='/vote' element={<VotePage />} />
           <Route path='/thanks' element={<Thanks election={data.election} />} />
           <Route path='/results' element={<ViewElectionResults election={data.election} />} />
           <Route path='/edit' element={<EditElection authSession={authSession} election={data.election} fetchElection={refreshElection} />} />

--- a/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/frontend/src/components/Election/Voting/VotePage.tsx
@@ -12,6 +12,7 @@ import { Box, Container, Step, StepLabel, Stepper, SvgIcon } from "@mui/material
 import Button from "@mui/material/Button";
 import { usePostBallot } from "../../../hooks/useAPI";
 import FiberManualRecordOutlinedIcon from '@mui/icons-material/FiberManualRecordOutlined';
+import useElection from "../../ElectionContextProvider";
 
 // I'm using the icon codes instead of an import because there was padding I couldn't get rid of
 // https://stackoverflow.com/questions/65721218/remove-material-ui-icon-margin
@@ -36,15 +37,20 @@ function shuffle(array) {
   return array;
 }
 
-const VotePage = ({ election, fetchElection }) => {
+const VotePage = () => {
+  
+  const { election } = useElection()
   const makePages = () => {
     // generate ballot pages
-    let pages = election.races.map((race, i) => ({
-      type: "ballot",
-      candidates: shuffle(race.candidates.map(c=> ({...c, score: null}))),
-      voting_method : race.voting_method,
-      race_index: i
-    }))
+    let pages = election.races.map((race, i) => {
+      let candidates = race.candidates.map(c=> ({...c, score: null}))
+      return {
+        type: "ballot",
+        candidates: election.settings.random_candidate_order ? shuffle(candidates) : candidates,
+        voting_method : race.voting_method,
+        race_index: i
+    }
+  })
 
     // determine where to add info pages
     // commented out for now in case we want to return to this

--- a/frontend/src/components/ElectionForm/CreateElectionTemplates.tsx
+++ b/frontend/src/components/ElectionForm/CreateElectionTemplates.tsx
@@ -30,6 +30,7 @@ const CreateElectionTemplates = ({ authSession }: { authSession: IAuthSession })
             public_results: true,
             time_zone: DateTime.now().zone.name,
             random_candidate_order: true,
+            require_instruction_confirmation: false,
         }
     }
 

--- a/frontend/src/components/ElectionForm/CreateElectionTemplates.tsx
+++ b/frontend/src/components/ElectionForm/CreateElectionTemplates.tsx
@@ -29,6 +29,7 @@ const CreateElectionTemplates = ({ authSession }: { authSession: IAuthSession })
             ballot_updates: false,
             public_results: true,
             time_zone: DateTime.now().zone.name,
+            random_candidate_order: true,
         }
     }
 

--- a/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -65,7 +65,7 @@ export default function ElectionSettings() {
                     <Grid item xs={12} sx={{ m: 0, my: 1, p: 1 }}>
                         <FormControl component="fieldset" variant="standard">
                             <FormGroup>
-                                <FormControlLabel disabled control={
+                                <FormControlLabel control={
                                     <Checkbox
                                         id="candidate-order"
                                         name="Randomize Candidate Order"

--- a/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -67,6 +67,18 @@ export default function ElectionSettings() {
                             <FormGroup>
                                 <FormControlLabel disabled control={
                                     <Checkbox
+                                        id="candidate-order"
+                                        name="Randomize Candidate Order"
+                                        checked={editedElectionSettings.random_candidate_order}
+                                        onChange={(e) => applySettingsUpdate(settings => { settings.random_candidate_order = e.target.checked })}
+                                    />}
+                                    label="Ballot Updates"
+                                />
+                                <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                    Allow voters to update their ballots while election is still open (currently not supported)
+                                </FormHelperText>
+                                <FormControlLabel disabled control={
+                                    <Checkbox
                                         id="ballot-updates"
                                         name="Ballot Updates"
                                         checked={editedElectionSettings.ballot_updates}

--- a/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -72,10 +72,10 @@ export default function ElectionSettings() {
                                         checked={editedElectionSettings.random_candidate_order}
                                         onChange={(e) => applySettingsUpdate(settings => { settings.random_candidate_order = e.target.checked })}
                                     />}
-                                    label="Ballot Updates"
+                                    label="Randomize Candidate Order"
                                 />
                                 <FormHelperText sx={{ pl: 4, mt: -1 }}>
-                                    Allow voters to update their ballots while election is still open (currently not supported)
+                                    Randomizes the order of candidates on the ballots.
                                 </FormHelperText>
                                 <FormControlLabel disabled control={
                                     <Checkbox

--- a/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -146,7 +146,8 @@ export default function ElectionSettings() {
                                         <Checkbox
                                             id="require-instructions-confirmations"
                                             name="Require Instruction Confirmations"
-                                            checked={false}
+                                            checked={editedElectionSettings.require_instruction_confirmation}
+                                            onChange={(e) => applySettingsUpdate(settings => { settings.require_instruction_confirmation = e.target.checked })}
                                         />}
                                     label="Require Instruction Confirmations"
                                 />

--- a/frontend/src/components/ElectionForm/QuickPoll.tsx
+++ b/frontend/src/components/ElectionForm/QuickPoll.tsx
@@ -62,6 +62,7 @@ const QuickPoll = ({ authSession }) => {
             ballot_updates: false,
             public_results: true,
             random_candidate_order: true,
+            require_instruction_confirmation: false,
         }
     }
 

--- a/frontend/src/components/ElectionForm/QuickPoll.tsx
+++ b/frontend/src/components/ElectionForm/QuickPoll.tsx
@@ -61,6 +61,7 @@ const QuickPoll = ({ authSession }) => {
             },
             ballot_updates: false,
             public_results: true,
+            random_candidate_order: true,
         }
     }
 


### PR DESCRIPTION
## Description
Adds setting to randomize candidate orders on the ballots. Order was already randomized but this allows you to disable it. Randomizing order is enabled by default. 
Also adds setting for requiring voter confirm they've read ballot instructions. Hooks are in to enable/disable it, but keeping it locked in the settings form for now until we get the checkbox added to the ballot.

## Screenshots / Videos (frontend only) 
Settings page
![image](https://github.com/Equal-Vote/star-server/assets/41272412/653507c6-4e26-418a-8900-6e03cf100ef4)
With randomization disabled
![image](https://github.com/Equal-Vote/star-server/assets/41272412/63c067cf-0373-4cf6-aade-b4b096e2f405)
With randomization enabled
![image](https://github.com/Equal-Vote/star-server/assets/41272412/13630d76-2250-4c9b-afef-bd60d5731b42)

## Related Issues

closes #335 
provides hook for #363 