### PR TITLE
fix: remove file extensions from relative imports

### DIFF
--- a/backend/src/Models/serialize-parameters/serialize-parameters-plugin.ts
+++ b/backend/src/Models/serialize-parameters/serialize-parameters-plugin.ts
@@ -6,8 +6,8 @@ import {
   RootOperationNode,
   QueryResult
 } from 'kysely'
-import { SerializeParametersTransformer } from './serialize-parameters-transformer.js'
-import { Caster, Serializer } from './serialize-parameters.js'
+import { SerializeParametersTransformer } from './serialize-parameters-transformer'
+import { Caster, Serializer } from './serialize-parameters'
 
 export interface SerializeParametersPluginOptions {
   /**

--- a/backend/src/Models/serialize-parameters/serialize-parameters-transformer.ts
+++ b/backend/src/Models/serialize-parameters/serialize-parameters-transformer.ts
@@ -12,7 +12,7 @@ import {
   Caster,
   defaultSerializer,
   Serializer,
-} from './serialize-parameters.js'
+} from './serialize-parameters'
 
 export class SerializeParametersTransformer extends OperationNodeTransformer {
   readonly #caster: Caster | undefined


### PR DESCRIPTION
## Description
Removes .js file extension from relative imports that were breaking dev server (nodemon) since it is looking at the files in src (.ts) and not in build dir (.js).

## Related Issues
None listed though this seems to be a recurring sticking point when folks are following the dev onboarding which suggests using `npm run dev`. It's not strictly necessary since folks can use `npm run build && npm run start`, but might be nice to be able to directly pickup backend changes during dev without restarting the server.