### PR TITLE
Add max width for results yaxis

### DIFF
--- a/frontend/src/components/Election/Results/STAR/STARResultSummaryWidget.tsx
+++ b/frontend/src/components/Election/Results/STAR/STARResultSummaryWidget.tsx
@@ -88,7 +88,8 @@ const STARResultSummaryWidget = ({ results, roundIndex }: {results: starResults,
         return (a.name.length > b.name.length)? a : b;
     })
 
-    const axisWidth = 15 * ((candidateWithLongestName.name.length > 20)? 20 : candidateWithLongestName.name.length);
+    // 200 is about the max width I'd want for a small mobile device, still looking for a better solution though
+    const axisWidth = Math.min(200, 15 * ((candidateWithLongestName.name.length > 20)? 20 : candidateWithLongestName.name.length));
     
     const pieAngle = 90 + 360 * (1 - (pieData[0].votes/results.summaryData.nValidVotes))
 


### PR DESCRIPTION
## Description

I noticed the mobile view on some elections cut off the names, so I set a max on the y axis width

![image](https://github.com/Equal-Vote/star-server/assets/9289903/8a43650e-be94-44aa-894e-27768b5c06d9)