### PR TITLE
Add <1% and include all rcv runoff candidates

### DIFF
--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -125,7 +125,7 @@ function IRVResultsViewer({ results, t }: {results: irvResults, t: Function}) {
   const runoffData = results.voteCounts.slice(-1)[0]
     .map((c,i) => ({name: results.summaryData.candidates[i].name, votes: c}))
     .sort((a, b) => b.votes - a.votes)
-    .slice(0, 2)
+    .filter(a => a.votes != 0) // filter out eliminated candidates
     .concat([{
       name: t('results.rcv.exhausted'),
       votes: results.exhaustedVoteCounts.slice(-1)[0]

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -209,12 +209,13 @@ export const ResultsBarChart = ({
   percentDenominator ??= data.reduce((sum, d) => sum + d[xKey], 0);
   percentDenominator = Math.max(1, percentDenominator);
   data = rawData.map((d, i) => {
+    let percentValue = Math.round((100 * d[xKey]) / percentDenominator);
     let s = {
       ...d,
       name: (star && i == 0 ? "⭐" : "") + truncName(d["name"], 40),
       // hack to get smaller values to allign different than larger ones
       left: percentage
-        ? `${Math.round((100 * d[xKey]) / percentDenominator)}%`
+        ? ((percentValue == 0 && d[xKey] > 0) ? '<1%' : `${Math.round((100 * d[xKey]) / percentDenominator)}%`)
         : Math.round(d[xKey]*100)/100,
       right: "",
     };
@@ -243,13 +244,14 @@ export const ResultsBarChart = ({
   for (let i = 0; i < colorOffset; i++) {
     colors.push(colors.shift());
   }
-  if (runoff) {
-    colors = colors.slice(0, 2).concat(["var(--brand-gray-1)"]);
-  }
 
   // Add majority
   if (majorityLegend || majorityOffset) {
-    let m = (data[0][xKey] + data[1][xKey]) / 2;
+    let sum = data.reduce((prev, d, i) => {
+      if(i == data.length-1) return prev; // don't include exhausted or equal preference votes in the denominator
+      return prev + d[xKey];
+    }, 0);
+    let m = sum / 2;
     data = data.map((d, i) => {
       let s = { ...d };
       s[majorityLegend] = i < 2 ? m : null;
@@ -317,7 +319,7 @@ export const ResultsBarChart = ({
             <LabelList dataKey="right" position="insideLeft" fill="black" />
           </>}
           {data.map((entry, index) => (
-            <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
+            <Cell key={`cell-${index}`} fill={(runoff && index == data.length-1)? 'var(--brand-gray-1)' : colors[index % colors.length]} />
           ))}
         </Bar>
         <Line


### PR DESCRIPTION
## Description

Here's the new final runoff graph for RCV. 

![image](https://github.com/user-attachments/assets/fad34b58-dfb6-4bf2-8426-7e6d179156be)

RCV continues to eliminate candidates until one of them has a relative majority. Previously it would only handle cases where there were 2 candidates in the final round, but now it can handle any number of candidates

Also add the <1% to make it more clear whether candidates were being rounded to 0%.

## Related Issues

fixes #701
fixes #702 