### PR TITLE
Make results page more print friendly

### DIFF
--- a/packages/frontend/src/components/Election/Admin/ViewBallot.tsx
+++ b/packages/frontend/src/components/Election/Admin/ViewBallot.tsx
@@ -28,7 +28,6 @@ const ViewBallot = ({ ballot, onClose }) => {
 
     return (
         <Container>
-
             {isPending && <div> Loading Data... </div>}
             {myballot &&
                 <Grid container direction="column" >

--- a/packages/frontend/src/components/Election/Election.tsx
+++ b/packages/frontend/src/components/Election/Election.tsx
@@ -31,7 +31,7 @@ const Election = () => {
         <Box sx={{maxWidth: {xs: '100%', md: '16%'}}}>
           <Sidebar />
         </Box>
-        <Box sx={{mt: '0', width: '100%'}}>
+        <Box sx={{mt: '0', width: '100%', '@media print': {maxWidth: '100%'}}}>
           <Routes>
             <Route path='/' element={<ElectionHome />} />
             <Route path='/vote' element={<VotePage />} />

--- a/packages/frontend/src/components/Election/Election.tsx
+++ b/packages/frontend/src/components/Election/Election.tsx
@@ -31,7 +31,7 @@ const Election = () => {
         <Box sx={{maxWidth: {xs: '100%', md: '16%'}}}>
           <Sidebar />
         </Box>
-        <Box sx={{mt: '0', width: '100%', '@media print': {maxWidth: '100%'}}}>
+        <Box sx={{mt: '0', width: '100%'}}>
           <Routes>
             <Route path='/' element={<ElectionHome />} />
             <Route path='/vote' element={<VotePage />} />

--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -359,6 +359,7 @@ export default function Results({ title, raceIndex, race, result }: ResultsProps
   return (
     <div>
       <div className="flexContainer" style={{textAlign: 'center'}}>
+        <Box sx={{pageBreakAfter:'avoid', pageBreakInside:'avoid'}}>
         {result.results.summaryData.nValidVotes == 0 && <h2>Still waiting for results<br/>No votes have been cast</h2>}
         {result.results.summaryData.nValidVotes >= 1 && <>
           {showTitleAsTie?
@@ -373,6 +374,7 @@ export default function Results({ title, raceIndex, race, result }: ResultsProps
           }
           <Typography variant="h6">{result.results.summaryData.nValidVotes} voters</Typography>
         </>}
+        </Box>
         {result.results.summaryData.nValidVotes == 1 && <p>There's only one vote so far.<br/>Full results will be displayed once there's more votes.</p> }
         {result.results.summaryData.nValidVotes > 1 &&
           <>

--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -59,7 +59,7 @@ function STARResultViewer({ results, rounds }: {results: starResults, rounds: nu
   return (
     <>
       <WinnerResultTabs numWinners={rounds}>
-        {roundIndexes.map((i) => <STARResultSummaryWidget results={results} roundIndex={i}/>)}
+        {roundIndexes.map((i) => <STARResultSummaryWidget key={i} results={results} roundIndex={i}/>)}
       </WinnerResultTabs>
       <DetailExpander title='Details'>
         <STARDetailedResults results={results} rounds={rounds}/>

--- a/packages/frontend/src/components/Election/Results/ViewElectionResults.tsx
+++ b/packages/frontend/src/components/Election/Results/ViewElectionResults.tsx
@@ -23,7 +23,7 @@ const ViewElectionResults = () => {
             alignItems="center"
             sx={{ width: '100%', textAlign: 'center'}}
         >
-            <Paper elevation={3} sx={{width: '100%', maxWidth: '1200px', m: 2, p:2, backgroundColor:'brand.white', marginBottom: 2}}  >
+            <Paper elevation={3} sx={{width: '100%', maxWidth: '1200px', m: 2, p:2, backgroundColor:'brand.white', marginBottom: 2, '@media print': { boxShadow: 'none'}}}>
                 <Typography variant="h3" component="h3" sx={{marginBottom: 4}}>
                     {election.state === 'closed' ? 'OFFICIAL RESULTS' : 'PRELIMINARY RESULTS'}
                 </Typography>
@@ -32,9 +32,10 @@ const ViewElectionResults = () => {
                 </Typography>
                 {isPending && <div> Loading Election... </div>}
 
-                <DetailExpanderGroup defaultSelectedIndex={-1}>
+                <DetailExpanderGroup defaultSelectedIndex={-1} allowMultiple>
                     {data?.results.map((result, race_index) => (
                         <Results 
+                            key={`results-${race_index}`}
                             title={`Race ${race_index+1}: ${election.races[race_index].title}`}
                             raceIndex={race_index}
                             race={election.races[race_index]}

--- a/packages/frontend/src/components/Election/Sidebar.tsx
+++ b/packages/frontend/src/components/Election/Sidebar.tsx
@@ -33,8 +33,6 @@ export default function Sidebar() {
                     justifyContent="center"
                     alignItems="center"
                     sx={{ 
-                        display: 'flex',
-                        width: '100%',
                         "@media print": {
                             display: 'none',
                         }

--- a/packages/frontend/src/components/Election/Sidebar.tsx
+++ b/packages/frontend/src/components/Election/Sidebar.tsx
@@ -32,7 +32,13 @@ export default function Sidebar() {
                     display='flex'
                     justifyContent="center"
                     alignItems="center"
-                    sx={{ width: '100%' }}>
+                    sx={{ 
+                        display: 'flex',
+                        width: '100%',
+                        "@media print": {
+                            display: 'none',
+                        }
+                    }}>
                     <Paper elevation={3} sx={{ width: 600 }} >
                         <Grid container direction="column" >
                             <ListItem text='Voting Page' link={`/${id}/`} />

--- a/packages/frontend/src/components/Footer.tsx
+++ b/packages/frontend/src/components/Footer.tsx
@@ -14,7 +14,10 @@ export default function Footer() {
         backgroundColor: themeSelector.mode === 'darkMode' ? 'brand.gray5' : 'brand.gray1',
         p: 6,
         width: '100%',
-        mt: 'auto'
+        mt: 'auto',
+        '@media print': {
+          display: 'none'
+        }
       }}
     >
       <Container maxWidth="lg">

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -66,7 +66,7 @@ const Header = () => {
     const [title, _] = useLocalStorage('title_override', process.env.REACT_APP_TITLE);
 
     return (
-        <AppBar position="sticky" sx={{ backgroundColor: "black" }}>
+        <AppBar className="navbar" position="sticky" sx={{ backgroundColor: "black", '@media print': {display: 'none', boxShadow: 'none'} }}>
             <Toolbar>
                 {/**** MOBILE HAMBURGER MENU ****/}
                 <Box sx={{ flexGrow: 0, display: { xs: 'flex', md: 'none' } }}>

--- a/packages/frontend/src/components/util.jsx
+++ b/packages/frontend/src/components/util.jsx
@@ -23,7 +23,6 @@ export const Widget = ({children, title}) => <Paper elevation={5} className='gra
     {children}
 </Paper>
 
-
 export const makeResultTable = (className, arr) => {
     let c = `resultTable ${className}`;
 
@@ -81,49 +80,66 @@ export const DetailExpander = ({children, title}) => {
     const expanderId = _uniqueId('detailExpander-')
 
     return <>
-        <div className={`detailExpander ${expanderId}`} style={{display: 'flex', flexDirection: 'row', gap: 10, justifyContent: 'center', cursor: 'pointer', alignItems: 'center'}} onClick={() => {
-            if(!viewDetails){
-                scrollToElement(document.querySelector(`${expanderId}:first-child`))
-            }
-            setViewDetails(!viewDetails)
-        }}>
+        <Box className={`detailExpander ${expanderId}`}
+            sx={{
+                display: 'flex', flexDirection: 'row', gap: 10, justifyContent: 'center', cursor: 'pointer', alignItems: 'center',
+                '@media print': {
+                    display: 'none'
+                }
+            }}
+            onClick={() => {
+                if(!viewDetails) scrollToElement(document.querySelector(`${expanderId}:first-child`))
+                setViewDetails(!viewDetails)
+            }}
+        >
             <Typography variant='h6'>{title}</Typography>
             {!viewDetails && <ExpandMore />}
             {viewDetails && <ExpandLess />}
-        </div>
+        </Box>
         {viewDetails && children}
     </>
 }
 
-export const DetailExpanderGroup = ({children, defaultSelectedIndex}) => {
-    const [widgetIndex, setWidgetIndex] = useState(defaultSelectedIndex);
+export const DetailExpanderGroup = ({children, defaultSelectedIndex, allowMultiple=false}) => {
+    let isSingle = !Array.isArray(children) || children.length <= 1;
+    const [openedWidgets, setOpenedWidgets] = useState([]);
 
     const groupRef = useRef(null);
 
-    if(!Array.isArray(children) || children.length <= 1) return <>{children}</>;
+    if(isSingle) return <>{children}</>;
 
+    if(openedWidgets.length == 0) setOpenedWidgets(new Array(Array.isArray(children)? children.length : 0).fill(false));
+
+    console.log('not single', children, children.length, isSingle, Array.isArray(children), openedWidgets, );
     return <div ref={groupRef} className='detailExpanderGroup'>
         {children.map((child,i) => (
             <Paper
+                key={`detail-expander-group-${i}`}
                 elevation={5}
                 sx={{backgroundColor: 'brand.white', padding: '8px', width: '100%'}} >
                 <div
                     className='detailSection'
                     style={{display: 'flex', flexDirection: 'row', justifyContent: 'flexStart', cursor: 'pointer'}}
                     onClick={() => {
-                        if((widgetIndex != i)){
+                        console.log('on click', openedWidgets);
+                        if(!openedWidgets[i]){
                             scrollToElement(groupRef.current.querySelectorAll(`.detailSection`)[i].parentNode);
                         }
-                        setWidgetIndex((widgetIndex == i)? -1 : i);
+                        setOpenedWidgets(openedWidgets.map((v, j) => {
+                            if(allowMultiple){
+                                return (i == j)? !v : v
+                            }else{
+                                return i == j;
+                            }
+                        }))
                     }}
                 >
                     <Typography variant='h6'>{child.props.title}</Typography>
                     <IconButton>
-                        {(widgetIndex != i) && <ExpandMore />}
-                        {(widgetIndex == i) && <ExpandLess />}
+                        {openedWidgets[i]? <ExpandLess /> : <ExpandMore />}
                     </IconButton>
                 </div>
-                {(widgetIndex == i) && 
+                {openedWidgets[i] && 
                     <>
                         <hr/>
                         <div style={{textAlign: 'left'}}>

--- a/packages/frontend/src/components/util.jsx
+++ b/packages/frontend/src/components/util.jsx
@@ -18,6 +18,7 @@ export const Widget = ({children, title}) => <Paper elevation={5} className='gra
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    pageBreakInside: 'avoid',
 }}>
     <Typography variant="h5">{title}</Typography>
     {children}
@@ -83,18 +84,15 @@ export const DetailExpander = ({children, title}) => {
         <Box className={`detailExpander ${expanderId}`}
             sx={{
                 display: 'flex', flexDirection: 'row', gap: 10, justifyContent: 'center', cursor: 'pointer', alignItems: 'center',
-                '@media print': {
-                    display: 'none'
-                }
             }}
             onClick={() => {
                 if(!viewDetails) scrollToElement(document.querySelector(`${expanderId}:first-child`))
                 setViewDetails(!viewDetails)
             }}
         >
-            <Typography variant='h6'>{title}</Typography>
-            {!viewDetails && <ExpandMore />}
-            {viewDetails && <ExpandLess />}
+            <Typography variant='h6' sx={{'@media print': {display: 'none'}}}>{title}</Typography>
+            {!viewDetails && <ExpandMore sx={{'@media print': {display: 'none'}}}/>}
+            {viewDetails && <ExpandLess sx={{'@media print': {display: 'none'}}}/>}
         </Box>
         {viewDetails && children}
     </>
@@ -117,7 +115,7 @@ export const DetailExpanderGroup = ({children, defaultSelectedIndex, allowMultip
                 sx={{backgroundColor: 'brand.white', padding: '8px', width: '100%'}} >
                 <div
                     className='detailSection'
-                    style={{display: 'flex', flexDirection: 'row', justifyContent: 'flexStart', cursor: 'pointer'}}
+                    style={{display: 'flex', flexDirection: 'row', justifyContent: 'flexStart', cursor: 'pointer', pageBreakAfter: 'avoid'}}
                     onClick={() => {
                         if(!openedWidgets[i]){
                             scrollToElement(groupRef.current.querySelectorAll(`.detailSection`)[i].parentNode);
@@ -132,13 +130,13 @@ export const DetailExpanderGroup = ({children, defaultSelectedIndex, allowMultip
                     }}
                 >
                     <Typography variant='h6'>{child.props.title}</Typography>
-                    <IconButton>
+                    <IconButton sx={{'@media print': {display: 'none'}}}>
                         {openedWidgets[i]? <ExpandLess /> : <ExpandMore />}
                     </IconButton>
                 </div>
                 {openedWidgets[i] && 
                     <>
-                        <hr/>
+                        <hr style={{pageBreakAfter: 'avoid'}}/>
                         <div style={{textAlign: 'left'}}>
                             {child}
                         </div>

--- a/packages/frontend/src/components/util.jsx
+++ b/packages/frontend/src/components/util.jsx
@@ -101,16 +101,14 @@ export const DetailExpander = ({children, title}) => {
 }
 
 export const DetailExpanderGroup = ({children, defaultSelectedIndex, allowMultiple=false}) => {
-    let isSingle = !Array.isArray(children) || children.length <= 1;
     const [openedWidgets, setOpenedWidgets] = useState([]);
 
     const groupRef = useRef(null);
 
-    if(isSingle) return <>{children}</>;
+    if(!Array.isArray(children) || children.length <= 1) return <>{children}</>;
 
     if(openedWidgets.length == 0) setOpenedWidgets(new Array(Array.isArray(children)? children.length : 0).fill(false));
 
-    console.log('not single', children, children.length, isSingle, Array.isArray(children), openedWidgets, );
     return <div ref={groupRef} className='detailExpanderGroup'>
         {children.map((child,i) => (
             <Paper
@@ -121,7 +119,6 @@ export const DetailExpanderGroup = ({children, defaultSelectedIndex, allowMultip
                     className='detailSection'
                     style={{display: 'flex', flexDirection: 'row', justifyContent: 'flexStart', cursor: 'pointer'}}
                     onClick={() => {
-                        console.log('on click', openedWidgets);
                         if(!openedWidgets[i]){
                             scrollToElement(groupRef.current.querySelectorAll(`.detailSection`)[i].parentNode);
                         }

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -372,9 +372,21 @@ code {
     0px 3px 14px 2px rgba(var(--brand-ltblue-comma), 0.24);
 }
 
-/* hide feedback button on mobile */
+/* hide feedback button on mobile and print*/
 @media(max-width: 900px){
   #launcher-frame{
     display: none;
   }
+}
+@media print{
+  #launcher-frame{
+    display: none;
+  }
+}
+
+@page {
+    margin-top: 0.75in;
+    margin-bottom: 0.75in;
+    margin-left: 0.75in;
+    margin-right: 0.75in;    
 }


### PR DESCRIPTION
## Description
When printing the results page this change hides any irrelevant details

NOTE: as shown in the video it's still possible for the results to break, but that can be fixed for now by changing the scaling of the print

## Screenshots / Videos (frontend only) 

https://github.com/Equal-Vote/star-server/assets/9289903/6005720a-04b2-4d3a-9ea8-2b5ea9668506

