### PR TITLE
Add view account to navbar and separate invitations and previous elections pages 

### DIFF
--- a/backend/src/Controllers/getElectionsController.ts
+++ b/backend/src/Controllers/getElectionsController.ts
@@ -30,12 +30,23 @@ const getElections = async (req: IElectionRequest, res: Response, next: NextFunc
     }
 
     /////////// ELECTIONS WE'RE INVITED TO ////////////////
-    var elections_as_voter = null;
+    var elections_as_unsubmitted_voter = null;
     if (email !== '') {
-        let myRolls = await ElectionRollModel.getByEmail(email, req)
+        let myRolls = await ElectionRollModel.getByEmailAndUnsubmitted(email, req)
+        console.log('unsubmitted output', myRolls);
         let election_ids = myRolls?.map(election => election.election_id)
         if (election_ids && election_ids.length > 0) {
-            elections_as_voter = await ElectionsModel.getElectionByIDs(election_ids,req)
+            elections_as_unsubmitted_voter = await ElectionsModel.getElectionByIDs(election_ids,req)
+        }
+    }
+
+    /////////// ELECTIONS WE'VE VOTED IN ////////////////
+    var elections_as_submitted_voter = null;
+    if (email !== '') {
+        let myRolls = await ElectionRollModel.getByEmailAndSubmitted(email, req)
+        let election_ids = myRolls?.map(election => election.election_id)
+        if (election_ids && election_ids.length > 0) {
+            elections_as_submitted_voter = await ElectionsModel.getElectionByIDs(election_ids,req)
         }
     }
 
@@ -43,9 +54,10 @@ const getElections = async (req: IElectionRequest, res: Response, next: NextFunc
     var open_elections = await ElectionsModel.getOpenElections(req);
 
     res.json({
-        elections_as_official: elections_as_official,
-        elections_as_voter: elections_as_voter,
-        open_elections: open_elections
+        elections_as_official,
+        elections_as_unsubmitted_voter,
+        elections_as_submitted_voter,
+        open_elections
     });
 }
 

--- a/backend/src/Models/ElectionRolls.ts
+++ b/backend/src/Models/ElectionRolls.ts
@@ -74,6 +74,36 @@ export default class ElectionRollDB implements IElectionRollStore {
             }))
     }
 
+    getByEmailAndSubmitted(email: string, ctx: ILoggingContext): Promise<ElectionRoll[] | null> {
+        Logger.debug(ctx, `${tableName}.getByEmail`);
+
+        return this._postgresClient
+            .selectFrom(tableName)
+            .where('email', '=', email)
+            .where('submitted', '=', true)
+            .selectAll()
+            .execute()
+            .catch(((reason: any) => {
+                Logger.debug(ctx, reason);
+                return null
+            }))
+    }
+
+    getByEmailAndUnsubmitted(email: string, ctx: ILoggingContext): Promise<ElectionRoll[] | null> {
+        Logger.debug(ctx, `${tableName}.getByEmail`);
+
+        return this._postgresClient
+            .selectFrom(tableName)
+            .where('email', '=', email)
+            .where('submitted', '=', false)
+            .selectAll()
+            .execute()
+            .catch(((reason: any) => {
+                Logger.debug(ctx, reason);
+                return null
+            }))
+    }
+
     getElectionRoll(election_id: string, voter_id: string | null, email: string | null, ip_address: string | null, ctx: ILoggingContext): Promise<ElectionRoll[] | null> {
         Logger.debug(ctx, `${tableName}.get election:${election_id}, voter:${voter_id}`);
 

--- a/docs/contributions/Infrastructure/11_keycloak_configuration.md
+++ b/docs/contributions/Infrastructure/11_keycloak_configuration.md
@@ -66,7 +66,9 @@ Repeat all the the following steps for the STAR Voting realm and the STAR Voting
 
 1. Hover over "Master" in the top left, and click "Add Realm"
 1. Give it a name (STARVoting or STARVotingDev), and hit create
-1. Under "Realm Settings", set the display name to include spaces
+1. Under "Realm Settings"
+    * Set the display name to include spaces
+    * Enable User-Managed Access
 1. Under "Realm Settings" > "Login". Enable the following
     * User Registration
     * Forgot password
@@ -105,7 +107,6 @@ We have all google api stuff under mike@equal.vote
 Follow the guide here to set that up
 
 https://keycloakthemes.com/blog/how-to-setup-sign-in-with-google-using-keycloak
-
 
 ## Point website to new endpoint
 

--- a/frontend/src/components/AuthSessionContextProvider.tsx
+++ b/frontend/src/components/AuthSessionContextProvider.tsx
@@ -20,7 +20,8 @@ const keycloakAuthConfig = {
         logout: `${keycloakBaseUrl}/logout`,
         token: `${keycloakBaseUrl}/token`,
         authorize: `${keycloakBaseUrl}/auth`,
-        userinfo: `${keycloakBaseUrl}/userinfo`
+        userinfo: `${keycloakBaseUrl}/userinfo`,
+        account: `${keycloakBaseUrl.split('/protocol')[0]}/account` // unlike the other endpoints account doesn't require /protocol/openid-connect
     },
 }
 
