### PR TITLE
Issue #634 differentiate between test ballots and real ballots

### DIFF
--- a/packages/frontend/src/components/Election/Admin/ViewBallots.tsx
+++ b/packages/frontend/src/components/Election/Admin/ViewBallots.tsx
@@ -11,7 +11,7 @@ import { useGetBallots } from "../../../hooks/useAPI";
 import { epochToDateString, getLocalTimeZoneShort, useSubstitutedTranslation } from "../../util";
 import useElection from "../../ElectionContextProvider";
 import useFeatureFlags from "../../FeatureFlagContextProvider";
-import { use } from "i18next";
+import DraftWarning from "../DraftWarning";
 
 const ViewBallots = () => {
     const { election } = useElection()
@@ -71,6 +71,7 @@ const ViewBallots = () => {
     }
     return (
         <Container>
+            <DraftWarning />
             <Typography align='center' gutterBottom variant="h4" component="h4">
                 {election.title}
             </Typography>


### PR DESCRIPTION
## Description

The simplest solution seemed to just add the DraftWarning component to indicate that these are test ballots. 

## Screenshots / Videos (frontend only)

![image](https://github.com/user-attachments/assets/69f1b430-24ef-46e3-9f01-b200a5773f33)


## Related Issues

> to close issue #634