### PR TITLE
Add tie result for approval

### DIFF
--- a/backend/src/Tabulators/AllocatedScore.ts
+++ b/backend/src/Tabulators/AllocatedScore.ts
@@ -48,6 +48,7 @@ export function AllocatedScore(candidates: string[], votes: ballot[], nWinners =
         other: [],
         roundResults: [],
         summaryData: summaryData,
+        tieBreakType: 'none',
     }
     var remainingCandidates = [...summaryData.candidates]
     // Run election rounds until there are no remaining candidates

--- a/backend/src/Tabulators/Approval.test.ts
+++ b/backend/src/Tabulators/Approval.test.ts
@@ -65,36 +65,37 @@ describe("Approval Tests", () => {
         expect(results.summaryData.nInvalidVotes).toBe(0)
     })
 
-    test("Ties Test", () => {
-        // Tie for second
-        // Tiebreak order not defined, select lower index
-        const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
+    // NOTE: I'm proposing we always have tie breaker order in place, so we wouldn't need to worry about this
+    //test("Ties Test", () => {
+    //    // Tie for second
+    //    // Tiebreak order not defined, select lower index
+    //    const candidates = ['Alice', 'Bob', 'Carol', 'Dave']
 
-        const votes = [
-            [1, 1, 1, 1],
-            [0, 1, 1, 1],
-            [0, 1, 1, 1],
-            [0, 1, 1, 1],
-            [0, 1, 1, 1],
-            [0, 1, 1, 1],
-            [0, 0, 0, 1],
-        ]
-        const results = Approval(candidates, votes)
-        expect(results.elected.length).toBe(1);
-        expect(results.elected[0].name).toBe('Dave');
-        expect(results.summaryData.totalScores[0].score).toBe(7)
-        expect(results.summaryData.totalScores[0].index).toBe(3)
-        expect(results.summaryData.totalScores[1].score).toBe(6)
-        expect(results.summaryData.totalScores[1].index).toBe(1) // random tiebreaker, second place lower index 1
-        expect(results.summaryData.totalScores[2].score).toBe(6)
-        expect(results.summaryData.totalScores[2].index).toBe(2) // random tiebreaker, third place higher index 2
-        expect(results.summaryData.totalScores[3].score).toBe(1)
-        expect(results.summaryData.totalScores[3].index).toBe(0)
-        
-        expect(results.summaryData.nUnderVotes).toBe(0)
-        expect(results.summaryData.nValidVotes).toBe(7)
-        expect(results.summaryData.nInvalidVotes).toBe(0)
-    })
+    //    const votes = [
+    //        [1, 1, 1, 1],
+    //        [0, 1, 1, 1],
+    //        [0, 1, 1, 1],
+    //        [0, 1, 1, 1],
+    //        [0, 1, 1, 1],
+    //        [0, 1, 1, 1],
+    //        [0, 0, 0, 1],
+    //    ]
+    //    const results = Approval(candidates, votes)
+    //    expect(results.elected.length).toBe(1);
+    //    expect(results.elected[0].name).toBe('Dave');
+    //    expect(results.summaryData.totalScores[0].score).toBe(7)
+    //    expect(results.summaryData.totalScores[0].index).toBe(3)
+    //    expect(results.summaryData.totalScores[1].score).toBe(6)
+    //    expect(results.summaryData.totalScores[1].index).toBe(1) // random tiebreaker, second place lower index 1
+    //    expect(results.summaryData.totalScores[2].score).toBe(6)
+    //    expect(results.summaryData.totalScores[2].index).toBe(2) // random tiebreaker, third place higher index 2
+    //    expect(results.summaryData.totalScores[3].score).toBe(1)
+    //    expect(results.summaryData.totalScores[3].index).toBe(0)
+    //    
+    //    expect(results.summaryData.nUnderVotes).toBe(0)
+    //    expect(results.summaryData.nValidVotes).toBe(7)
+    //    expect(results.summaryData.nInvalidVotes).toBe(0)
+    //})
     test("Ties Test, tiebreak order defined", () => {
         // Tie for second
         // Tiebreak order defined, select lower

--- a/backend/src/Tabulators/IRV.ts
+++ b/backend/src/Tabulators/IRV.ts
@@ -26,7 +26,8 @@ export function IRV(candidates: string[], votes: ballot[], nWinners = 1, randomT
         logs: [],
         voteCounts: [],
         exhaustedVoteCounts: [],
-        overVoteCounts: []
+        overVoteCounts: [],
+        tieBreakType: 'none',
     }
 
     let remainingCandidates = [...summaryData.candidates]

--- a/backend/src/Tabulators/Plurality.ts
+++ b/backend/src/Tabulators/Plurality.ts
@@ -12,6 +12,7 @@ export function Plurality(candidates: string[], votes: ballot[], nWinners = 1, r
     other: [],
     roundResults: [],
     summaryData: summaryData,
+    tieBreakType: 'none',
   }
   const sortedScores = summaryData.totalScores.sort((a: totalScore, b: totalScore) => {
     if (a.score > b.score) return -1

--- a/backend/src/Tabulators/RankedRobin.ts
+++ b/backend/src/Tabulators/RankedRobin.ts
@@ -29,6 +29,7 @@ export function RankedRobin(candidates: string[], votes: ballot[], nWinners = 1,
     other: [],
     roundResults: [],
     summaryData: summaryData,
+    tieBreakType: 'none',
   }
   var remainingCandidates = [...summaryData.candidates]
   // Run election rounds until there are no remaining candidates

--- a/backend/src/Tabulators/Star.ts
+++ b/backend/src/Tabulators/Star.ts
@@ -37,6 +37,7 @@ export function Star(candidates: string[], votes: ballot[], nWinners = 1, random
     other: [],
     roundResults: [],
     summaryData: summaryData,
+    tieBreakType: 'none',
   }
   var remainingCandidates = [...summaryData.candidates]
   // Run election rounds until there are no remaining candidates

--- a/backend/src/Tabulators/Util.ts
+++ b/backend/src/Tabulators/Util.ts
@@ -1,6 +1,25 @@
+import { candidate, totalScore } from "./../../../domain_model/ITabulators";
+
+declare namespace Intl {
+  class ListFormat {
+    constructor(locales?: string | string[], options?: {});
+    public format: (items: string[]) => string;
+  }
+}
+// converts list of strings to string with correct grammar ([a,b,c] => 'a, b, and c')
+export const commaListFormatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+
+export function sortTotalScores(totalScores : totalScore[], candidates : candidate[]){
+  return totalScores.sort((a: totalScore, b: totalScore) => {
+    if (a.score > b.score) return -1
+    if (a.score < b.score) return 1
+    if (candidates[a.index].tieBreakOrder < candidates[b.index].tieBreakOrder) return -1
+    return 1
+  });
+}
 
 // Format a Timestamp value into a compact string for display;
-function formatTimestamp(value) {
+function formatTimestamp(value : string) {
   const d = new Date(Date.parse(value));
   const month = d.getMonth() + 1;
   const date = d.getDate();
@@ -20,32 +39,25 @@ function formatTimestamp(value) {
   return timeStamp;
 }
 
-function position(number) {
-  const numberString = Number(number).toFixed(0).toString();
-  const lastDigit = numberString.substr(-1);
-  const suffix =
-    lastDigit === "1"
-      ? "st"
-      : lastDigit === "2"
-        ? "nd"
-        : lastDigit === "3"
-          ? "rd"
-          : "th";
-  return `${numberString}${suffix}`;
+
+
+const isScore = (value : any) =>
+  !isNaN(value) && (value === null || (value > -10 && value < 10));
+
+const transformScore = (value : number) => {
+  // minScore and maxScore were undefined when moving the file to typescript, so I'm hard coding them for now
+  const minScore = 0;
+  const maxScore = 5;
+  value ? Math.min(maxScore, Math.max(minScore, value)) : 0;
 }
 
-const isScore = (value) =>
-  !isNaN(value) && (value === null || (value > -10 && value < 10));
-const transformScore = (value) =>
-  value ? Math.min(maxScore, Math.max(minScore, value)) : 0;
-
 // Functions to parse Timestamps
-const isTimestamp = (value) => !isNaN(Date.parse(value));
-const transformTimestamp = (value) => formatTimestamp(value);
+const isTimestamp = (value : any) => !isNaN(Date.parse(value));
+const transformTimestamp = (value : any) => formatTimestamp(value);
 
 // Functions to parse everything else
-const isAny = (value) => true;
-const transformAny = (value) => (value ? value.toString().trim() : "");
+const isAny = (value : any) => true;
+const transformAny = (value : any) => (value ? value.toString().trim() : "");
 
 // Column types to recognize in Cast Vote Records passed as CSV data
 const columnTypes = [
@@ -55,10 +67,10 @@ const columnTypes = [
   { test: isAny, transform: transformAny }
 ];
 
-function getTransforms(header, data) {
-  const transforms = [];
+function getTransforms(header : any, data : string[][]) {
+  const transforms : any[] = [];
   const rowCount = Math.min(data.length, 3);
-  header.forEach((title, n) => {
+  header.forEach((title : string, n : number) => {
     var transformIndex = 0;
     if (title === "Timestamp") {
       transformIndex = 1;

--- a/domain_model/ElectionSettings.ts
+++ b/domain_model/ElectionSettings.ts
@@ -24,4 +24,5 @@ export interface ElectionSettings {
     time_zone?:           string; // Time zone for displaying election start/end times 
     random_candidate_order?: boolean; // Randomize order of candidates on the ballot
     require_instruction_confirmation?: boolean // Require voter to confirm that they've read the instructions in order to vote
-  }
+    break_ties_randomly?: boolean // whether true ties should be broken randomly
+}

--- a/domain_model/ITabulators.ts
+++ b/domain_model/ITabulators.ts
@@ -76,6 +76,7 @@ interface genericResults {
     other: candidate[],
     roundResults: roundResults[],
     summaryData: genericSummaryData,
+    tieBreakType: string,
 }
 
 export interface starResults extends genericResults {


### PR DESCRIPTION
## Description
This updates the approval results page to sometimes indicate that the election is tied instead of showing a winner

Here are the specific updates
* Add election setting for breaking ties randomly
* Adjust results title to show ties
* Refactor tabulator to avoid managing offsets on an array
* Refactor tabulator to always sort candidates and break ties randomly (the break ties randomly setting is only used by the frontend)
* Refactor tabulator with SingleWinnerApproval sub-method

Here's some follow up tasks
 * filter random tie break out of the detailed steps if random tiebreaker isn't enabled
 * add support for random tie breaker in the settings (it's currently locked to disabled)

## Screenshots / Videos (frontend only) 
![image](https://github.com/Equal-Vote/star-server/assets/9289903/7e475c74-f60f-423b-a08b-abebb9cbf5ef)


## Related Issues

related #415 