### PR TITLE
Admin can now set rank limits in ranked ballots

### DIFF
--- a/packages/frontend/src/components/Election/Voting/RankedBallotView.jsx
+++ b/packages/frontend/src/components/Election/Voting/RankedBallotView.jsx
@@ -1,8 +1,9 @@
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import Typography from '@mui/material/Typography';
 import { BallotContext } from "./VotePage";
 import GenericBallotView from "./GenericBallotView";
 import { useSubstitutedTranslation } from "~/components/util";
+import { min } from "date-fns";
 
 function scoresAreOverVote({scores}){
   let uniqueScores = new Set();
@@ -33,8 +34,19 @@ export default function RankedBallotView({onlyGrid=false}) {
 
 
   const { t } = useSubstitutedTranslation();
-  let columnValues = ballotContext.candidates.slice(0, ballotContext.maxRankings).map((c, i) => i+1)
-  let columns = columnValues.map(v => t('number.rank', {count: v, ordinal: true}))
+  const maxRankings = useMemo(() => {
+    if (ballotContext.maxRankings) {
+      return min(ballotContext.maxRankings, Number(process.env.REACT_APP_MAX_BALLOT_RANKS));
+    } else {
+      return Number(process.env.REACT_APP_MAX_BALLOT_RANKS);
+    }
+  }, [ballotContext.maxRankings]);
+  const columnValues = useMemo (() => { 
+    return ballotContext.candidates.slice(0, maxRankings).map((c, i) => i+1)
+  }, [ballotContext.candidates, maxRankings]);
+  const columns = useMemo (() => {
+    return columnValues.map(v => t('number.rank', {count: v, ordinal: true}))
+}, [columnValues, t]);
     return (
     <GenericBallotView
       key="rankedBallot"

--- a/packages/frontend/src/components/Election/Voting/RankedBallotView.jsx
+++ b/packages/frontend/src/components/Election/Voting/RankedBallotView.jsx
@@ -33,11 +33,9 @@ export default function RankedBallotView({onlyGrid=false}) {
 
 
   const { t } = useSubstitutedTranslation();
-  
   let columnValues = ballotContext.candidates.slice(0, ballotContext.maxRankings).map((c, i) => i+1)
   let columns = columnValues.map(v => t('number.rank', {count: v, ordinal: true}))
-  debugger;
-  return (
+    return (
     <GenericBallotView
       key="rankedBallot"
       methodKey={

--- a/packages/frontend/src/components/Election/Voting/RankedBallotView.jsx
+++ b/packages/frontend/src/components/Election/Voting/RankedBallotView.jsx
@@ -33,10 +33,10 @@ export default function RankedBallotView({onlyGrid=false}) {
 
 
   const { t } = useSubstitutedTranslation();
-
-  let columnValues = ballotContext.candidates.slice(0, Number(process.env.REACT_APP_MAX_BALLOT_RANKS??999999)).map((c, i) => i+1)
+  
+  let columnValues = ballotContext.candidates.slice(0, ballotContext.maxRankings).map((c, i) => i+1)
   let columns = columnValues.map(v => t('number.rank', {count: v, ordinal: true}))
-
+  debugger;
   return (
     <GenericBallotView
       key="rankedBallot"

--- a/packages/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/packages/frontend/src/components/Election/Voting/VotePage.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from "react"
+import { createContext, useMemo, useState } from "react"
 import BallotPageSelector from "./BallotPageSelector";
 import { useParams } from "react-router";
 import React from 'react'
@@ -39,6 +39,7 @@ export interface IBallotContext {
   onUpdate: (any) => void,
   receiptEmail: receiptEmail,
   setReceiptEmail: React.Dispatch<receiptEmail>
+  maxRankings: number,
 }
 
 export const BallotContext = createContext<IBallotContext>(null);
@@ -87,6 +88,10 @@ const VotePage = () => {
     // shallow copy to trigger a refresh
     setPages([...pages])
   }
+  const maxRankings = useMemo(() => {
+    return election.settings.max_rankings == 0 ? Number(process.env.REACT_APP_DEFAULT_MAX_RANKINGS??999) : election.settings.max_rankings
+  }, [election.settings.max_rankings])
+
   const [isOpen, setIsOpen] = useState(false)
 
   const { data, isPending, error, makeRequest: postBallot } = usePostBallot(election.election_id)
@@ -143,7 +148,8 @@ const VotePage = () => {
         race: election.races[currentPage],
         onUpdate: newRankings => onUpdate(currentPage, newRankings),
         receiptEmail: receiptEmail,
-        setReceiptEmail: setReceiptEmail
+        setReceiptEmail: setReceiptEmail,
+        maxRankings: maxRankings
       }}>
         <BallotPageSelector votingMethod={pages[currentPage].voting_method} />
       </BallotContext.Provider>

--- a/packages/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/packages/frontend/src/components/Election/Voting/VotePage.tsx
@@ -39,7 +39,7 @@ export interface IBallotContext {
   onUpdate: (any) => void,
   receiptEmail: receiptEmail,
   setReceiptEmail: React.Dispatch<receiptEmail>
-  maxRankings: number,
+  maxRankings?: number,
 }
 
 export const BallotContext = createContext<IBallotContext>(null);
@@ -88,11 +88,6 @@ const VotePage = () => {
     // shallow copy to trigger a refresh
     setPages([...pages])
   }
-  const maxRankings = useMemo(() => {
-    debugger;
-    return election.settings.max_rankings ? election.settings.max_rankings : Number(process.env.REACT_APP_MAX_BALLOT_RANKS??999)
-  }, [election.settings.max_rankings])
-
   const [isOpen, setIsOpen] = useState(false)
 
   const { data, isPending, error, makeRequest: postBallot } = usePostBallot(election.election_id)
@@ -150,7 +145,7 @@ const VotePage = () => {
         onUpdate: newRankings => onUpdate(currentPage, newRankings),
         receiptEmail: receiptEmail,
         setReceiptEmail: setReceiptEmail,
-        maxRankings: maxRankings
+        maxRankings: election.settings.max_rankings
       }}>
         <BallotPageSelector votingMethod={pages[currentPage].voting_method} />
       </BallotContext.Provider>

--- a/packages/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/packages/frontend/src/components/Election/Voting/VotePage.tsx
@@ -89,7 +89,7 @@ const VotePage = () => {
     setPages([...pages])
   }
   const maxRankings = useMemo(() => {
-    return election.settings.max_rankings == 0 ? Number(process.env.REACT_APP_DEFAULT_MAX_RANKINGS??999) : election.settings.max_rankings
+    return election.settings.max_rankings ? election.settings.max_rankings : Number(process.env.REACT_APP_DEFAULT_MAX_RANKINGS??999)
   }, [election.settings.max_rankings])
 
   const [isOpen, setIsOpen] = useState(false)

--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -67,6 +67,7 @@ const defaultElection: NewElection = {
         random_candidate_order: false,
         require_instruction_confirmation: true,
         invitation: undefined,
+        max_rankings: 0
         // election_term, and voter_access are intentially omitted
         // this let's me start them at undefined for the stepper
     }

--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -67,7 +67,6 @@ const defaultElection: NewElection = {
         random_candidate_order: false,
         require_instruction_confirmation: true,
         invitation: undefined,
-        max_rankings: 0
         // election_term, and voter_access are intentially omitted
         // this let's me start them at undefined for the stepper
     }

--- a/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -3,7 +3,7 @@ import Grid from "@mui/material/Grid";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 import Typography from '@mui/material/Typography';
-import { Checkbox, FormGroup, FormHelperText, FormLabel, InputLabel, Radio, RadioGroup, Tooltip, Dialog, DialogActions, DialogContent, DialogTitle, Paper, Box, IconButton } from "@mui/material"
+import { Checkbox, FormGroup, FormHelperText, FormLabel, InputLabel, Radio, RadioGroup, Tooltip, Dialog, DialogActions, DialogContent, DialogTitle, Paper, Box, IconButton, TextField } from "@mui/material"
 import { StyledButton } from '../styles';
 import useElection, { ElectionContext } from '../ElectionContextProvider';
 import structuredClone from '@ungap/structured-clone';
@@ -168,6 +168,30 @@ export default function ElectionSettings() {
                                 <FormHelperText sx={{ pl: 4, mt: -1 }}>
                                     Allow election to be searchable in the public elections tab.
                                 </FormHelperText>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            id="rank-limit"
+                                            name="Rank Limit"
+                                            checked={editedElectionSettings.max_rankings != 0}
+                                            onChange={(e) => applySettingsUpdate(settings => { settings.max_rankings = e.target.checked ? 3 : 0 })}
+                                        />
+
+                                    }
+                                    label="Rank Limit"
+                                />
+                                <FormHelperText sx={{ pl: 4, mt: -1 }}>
+                                    Set a maximum number of rankings for ranked voting. (Must be between 3 and 8)
+                                </FormHelperText>
+                                <TextField
+                                            id="rank-limit"
+                                            type="number"
+                                            value={editedElectionSettings.max_rankings == 0 ? '' : editedElectionSettings.max_rankings}
+                                            onChange={(e) => applySettingsUpdate(settings => { settings.max_rankings = e.target.value })}
+                                            variant='standard'
+                                            InputProps={{ inputProps: { min: 3, max: 8 } }}
+                                            sx={{ pl: 4, mt: -1, display: editedElectionSettings.max_rankings == 0 ? 'none' : 'block' }}
+                                        />
                             </FormGroup>
                         </FormControl>
                     </Grid >

--- a/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -173,8 +173,8 @@ export default function ElectionSettings() {
                                         <Checkbox
                                             id="rank-limit"
                                             name="Rank Limit"
-                                            checked={editedElectionSettings.max_rankings != 0}
-                                            onChange={(e) => applySettingsUpdate(settings => { settings.max_rankings = e.target.checked ? 3 : 0 })}
+                                            checked={!!editedElectionSettings.max_rankings}
+                                            onChange={(e) => applySettingsUpdate(settings => { settings.max_rankings = e.target.checked ? 3 : undefined })}
                                         />
 
                                     }
@@ -186,11 +186,11 @@ export default function ElectionSettings() {
                                 <TextField
                                             id="rank-limit"
                                             type="number"
-                                            value={editedElectionSettings.max_rankings == 0 ? '' : editedElectionSettings.max_rankings}
+                                            value={editedElectionSettings.max_rankings ? editedElectionSettings.max_rankings : null}
                                             onChange={(e) => applySettingsUpdate(settings => { settings.max_rankings = e.target.value })}
                                             variant='standard'
                                             InputProps={{ inputProps: { min: 3, max: 8 } }}
-                                            sx={{ pl: 4, mt: -1, display: editedElectionSettings.max_rankings == 0 ? 'none' : 'block' }}
+                                            sx={{ pl: 4, mt: -1, display: editedElectionSettings.max_rankings ? 'block' : 'none' }}
                                         />
                             </FormGroup>
                         </FormControl>

--- a/packages/frontend/src/components/LandingPage/LandingPageHero.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageHero.tsx
@@ -20,6 +20,7 @@ import { useSubstitutedTranslation } from '../util'
 import { useTranslation } from 'react-i18next'
 import { CreateElectionContext } from '../ElectionForm/CreateElectionDialog'
 import { Button } from '@mui/material'
+import { max } from 'date-fns'
 
 export default ({}) => {
     const authSession = useAuthSession();
@@ -96,7 +97,8 @@ export default ({}) => {
                 email: ''
             },
             setReceiptEmail: () => {},
-            onUpdate: onUpdate
+            onUpdate: onUpdate,
+            maxRankings: Number(process.env.REACT_APP_MAX_BALLOT_RANKS)
         }
     }
 

--- a/packages/frontend/src/components/LandingPage/LandingPageHero.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageHero.tsx
@@ -98,7 +98,7 @@ export default ({}) => {
             },
             setReceiptEmail: () => {},
             onUpdate: onUpdate,
-            maxRankings: Number(process.env.REACT_APP_MAX_BALLOT_RANKS)
+            maxRankings: undefined
         }
     }
 

--- a/packages/shared/src/domain_model/ElectionSettings.ts
+++ b/packages/shared/src/domain_model/ElectionSettings.ts
@@ -28,4 +28,5 @@ export interface ElectionSettings {
     require_instruction_confirmation?: boolean; // Require voter to confirm that they've read the instructions in order to vote
     break_ties_randomly?: boolean; // whether true ties should be broken randomly
     term_type?: TermType; // whether poll or election should be used as the term
+    max_rankings?: number; // maximum rank limit for ranked choice voting
 }


### PR DESCRIPTION
## Description
Admins have the option of limiting the amount of ranks on a ranked ballot to a number between 3 and 8. If no option is selected, the MAX_BALLOT_RANKS environment variable will be used instead

## Screenshots / Videos (frontend only) 

https://github.com/user-attachments/assets/4ce376e9-9821-43fe-96b0-e4e69da03fa5


## Related Issues

to close issue #645 