### PR TITLE
Disable email buttons when not supported 

### DIFF
--- a/frontend/src/components/Election/Admin/AddElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/AddElectionRoll.tsx
@@ -18,8 +18,8 @@ const AddElectionRoll = ({ onClose }) => {
     const postRoll = usePostRolls(election.election_id)
     const [file, setFile] = useState()
     const fileReader = new FileReader()
-    const [enableVoterID, setEnableVoterID] = useState(false)
-    const [enableEmail, setEnableEmail] = useState(true)
+    const [enableVoterID, setEnableVoterID] = useState(election.settings.voter_authentication.voter_id && election.settings.invitation !== 'email')
+    const [enableEmail, setEnableEmail] = useState(election.settings.voter_authentication.email || election.settings.invitation === 'email')
     const [enablePrecinct, setEnablePrecinct] = useState(false)
     const inputRef = useRef(null)
 

--- a/frontend/src/components/Election/Admin/AddElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/AddElectionRoll.tsx
@@ -9,10 +9,11 @@ import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import { Checkbox, FormGroup, FormControlLabel } from '@mui/material';
 import { usePostRolls } from "../../../hooks/useAPI";
+import useElection from "../../ElectionContextProvider";
 
 
-const AddElectionRoll = ({ election, onClose }) => {
-
+const AddElectionRoll = ({ onClose }) => {
+    const { election } = useElection()
     const [voterIDList, setVoterIDList] = useState('')
     const postRoll = usePostRolls(election.election_id)
     const [file, setFile] = useState()

--- a/frontend/src/components/Election/Admin/Admin.tsx
+++ b/frontend/src/components/Election/Admin/Admin.tsx
@@ -10,7 +10,7 @@ const Admin = ({ authSession, election, permissions, fetchElection }) => {
         <Container>
             <Routes>
                 <Route path='/' element={<AdminHome authSession={authSession}/>} />
-                <Route path='/voters' element={<ViewElectionRolls election={election} permissions={permissions} />} />
+                <Route path='/voters' element={<ViewElectionRolls />} />
                 <Route path='/roles' element={<EditRoles election={election} permissions={permissions} fetchElection={fetchElection} />} />
                 <Route path='/ballots' element={<ViewBallots election={election} permissions={permissions} />} />
             </Routes>

--- a/frontend/src/components/Election/Admin/EditElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/EditElectionRoll.tsx
@@ -8,15 +8,22 @@ import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow
 import PermissionHandler from "../../PermissionHandler";
 import { useApproveRoll, useFlagRoll, useInvalidateRoll, useSendInvite, useUnflagRoll } from "../../../hooks/useAPI";
 import { formatDate } from "../../util";
-
-const EditElectionRoll = ({ roll, onClose, fetchRolls, id, permissions }) => {
+import useElection from "../../ElectionContextProvider";
+import { ElectionRoll } from "../../../../../domain_model/ElectionRoll";
+type Props = {
+    roll: ElectionRoll,
+    onClose: Function,
+    fetchRolls: Function,
+  }
+const EditElectionRoll = ({ roll, onClose, fetchRolls }:Props) => {
+    const { election, permissions } = useElection()
     const [updatedRoll, setUpdatedRoll] = useState(roll)
 
-    const approve = useApproveRoll(id)
-    const flag = useFlagRoll(id)
-    const unflag = useUnflagRoll(id)
-    const invalidate = useInvalidateRoll(id)
-    const sendInvite = useSendInvite(id, roll.voter_id)
+    const approve = useApproveRoll(election.election_id)
+    const flag = useFlagRoll(election.election_id)
+    const unflag = useUnflagRoll(election.election_id)
+    const invalidate = useInvalidateRoll(election.election_id)
+    const sendInvite = useSendInvite(election.election_id, roll.voter_id)
 
     const onApprove = async () => {
         if (!await approve.makeRequest({ electionRollEntry: roll })) { return }
@@ -39,7 +46,6 @@ const EditElectionRoll = ({ roll, onClose, fetchRolls, id, permissions }) => {
 
         await fetchRolls()
     }
-
     return (
         <Container>
             {(approve.isPending || flag.isPending || unflag.isPending || invalidate.isPending) &&
@@ -69,7 +75,7 @@ const EditElectionRoll = ({ roll, onClose, fetchRolls, id, permissions }) => {
                     </Typography>
                 </Grid>
                 
-                {roll.email &&
+                {election.settings.invitation === 'email' && roll.email &&
                     <>
                         {roll && !(roll.email_data && roll.email_data.inviteResponse) &&
                             <Grid item sm={12}>


### PR DESCRIPTION
## Description
Hides the "add voters" button when voter access is not open.
Hides the send invites button when email invites not enabled.
Hides email invite status when email invite not enabled.
Sets default values for add voter check boxes based on election. Should probably remove checkboxes in the future and just tell user what data is expected.

## Screenshots / Videos (frontend only) 

With email invites enabled
![image](https://github.com/Equal-Vote/star-server/assets/41272412/24a686bb-b7c4-4c7c-93a7-8afa27ce4bb8)
![image](https://github.com/Equal-Vote/star-server/assets/41272412/eceabfb6-39f0-4fe4-ab6c-7bbf9597d411)


With email invites disabled
![image](https://github.com/Equal-Vote/star-server/assets/41272412/5e893d46-8182-4ce9-b685-07284e737d37)
![image](https://github.com/Equal-Vote/star-server/assets/41272412/2b4ff848-9107-4b2a-a603-8c18656004e4)


## Related Issues

closes #310 
