### PR TITLE
Use paths to clean up domain_model references

### DIFF
--- a/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -4,7 +4,7 @@ import { Box, Divider, Paper } from "@mui/material";
 import { Typography } from "@mui/material";
 import { StyledButton } from "../../styles";
 import { Link, useNavigate } from 'react-router-dom';
-import { Election } from '../../../../../domain_model/Election';
+import { Election } from '@domain_model/Election';
 import ShareButton from "../ShareButton";
 import { useArchiveEleciton, useFinalizeEleciton, usePostElection, useSetPublicResults } from "../../../hooks/useAPI";
 import { formatDate } from '../../util';

--- a/frontend/src/components/Election/Admin/EditElectionRoll.tsx
+++ b/frontend/src/components/Election/Admin/EditElectionRoll.tsx
@@ -9,7 +9,7 @@ import PermissionHandler from "../../PermissionHandler";
 import { useApproveRoll, useFlagRoll, useInvalidateRoll, useSendInvite, useUnflagRoll } from "../../../hooks/useAPI";
 import { formatDate } from "../../util";
 import useElection from "../../ElectionContextProvider";
-import { ElectionRoll } from "../../../../../domain_model/ElectionRoll";
+import { ElectionRoll } from "@domain_model/ElectionRoll";
 type Props = {
     roll: ElectionRoll,
     onClose: Function,

--- a/frontend/src/components/Election/Admin/EditRoles.tsx
+++ b/frontend/src/components/Election/Admin/EditRoles.tsx
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import PermissionHandler from "../../PermissionHandler";
 import { usePutElectionRoles } from "../../../hooks/useAPI";
-import { Election } from "../../../../../domain_model/Election";
+import { Election } from "@domain_model/Election";
 import { StyledButton } from "../../styles";
 import useAuthSession from "../../AuthSessionContextProvider";
 import useElection from "../../ElectionContextProvider";

--- a/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
+++ b/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
@@ -11,7 +11,7 @@ import { Typography } from "@mui/material";
 import EnhancedTable, { HeadCell, TableData } from "./../../EnhancedTable";
 import { useGetRolls, useSendInvites } from "../../../hooks/useAPI";
 import useElection from "../../ElectionContextProvider";
-import { ElectionRoll } from "../../../../../domain_model/ElectionRoll";
+import { ElectionRoll } from "@domain_model/ElectionRoll";
 
 interface Data extends TableData {
     voter_id: string;

--- a/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/frontend/src/components/Election/Voting/VotePage.tsx
@@ -5,16 +5,16 @@ import { useParams } from "react-router";
 import React from 'react'
 import CheckBoxOutlineBlankOutlinedIcon from '@mui/icons-material/CheckBoxOutlineBlankOutlined';
 import { useNavigate } from "react-router";
-import { Ballot } from "../../../../../domain_model/Ballot";
-import { Vote } from "../../../../../domain_model/Vote";
-import { Score } from "../../../../../domain_model/Score";
+import { Ballot } from "@domain_model/Ballot";
+import { Vote } from "@domain_model/Vote";
+import { Score } from "@domain_model/Score";
 import { Box, Container, Step, StepLabel, Stepper, SvgIcon } from "@mui/material";
 import Button from "@mui/material/Button";
 import { usePostBallot } from "../../../hooks/useAPI";
 import FiberManualRecordOutlinedIcon from '@mui/icons-material/FiberManualRecordOutlined';
 import useElection from "../../ElectionContextProvider";
-import { Candidate } from "../../../../../domain_model/Candidate";
-import { Race } from "../../../../../domain_model/Race";
+import { Candidate } from "@domain_model/Candidate";
+import { Race } from "@domain_model/Race";
 
 // I'm using the icon codes instead of an import because there was padding I couldn't get rid of
 // https://stackoverflow.com/questions/65721218/remove-material-ui-icon-margin

--- a/frontend/src/components/ElectionCard.tsx
+++ b/frontend/src/components/ElectionCard.tsx
@@ -1,7 +1,7 @@
 import Button from "./Button"
 import { Link } from "react-router-dom"
 import React from 'react'
-import { Election } from "../../../domain_model/Election"
+import { Election } from "@domain_model/Election"
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';

--- a/frontend/src/components/ElectionContextProvider.tsx
+++ b/frontend/src/components/ElectionContextProvider.tsx
@@ -1,9 +1,9 @@
 import React, { useContext, useEffect } from 'react'
 import { createContext, Dispatch, SetStateAction } from 'react'
-import { Election } from '../../../domain_model/Election';
+import { Election } from '@domain_model/Election';
 import { useEditElection, useGetElection } from '../hooks/useAPI';
-import { Election as IElection } from '../../../domain_model/Election';
-import { VoterAuth } from '../../../domain_model/VoterAuth';
+import { Election as IElection } from '@domain_model/Election';
+import { VoterAuth } from '@domain_model/VoterAuth';
 import structuredClone from '@ungap/structured-clone';
 
 

--- a/frontend/src/components/ElectionForm/AddElection.tsx
+++ b/frontend/src/components/ElectionForm/AddElection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ElectionForm from "./ElectionForm";
 import { useNavigate } from "react-router"
-import { Election } from '../../../../domain_model/Election';
+import { Election } from '@domain_model/Election';
 import { usePostElection } from '../../hooks/useAPI';
 import useAuthSession from '../AuthSessionContextProvider';
 

--- a/frontend/src/components/ElectionForm/Candidates/AddCandidate.tsx
+++ b/frontend/src/components/ElectionForm/Candidates/AddCandidate.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback } from 'react'
-import { Candidate } from "../../../../../domain_model/Candidate"
+import { Candidate } from "@domain_model/Candidate"
 import React from 'react'
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";

--- a/frontend/src/components/ElectionForm/CreateElectionTemplates.tsx
+++ b/frontend/src/components/ElectionForm/CreateElectionTemplates.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useNavigate } from "react-router"
-import { Election } from '../../../../domain_model/Election';
+import { Election } from '@domain_model/Election';
 import { usePostElection } from '../../hooks/useAPI';
 import { DateTime } from 'luxon'
 import { Card, CardActionArea, CardMedia, CardContent, Typography, Box, Grid } from '@mui/material';

