### PR TITLE
Fixing links in footer, disabled random candidate order as default

### DIFF
--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -64,7 +64,7 @@ const defaultElection: NewElection = {
         ballot_updates: false,
         public_results: true,
         time_zone: DateTime.now().zone.name,
-        random_candidate_order: true,
+        random_candidate_order: false,
         require_instruction_confirmation: true,
         invitation: undefined,
         // election_term, and voter_access are intentially omitted

--- a/packages/frontend/src/components/ElectionForm/QuickPoll.tsx
+++ b/packages/frontend/src/components/ElectionForm/QuickPoll.tsx
@@ -66,7 +66,7 @@ const QuickPoll = ({ authSession, methodName, methodKey, grow }) => {
             },
             ballot_updates: false,
             public_results: true,
-            random_candidate_order: true,
+            random_candidate_order: false,
             require_instruction_confirmation: true,
         }
     }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -138,7 +138,7 @@ footer:
     for polling, surveys, and real elections at any scale and for any scenario.
 
 
-    [starvoting.org](https://www.starvoting.org) | [http://www.equal.vote](equal.vote) | [elections@equal.vote](mailto:elections@equal.vote)
+    [starvoting.org](https://www.starvoting.org) | [equal.vote](http://www.equal.vote) | [elections@equal.vote](mailto:elections@equal.vote)
   # TODO: I'll add this section to project description once we have those features in place
   # All of our voting methods can be used for single winner, multi-winner, or 
   # proportional representation elections with either paper or digital ballots.
@@ -148,7 +148,7 @@ footer:
     Our mission is to fight for true equality in the vote itself.
 
 
-    [Donations](equal.vote/donate) are the best way to support our work. All proceeds from
+    [Donations](https://www.equal.vote/donate) are the best way to support our work. All proceeds from
     dev.star.vote go directly to helping fund and support the adoption and use of STAR Voting.
 
 


### PR DESCRIPTION
## Description
Fixes links in footer. When using links in en.yaml, the url has to include "http://www.", otherwise it sees it as page on the current site. 

Another note, it doesn't look like its possible to insert a target="_blank" in the yaml file to open the page in a new tab. We should figure out a workaround at some point.

Edit: 
Turning off random candidate order by default

## Screenshots / Videos (frontend only) 

## Related Issues

closes #610
closes #621 