### PR TITLE
Adding "Last Updated" to election tables and fixing table date bugs

### DIFF
--- a/packages/frontend/src/components/Elections/ElectionsYouManage.tsx
+++ b/packages/frontend/src/components/Elections/ElectionsYouManage.tsx
@@ -47,12 +47,12 @@ export default () => {
             
     return <EnhancedTable
         title='My Elections & Polls'
-        headKeys={['title', 'roles', 'election_state', 'start_time', 'end_time', 'description']}
+        headKeys={['title', 'update_date', 'roles', 'election_state', 'start_time', 'end_time', 'description']}
         isPending={isPending}
         pendingMessage='Loading Elections...'
         data={managedElectionsData}
         handleOnClick={(row) => navigate(`/${String(row.raw.election_id)}`)}
-        defaultSortBy='title'
+        defaultSortBy='update_date'
         emptyContent={<>"You don't have any elections yet"<button>Create Election</button></>}
     />
 }

--- a/packages/frontend/src/components/Elections/ElectionsYouVotedIn.tsx
+++ b/packages/frontend/src/components/Elections/ElectionsYouVotedIn.tsx
@@ -17,12 +17,12 @@ export default () => {
             
     return <EnhancedTable
         title='Elections You Voted In'
-        headKeys={['title', 'election_state', 'start_time', 'end_time', 'description']}
+        headKeys={['title', 'update_date', 'election_state', 'start_time', 'end_time', 'description']}
         handleOnClick={(election) => navigate(`/${String(election.election_id)}`)}
         isPending={isPending}
         pendingMessage='Loading Elections...'
         data={electionInvitations}
-        defaultSortBy='title'
+        defaultSortBy='update_date'
         emptyContent="You haven't voted in any elections"
     />
 }

--- a/packages/frontend/src/components/Elections/OpenElections.tsx
+++ b/packages/frontend/src/components/Elections/OpenElections.tsx
@@ -17,12 +17,12 @@ export default () => {
 
     return <EnhancedTable
         title='Open Elections'
-        headKeys={['title', 'start_time', 'end_time', 'description']}
+        headKeys={[ 'title', 'update_date', 'start_time', 'end_time', 'description']}
         data={openElectionsData}
         isPending={isPending}
         pendingMessage='Loading Elections...'
         handleOnClick={(election) => navigate(`/${String(election.raw.election_id)}`)}
-        defaultSortBy='title'
+        defaultSortBy='update_date'
         emptyContent='No Election Invitations'
     />
 }

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -628,7 +628,7 @@ export const formatDate = (time, displayTimezone = null) => {
 
   return DateTime.fromJSDate(new Date(time))
     .setZone(displayTimezone)
-    .toLocaleString(DateTime.DATETIME_FULL);
+    .toLocaleString(DateTime.DATETIME_MED);
 };
 
 export const isValidDate = (d) => {
@@ -636,3 +636,7 @@ export const isValidDate = (d) => {
   if (typeof d === "string") return !isNaN(new Date(d).valueOf());
   return false;
 };
+
+export const getLocalTimeZoneShort = () => {
+  return DateTime.local().offsetNameShort
+}


### PR DESCRIPTION
## Description
Adds the "update_date" election field and adds it to the election tables and makes it the default sort method. 
Adds local time zones to table header.
Fixes a bug with date formatting. It was trying to pass the entire election object into the formatter as the time zone which was making all dates "Invalid Datetime".
Temporarily fixes bug with date sorting. The table sorting function sorts based on already formatted data, so dates were sorting by their string version which led to many issues. Now the comparator function is passed a isDate parameter that tells the comparator to convert back to dates and then to integers. I hate this solution and myself for implementing it, but it works until I fix the table to sort and then format data. 

## Screenshots / Videos (frontend only) 

![image](https://github.com/user-attachments/assets/abc0aec9-aa75-4ae9-92b7-e351238536a0)