@@ -33,6 +34,7 @@ export interface IAuthSession {
     openLogin: () => void
     openLogout: () => void
     getIdField: (fieldName: any) => any
+    accountUrl: string
 }
 
 const AuthSessionContext = createContext<IAuthSession>(null);
@@ -161,6 +163,7 @@ export function AuthSessionContextProvider({ children }) {
                 openLogin: openLogin,
                 openLogout: openLogout,
                 getIdField: getIdField,
+                accountUrl: authConfig.endpoints.account
             }}>
             {children}
         </AuthSessionContext.Provider>

--- a/frontend/src/components/Elections/ElectionInvitations.tsx
+++ b/frontend/src/components/Elections/ElectionInvitations.tsx
@@ -9,7 +9,7 @@ export default () => {
     useEffect(() => {fetchElections()}, []);
 
     const electionInvitations = React.useMemo(
-        () => data?.elections_as_voter ? data.elections_as_voter : [],
+        () => data?.elections_as_unsubmitted_voter ? data.elections_as_unsubmitted_voter : [],
         [data],
     );
             

--- a/frontend/src/components/Elections/ElectionsYouVotedIn.tsx
+++ b/frontend/src/components/Elections/ElectionsYouVotedIn.tsx
@@ -9,15 +9,15 @@ export default () => {
 
     useEffect(() => {fetchElections()}, []);
 
-    const electionInvitations = React.useMemo(
-        () => data?.elections_as_voter ? data.elections_as_voter : [],
+    const previousElections = React.useMemo(
+        () => data?.elections_as_submitted_voter ? data.elections_as_submitted_voter : [],
         [data],
     );
             
     return <ElectionsTable
-        title='Elections You Can Vote In'
+        title='Elections You Voted In'
         headKeys={['title', 'state', 'start_time', 'end_time', 'description']}
         isPending={isPending}
-        electionData={electionInvitations}
+        electionData={previousElections}
     />
 }

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -162,6 +162,9 @@ const Header = () => {
                             <MenuItem disabled>
                                 Hello {authSession.getIdField('given_name')}!
                             </MenuItem>
+                            <MenuItem component={Link} href={authSession.accountUrl} target='_blank'>
+                                Your Account
+                            </MenuItem>
                             <MenuItem component={Link} href='/CreateElection'>
                                 New Election
                             </MenuItem>

--- a/frontend/src/hooks/useAPI.ts
+++ b/frontend/src/hooks/useAPI.ts
@@ -11,7 +11,12 @@ export const useGetElection = (electionID: string | undefined) => {
 }
 
 export const useGetElections = () => {
-    return useFetch<undefined, { elections_as_official: Election[] | null, elections_as_voter: Election[] | null, open_elections: Election[] | null }>('/API/Elections', 'get')
+    return useFetch<undefined, {
+        elections_as_official: Election[] | null,
+        elections_as_unsubmitted_voter: Election[] | null,
+        elections_as_submitted_voter: Election[] | null,
+        open_elections: Election[] | null
+    }>('/API/Elections', 'get')
 }
 
 export const usePostElection = () => {


### PR DESCRIPTION
## Description

* Update getElections to seperate unsubmitted and submitted votes
* Add "your account" button that takes you to the keycloak account console

![image](https://github.com/Equal-Vote/star-server/assets/9289903/412a9372-97c4-4287-9a1e-1983f3118dc0)

## Not covered

* Avatars: I looked into this but hit some complications. It's probably not worth it pre-beta (more details #447)
* Voter Roll Logic: Current voters get added to rolls as a side effect of getElection. As a result your ip get's readded to the featured elections every time your on a new device. This causes the unsubmitted ballot and submitted ballot views to have identical entries even though the queries are correct (more details #449)

## Related Issues

fixes #446 