### PR TITLE
Admin settings

### DIFF
--- a/packages/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/packages/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -541,7 +541,7 @@ const AdminHome = () => {
                     <ElectionSettings />
                 </Grid>
                 <PreviewBallotSection election={election} permissions={permissions} />
-                {(election.settings.voter_access === 'closed' || election.state !== 'draft') && <>
+                {(election.settings.voter_access === 'closed') && <>
                     <Divider style={{ width: '100%' }} />
                     <VotersSection election={election} permissions={permissions} />
                 </>}

--- a/packages/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/packages/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -16,6 +16,7 @@ import ElectionSettings from '../../ElectionForm/ElectionSettings';
 import structuredClone from '@ungap/structured-clone';
 import useAuthSession from '../../AuthSessionContextProvider';
 import useFeatureFlags from '../../FeatureFlagContextProvider';
+import ElectionAuthForm from '~/components/ElectionForm/Details/ElectionAuthForm';
 const hasPermission = (permissions: string[], requiredPermission: string) => {
     return (permissions && permissions.includes(requiredPermission))
 }
@@ -528,6 +529,11 @@ const AdminHome = () => {
                 <Grid xs={12} sx={{ p: 1 }}>
                     <ElectionDetailsInlineForm />
                 </Grid>
+                {(election.settings.voter_access === 'open') && 
+                    <Grid xs={12} sx={{ p: 1 }}>
+                        <ElectionAuthForm />
+                    </Grid>
+                }
                 <Grid xs={12} sx={{ p: 1 }}>
                     <Races />
                 </Grid>

--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -83,7 +83,7 @@ const templateMappers = {
             ...election.settings,
             voter_authentication: {
                 ...election.settings.voter_authentication,
-                ip_address: true
+                voter_id: true
             },
         }
     }),
@@ -94,7 +94,7 @@ const templateMappers = {
             ...election.settings,
             voter_authentication: {
                 ...election.settings.voter_authentication,
-                ip_address: true
+                voter_id: true
             },
         }
     }),

--- a/packages/frontend/src/components/ElectionForm/Details/ElectionAuthForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Details/ElectionAuthForm.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { FormControl, FormControlLabel, FormLabel, Grid, Paper, Radio, Typography } from "@mui/material"
+import useElection from '../../ElectionContextProvider';
+
+export default function ElectionAuthForm() {
+
+    const { election, refreshElection, permissions, updateElection } = useElection()
+    const ip = election.settings.voter_authentication.ip_address == true
+    const device_id = election.settings.voter_authentication.voter_id == true
+    const email = election.settings.voter_authentication.email == true
+    const none = !(ip || device_id || email)
+
+    const handleUpdate = async (voter_authentication) => {
+        await updateElection(election => election.settings.voter_authentication = voter_authentication)
+        await refreshElection()
+    }
+
+    return (
+        <Paper elevation={3}>
+            <Grid container
+                sx={{
+                    m: 0,
+                    p: 1,
+                }}
+            >
+                <Grid xs={12}>
+                    <Typography gutterBottom variant="h4" component="h4">
+                        Voter Authentication
+                    </Typography>
+                </Grid>
+                <FormControl>
+                    <FormLabel id="demo-radio-buttons-group-label">Limit to one vote per...</FormLabel>
+                    <FormControlLabel value="female" control={
+                        <Radio
+                            disabled = {election.state !== 'draft'}
+                            checked={none}
+                            onChange={() => handleUpdate({})}
+                            value="none"
+                        />}
+                        label="No Limit" />
+                    <FormControlLabel value="female" control={
+                        <Radio
+                            disabled = {election.state !== 'draft'}
+                            checked={ip}
+                            onChange={() => handleUpdate({ ip_address: true })}
+                            value="ip"
+                        />}
+                        label="IP Address" />
+                    <FormControlLabel value="female" control={
+                        <Radio
+                            disabled = {election.state !== 'draft'}
+                            checked={device_id}
+                            onChange={() => handleUpdate({ voter_id: true })}
+                            value="device_id"
+                        />}
+                        label="Device" />
+
+                    <FormControlLabel value="female" control={
+                        <Radio
+                            disabled = {election.state !== 'draft'}
+                            checked={email}
+                            onChange={() => handleUpdate({ email: true })}
+                            value="email"
+                        />}
+                        label="Login Email Address" />
+                </FormControl>
+            </Grid>
+        </Paper>
+    )
+}

