### PR TITLE
Adding race titles above candidates in ballot table

### DIFF
--- a/packages/frontend/src/components/Election/Admin/ViewBallots.tsx
+++ b/packages/frontend/src/components/Election/Admin/ViewBallots.tsx
@@ -71,7 +71,7 @@ const ViewBallots = () => {
                                 <TableRow >
                                     <TableCell colSpan={3}></TableCell>
                                     {election.races.map(race => (
-                                        <TableCell align='center' sx={{borderWidth: 1, borderColor: 'lightgray', borderStyle: 'solid'}}  colSpan={race.candidates.length}>
+                                        <TableCell align='center' sx={{borderWidth: 1, borderTopWidth: 0, borderColor: 'lightgray', borderStyle: 'solid'}}  colSpan={race.candidates.length}>
                                             {race.title}
                                         </TableCell>
                                     ))}

--- a/packages/frontend/src/components/Election/Admin/ViewBallots.tsx
+++ b/packages/frontend/src/components/Election/Admin/ViewBallots.tsx
@@ -68,6 +68,17 @@ const ViewBallots = () => {
                     <TableContainer component={Paper}>
                         <Table style={{ width: '100%' }} aria-label="simple table">
                             <TableHead>
+                                <TableRow >
+                                    <TableCell colSpan={3}></TableCell>
+                                    {election.races.map(race => (
+                                        <TableCell align='center' sx={{borderWidth: 1, borderColor: 'lightgray', borderStyle: 'solid'}}  colSpan={race.candidates.length}>
+                                            {race.title}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+
+                            </TableHead>
+                            <TableHead>
                                 <TableCell> Ballot ID </TableCell>
                                 {flags.isSet('VOTER_FLAGGING') &&
                                     <TableCell> Precinct </TableCell>


### PR DESCRIPTION
## Description
Putting the race titles in the candidate cells made the table too wide. This adds a row above candidates with the race titles, races span multiple columns. The default MUI tables don't have cell borders so I added borders to the races to make it clear, but I don't really like how it looks. Maybe ok for now.

## Screenshots / Videos (frontend only) 

![image](https://github.com/user-attachments/assets/4670fa31-362e-4b58-a7e2-5626160790ad)


![image](https://github.com/user-attachments/assets/fb2bd47f-81a5-4149-ad5b-20cd0d38779e)


## Related Issues

closes #562