### PR TITLE
Center the header

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -75,9 +75,9 @@ const Header = () => {
 
     return (
         <AppBar className="navbar" position="sticky" sx={{ backgroundColor: "black", '@media print': {display: 'none', boxShadow: 'none'}}}>
-            <Toolbar>
+            <Toolbar sx={{justifyContent: 'space-between'}}>
                 {/**** MOBILE HAMBURGER MENU ****/}
-                <Box sx={{ flexGrow: 0, display: { xs: 'flex', md: 'none' } }}>
+                <Box sx={{ flexGrow: 0, display: { xs: 'flex', lg: 'none' } }}>
                     <IconButton
                         size="large"
                         aria-label="nav-menu"
@@ -102,7 +102,7 @@ const Header = () => {
                         open={Boolean(anchorElNav)}
                         onClose={handleCloseNavMenu}
                         sx={{
-                            display: { xs: 'block', md: 'none' },
+                            display: { xs: 'block', lg: 'none' },
                         }}
                     >
                         {navItems.map((item, i) => 
@@ -124,17 +124,9 @@ const Header = () => {
                     </Menu>
                 </Box>
 
-                {/**** Title ****/}
-                <IconButton
-                    size="large"
-                    href="/"
-                    sx={{display: 'flex', gap: 1, flexGrow: {xs: '1', md: '0'}}}>
-                        <Avatar src='/favicon-local.png'/>
-                </IconButton>
-
                 {/**** DESKTOP OPTIONS ****/}
                 <Box
-                    sx={{ flexGrow: 100, flexWrap: 'wrap', display: { xs: 'none', md: 'flex' }, gap: 2, rowGap: 0 }}>
+                    sx={{ flexGrow: 100, flexWrap: 'wrap', display: { xs: 'none', lg: 'flex' }, gap: 2, rowGap: 0 }}>
                     {navItems.map((item, i) => 
                         <Button key={`desktop-nav-${i}`} href={item.href} target={item.target}>
                             <Typography sx={navTextSx} color={headerTextColor}>
@@ -153,7 +145,7 @@ const Header = () => {
                 {/**** ACCOUNT OPTIONS ****/}
                 <Box sx={{ flexGrow: 0, display: 'flex' }}>
                     {authSession.isLoggedIn() && <>
-                        <Button color='inherit' onClick={() => createElectionContext.openDialog()} sx={{display: { xs: 'none', md: 'flex' }}}>
+                        <Button color='inherit' onClick={() => createElectionContext.openDialog()} sx={{display: { xs: 'none', lg: 'flex' }}}>
                             <Typography sx={navTextSx} color={headerTextColor}>
                                 {t('nav.new_election')}
                             </Typography>
@@ -165,11 +157,11 @@ const Header = () => {
                             aria-haspopup="true"
                             onClick={handleOpenUserMenu}
                             color="inherit"
-                            sx={{display: { xs: 'inline', md: 'none' }}}
+                            sx={{display: { xs: 'inline', lg: 'none' }}}
                             >
                             <AccountCircleIcon />
                         </IconButton>
-                        <Button color='inherit' onClick={handleOpenUserMenu} sx={{display: { xs: 'none', md: 'flex' }}}>
+                        <Button color='inherit' onClick={handleOpenUserMenu} sx={{display: { xs: 'none', lg: 'flex' }}}>
                             <Typography sx={navTextSx} color={headerTextColor}>
                                 {t('nav.greeting', {name: authSession.getIdField('given_name')})}
                             </Typography>
@@ -249,8 +241,15 @@ const Header = () => {
                         </Button>
                     }
                 </Box>
-
             </Toolbar>
+            {/**** Title ****/}
+            {/* Pull title outside of the flexbox toolbar so that it can be centered relative to the screen */}
+            <IconButton
+                size="large"
+                href="/"
+                sx={{position: 'fixed', width: '100%', margin: 'auto', pointerEvents: 'none' }}>
+                    <Avatar src='/favicon-local.png' sx={{pointerEvents: 'auto' }}/>
+            </IconButton>
         </AppBar >
     )
 }

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -124,6 +124,14 @@ const Header = () => {
                     </Menu>
                 </Box>
 
+                {/**** Desktop Title Icon ****/}
+                <IconButton
+                    size="large"
+                    href="/"
+                    sx={{display: {xs: 'none', lg: 'block'},  flexGrow: {xs: '1', md: '0'}}}>
+                        <Avatar src='/favicon-local.png'/>
+                </IconButton>
+
                 {/**** DESKTOP OPTIONS ****/}
                 <Box
                     sx={{ flexGrow: 100, flexWrap: 'wrap', display: { xs: 'none', lg: 'flex' }, gap: 2, rowGap: 0 }}>
@@ -247,8 +255,9 @@ const Header = () => {
             <IconButton
                 size="large"
                 href="/"
-                sx={{position: 'fixed', width: '100%', margin: 'auto', pointerEvents: 'none' }}>
-                    <Avatar src='/favicon-local.png' sx={{pointerEvents: 'auto' }}/>
+                sx={{display: {xs: 'inline-flex', lg: 'none'}, position: 'fixed', width: '100%', pointerEvents: 'none' }}
+            >
+                <Avatar src='/favicon-local.png' sx={{pointerEvents: 'auto' }}/>
             </IconButton>
         </AppBar >
     )

--- a/packages/frontend/src/components/LandingPage/LandingPageFeatures.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageFeatures.tsx
@@ -40,7 +40,7 @@ export default () => {
                     gap: '3rem',
                     backgroundColor: 'brand.gray1',
                 }}>
-                    {panels.map((panel, i) => <Box key={i}><FadeUp delay={`${i*100}ms`}><Box sx={{width: '380px'}}>
+                    {panels.map((panel, i) => <Box key={i}><FadeUp delay={`${i*100}ms`}><Box sx={{width: {xs: '100%', md: '380px'}}}>
                         <Typography variant='h4'>{panel.title}</Typography>
                         <Typography component='p'>{panel.text}</Typography>
                     </Box></FadeUp></Box>)}

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -2,7 +2,7 @@
 nav:
   about: About 
   help: Help 
-  public_elections: Public Elections
+  public_elections: Browse Elections
   new_election: New Election
   greeting: Hello, {{name}}
   feedback: Feedback?


### PR DESCRIPTION
## Description
The logo is now in the center of the screen (previously it was centered between the left/right elements)

## Screenshots / Videos (frontend only) 

![image](https://github.com/user-attachments/assets/769483d5-c47f-4a8e-9d1d-9d1fa584c5c5)