--- a/frontend/src/components/ElectionForm/Details/ElectionDetails.tsx
+++ b/frontend/src/components/ElectionForm/Details/ElectionDetails.tsx
@@ -8,7 +8,7 @@ import { StyledButton } from '../../styles';
 import { Input } from '@mui/material';
 import { DateTime } from 'luxon'
 import { timeZones } from './TimeZones'
-import { Election } from '../../../../../domain_model/Election';
+import { Election } from '@domain_model/Election';
 
 
 type Props = {

--- a/frontend/src/components/ElectionForm/ElectionForm.tsx
+++ b/frontend/src/components/ElectionForm/ElectionForm.tsx
@@ -16,8 +16,8 @@ import { CardActionArea } from "@mui/material";
 import Typography from '@mui/material/Typography';
 import { StyledButton } from '../styles';
 import SummaryPage from "./SummaryPage";
-import { Election } from "./../../../../domain_model/Election";
-import { Candidate } from "../../../../domain_model/Candidate";
+import { Election } from "@domain_model/Election";
+import { Candidate } from "@domain_model/Candidate";
 
 
 type Pages = 'ElectionDetails' | 'RaceDetails' | 'Open?' | 'Limit?' | 'VoterList?' | 'Emails?' | 'Invitations?' | 'Login?' | 'Register?' | 'CustomRegister?' |

--- a/frontend/src/components/ElectionForm/QuickPoll.tsx
+++ b/frontend/src/components/ElectionForm/QuickPoll.tsx
@@ -11,7 +11,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import Typography from '@mui/material/Typography';
 import { usePostElection } from '../../hooks/useAPI';
 import { useCookie } from '../../hooks/useCookie';
-import { Election } from '../../../../domain_model/Election.js';
+import { Election } from '@domain_model/Election.js';
 
 const QuickPoll = ({ authSession }) => {
     const [tempID, setTempID] = useCookie('temp_id', '0')

--- a/frontend/src/components/ElectionForm/Races/RaceForm.tsx
+++ b/frontend/src/components/ElectionForm/Races/RaceForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useState } from "react"
-import { Candidate } from "../../../../../domain_model/Candidate"
+import { Candidate } from "@domain_model/Candidate"
 import AddCandidate, { CandidateForm } from "../Candidates/AddCandidate"
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";

--- a/frontend/src/components/ElectionForm/Races/useEditRace.tsx
+++ b/frontend/src/components/ElectionForm/Races/useEditRace.tsx
@@ -3,11 +3,11 @@ import { useState } from "react"
 
 import { scrollToElement } from '../../util';
 import useElection from '../../ElectionContextProvider';
-import { Race as iRace } from '../../../../../domain_model/Race';
+import { Race as iRace } from '@domain_model/Race';
 import structuredClone from '@ungap/structured-clone';
 import useConfirm from '../../ConfirmationDialogProvider';
 import { v4 as uuidv4 } from 'uuid';
-import { Candidate } from '../../../../../domain_model/Candidate';
+import { Candidate } from '@domain_model/Candidate';
 
 export const useEditRace = (race, race_index) => {
     const { election, refreshElection, permissions, updateElection } = useElection()

--- a/frontend/src/components/ElectionForm/Settings.tsx
+++ b/frontend/src/components/ElectionForm/Settings.tsx
@@ -4,7 +4,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 import Typography from '@mui/material/Typography';
 import { Checkbox, FormGroup, FormHelperText, FormLabel, InputLabel, Radio, RadioGroup, Tooltip } from "@mui/material"
-import { Election } from '../../../../domain_model/Election';
+import { Election } from '@domain_model/Election';
 import { StyledButton } from '../styles';
 
 type SettingsProps = {

--- a/frontend/src/components/Elections.tsx
+++ b/frontend/src/components/Elections.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Election } from "../../../domain_model/Election"
+import { Election } from "@domain_model/Election"
 import Typography from '@mui/material/Typography';
 import { Box, Container } from "@mui/material"
 import Button from "@mui/material/Button";

--- a/frontend/src/hooks/useAPI.ts
+++ b/frontend/src/hooks/useAPI.ts
@@ -1,8 +1,8 @@
-import { Election } from "../../../domain_model/Election";
-import { VoterAuth } from '../../../domain_model/VoterAuth';
-import { ElectionRoll } from "../../../domain_model/ElectionRoll";
+import { Election } from "@domain_model/Election";
+import { VoterAuth } from '@domain_model/VoterAuth';
+import { ElectionRoll } from "@domain_model/ElectionRoll";
 import useFetch from "./useFetch";
-import { Ballot } from "../../../domain_model/Ballot";
+import { Ballot } from "@domain_model/Ballot";
 
 export const useGetElection = (electionID: string | undefined) => {
     return useFetch<undefined, { election: Election, voterAuth: VoterAuth }>(`/API/Election/${electionID}`, 'get')

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,8 +18,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@domain_model/*": ["../domain_model/*"]
+    }
   },
   
-  "include": ["../domain_model/**/*", "./src/**/*"],
+  "include": ["@domain_model/**/*", "./src/**/*"],
 }


### PR DESCRIPTION
## Description

This cleans up references to the domain_model

It's only applied to the frontend, backend is harder since there are multiple domain_model folders that are used there