### PR TITLE
Add extra step to catch more errors during PR

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,5 +27,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm i
-    - run: npm run build -w shared -w backend
+    - run: npm run build -ws
     - run: npm test


### PR DESCRIPTION
## Description

On my previous PR, the PR tests pass, but then it failed when running the deployment script. 

This PR adds another build script so the PR tests can catch more things

### Details

Previous deployment failure: https://github.com/Equal-Vote/star-server/actions/runs/8312718247/job/22747880307

Error when running locally: (looks like the PR was specifically missing errors on the frontend)

```
$ npm run build -ws

> shared@1.0.0 build
> tsc --project ./


> backend@1.0.0 build
> tsc --project ./


> star-vote@0.1.0 build
> tsc && vite build

src/components/Election/Results/STAR/STARResultSummaryWidget.tsx:69:13 - error TS2322: Type 'string' is not assignable to type 'number'.

69             votes: '', // this is making typescript unhappy, but it seems to work
               ~~~~~

  src/components/Election/Results/STAR/STARResultSummaryWidget.tsx:38:13
    38             votes: results.summaryData.totalScores[i].score,
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from property 'votes' which is declared here on type '{ name: string; index: number; votes: number; votesBig: number; }'


Found 1 error in src/components/Election/Results/STAR/STARResultSummaryWidget.tsx:69

npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed
npm ERR!   in workspace: star-vote@0.1.0
npm ERR!   at location: C:\w\star-server\packages\frontend
```