### PR TITLE
Adding Basic STAR PR widgets

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -455,6 +455,12 @@ results:
       - Ties are 10 times less likely to occur with STAR Voting than with Choose-One Voting and generally resolve as the number of voters increases.
     equal_preferences_title: Distribution of Equal Preferences
     equal_preferences: Equal Preferences
+  star_pr:
+    chart_title: Round Results
+    table_title: Results Table
+    table_columns:
+      - '{{candidate}}'
+    round_column: Round {{n}}
 
 # Tabulation Logs
 tabulation_logs:

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -87,7 +87,8 @@ code {
   border: 1px solid black;
 }
 
-.resultTable tr:nth-child(1) > td{
+
+.starScoreTable tr:nth-child(1) > td{
   background: var(--brand-gold);
 }
 
@@ -98,8 +99,18 @@ code {
 .starRunoffTable tr:nth-child(3) > td{
   background: var(--brand-gray-1);
 }
+
 .starRunoffTable tr:nth-child(4) > td{
   background: var(--brand-gray-2);
+}
+
+
+.approvalTable tr:nth-child(1) > td{
+  background: var(--brand-gold);
+}
+
+.chooseOneTable tr:nth-child(1) > td{
+  background: var(--brand-gold);
 }
 
 .login-form {


### PR DESCRIPTION
## Description
Adds widgets for STAR PR using existing components.
First widget is a round by round bar chart with a pagination button to navigate rounds.
Second widget is a basic table showing all the round scores. 

This doesn't do any special highlighting because the existing components don't work for multi winner highlighting. 

## Screenshots / Videos (frontend only) 

![image](https://github.com/user-attachments/assets/fad3ca2d-3a9c-4e02-b1ff-02f8d77884bc)