--- a/packages/frontend/src/components/ElectionForm/Details/ElectionAuthForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Details/ElectionAuthForm.tsx
@@ -16,8 +16,7 @@ export default function ElectionAuthForm() {
         await refreshElection()
     }
 
-    
-    const {t} = useSubstitutedTranslation('election');
+    const {t} = useSubstitutedTranslation(election.settings.term_type);
 
     return (
         <Paper elevation={3}>
@@ -34,7 +33,7 @@ export default function ElectionAuthForm() {
                 </Grid>
                 <FormControl>
                     <FormLabel id="demo-radio-buttons-group-label">{t('admin_home.voter_authentication.help_text')}</FormLabel>
-                    <FormControlLabel value="female" control={
+                    <FormControlLabel control={
                         <Radio
                             disabled = {election.state !== 'draft'}
                             checked={none}
@@ -42,7 +41,7 @@ export default function ElectionAuthForm() {
                             value="none"
                         />}
                         label={t('admin_home.voter_authentication.no_limit_label')} />
-                    <FormControlLabel value="female" control={
+                    <FormControlLabel control={
                         <Radio
                             disabled = {election.state !== 'draft'}
                             checked={ip}
@@ -50,7 +49,7 @@ export default function ElectionAuthForm() {
                             value="ip"
                         />}
                         label={t('admin_home.voter_authentication.ip_label')} />
-                    <FormControlLabel value="female" control={
+                    <FormControlLabel control={
                         <Radio
                             disabled = {election.state !== 'draft'}
                             checked={device_id}
@@ -59,7 +58,7 @@ export default function ElectionAuthForm() {
                         />}
                         label={t('admin_home.voter_authentication.device_label')} />
 
-                    <FormControlLabel value="female" control={
+                    <FormControlLabel control={
                         <Radio
                             disabled = {election.state !== 'draft'}
                             checked={email}

--- a/packages/frontend/src/components/ElectionForm/Details/ElectionAuthForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Details/ElectionAuthForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { FormControl, FormControlLabel, FormLabel, Grid, Paper, Radio, Typography } from "@mui/material"
 import useElection from '../../ElectionContextProvider';
+import { useSubstitutedTranslation } from '~/components/util';
 
 export default function ElectionAuthForm() {
 
@@ -15,6 +16,9 @@ export default function ElectionAuthForm() {
         await refreshElection()
     }
 
+    
+    const {t} = useSubstitutedTranslation('election');
+
     return (
         <Paper elevation={3}>
             <Grid container
@@ -25,11 +29,11 @@ export default function ElectionAuthForm() {
             >
                 <Grid xs={12}>
                     <Typography gutterBottom variant="h4" component="h4">
-                        Voter Authentication
+                        {t('admin_home.voter_authentication.form_label')}
                     </Typography>
                 </Grid>
                 <FormControl>
-                    <FormLabel id="demo-radio-buttons-group-label">Limit to one vote per...</FormLabel>
+                    <FormLabel id="demo-radio-buttons-group-label">{t('admin_home.voter_authentication.help_text')}</FormLabel>
                     <FormControlLabel value="female" control={
                         <Radio
                             disabled = {election.state !== 'draft'}
@@ -37,7 +41,7 @@ export default function ElectionAuthForm() {
                             onChange={() => handleUpdate({})}
                             value="none"
                         />}
-                        label="No Limit" />
+                        label={t('admin_home.voter_authentication.no_limit_label')} />
                     <FormControlLabel value="female" control={
                         <Radio
                             disabled = {election.state !== 'draft'}
@@ -45,7 +49,7 @@ export default function ElectionAuthForm() {
                             onChange={() => handleUpdate({ ip_address: true })}
                             value="ip"
                         />}
-                        label="IP Address" />
+                        label={t('admin_home.voter_authentication.ip_label')} />
                     <FormControlLabel value="female" control={
                         <Radio
                             disabled = {election.state !== 'draft'}
@@ -53,7 +57,7 @@ export default function ElectionAuthForm() {
                             onChange={() => handleUpdate({ voter_id: true })}
                             value="device_id"
                         />}
-                        label="Device" />
+                        label={t('admin_home.voter_authentication.device_label')} />
 
                     <FormControlLabel value="female" control={
                         <Radio
@@ -62,7 +66,7 @@ export default function ElectionAuthForm() {
                             onChange={() => handleUpdate({ email: true })}
                             value="email"
                         />}
-                        label="Login Email Address" />
+                        label={t('admin_home.voter_authentication.email_label')} />
                 </FormControl>
             </Grid>
         </Paper>

--- a/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -13,6 +13,7 @@ export default function ElectionSettings() {
     const { election, refreshElection, permissions, updateElection } = useElection()
 
     const [editedElectionSettings, setEditedElectionSettings] = useState(election.settings)
+    const [editedIsPublic, setEditedIsPublic] = useState(election.is_public)
 
     const applySettingsUpdate = (updateFunc: (settings) => any) => {
         const settingsCopy = structuredClone(editedElectionSettings)
@@ -33,6 +34,7 @@ export default function ElectionSettings() {
         if (!validatePage()) return
         const success = await updateElection(election => {
             election.settings = editedElectionSettings
+            election.is_public = editedIsPublic
         })
         if (!success) return false
         await refreshElection()
@@ -152,6 +154,19 @@ export default function ElectionSettings() {
                                 />
                                 <FormHelperText sx={{ pl: 4, mt: -1 }}>
                                     Requires voters to confirm that they have read ballot instructions in order to vote.
+                                </FormHelperText>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            id="publicly-searchable"
+                                            name="Publicly Searchable"
+                                            checked={editedIsPublic == true}
+                                            onChange={(e) => setEditedIsPublic(e.target.checked )}
+                                        />}
+                                    label="Publicly Searchable"
+                                />
+                                <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                    Allow election to be searchable in the public elections tab.
                                 </FormHelperText>
                             </FormGroup>
                         </FormControl>

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -173,7 +173,7 @@ election_home:
 admin_home:
   voter_authentication:
     form_label: Voter Authentication
-    help_text: Limit to one vote per...
+    help_text: Limit to one {{vote}} per...
     no_limit_label: No Limit
     ip_label: IP Address
     device_label: Device
@@ -409,12 +409,14 @@ keyword:
     candidates: Candidates
     race: Race
     ballot: Ballot
+    vote: vote
   poll:
     election: Poll
     candidate: Option
     candidates: Options
     race: Question
     ballot: Response
+    vote: response
 
   yes: Yes
   no: No

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -170,6 +170,14 @@ election_home:
   drafted: This election is still being drafted
   archived: This election has been archived
 
+admin_home:
+  voter_authentication:
+    form_label: Voter Authentication
+    help_text: Limit to one vote per...
+    no_limit_label: No Limit
+    ip_label: IP Address
+    device_label: Device
+    email_label: Login Email Address
 # Ballot
 ballot:
   this_election_uses: This election uses {{voting_method}}


### PR DESCRIPTION
## Description
Sets device id as default option when creating open access elections
Adds Voter Authentication form to admin page
Adds Publicly Searchable setting to settings form
Removes view voters button from open access elections

## Screenshots / Videos (frontend only) 
Voter Authentication form, only visible in open access elections
![image](https://github.com/user-attachments/assets/a1740fc1-2eab-4206-827c-4be58bf1bbef)

Publicly Searchable
![image](https://github.com/user-attachments/assets/27b1809d-85d3-4309-88db-f6494dd92016)

## Related Issues
closes #461 and #471 
closes #560 and #597