### PR TITLE
10 21 decrease gaps between elements in the landing pages

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -22,7 +22,7 @@
     <link rel="manifest" href="/manifest.json" />
     <!-- Importing for ballot bubble font-->
     <link href='https://fonts.googleapis.com/css?family=Archivo Black' rel='stylesheet'>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito Sans:ital,wght@0,400;0,700;1,400;1,700&family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
     <!--
       Notice the use of  in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -22,6 +22,7 @@
     <link rel="manifest" href="/manifest.json" />
     <!-- Importing for ballot bubble font-->
     <link href='https://fonts.googleapis.com/css?family=Archivo Black' rel='stylesheet'>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito Sans:ital,wght@0,400;0,700;1,400;1,700&family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <!--
       Notice the use of  in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -49,7 +49,7 @@ const LandingPage = () => {
             width: '100%',
             display: 'flex',
             flexDirection: 'column',
-            gap: '1rem',
+            gap: '2rem',
             margin: 'auto',
         }}>
             <Box sx={{position:'absolute', top: '95vh', width: '100%', textAlign: 'center'}}>

--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -49,11 +49,8 @@ const LandingPage = () => {
             width: '100%',
             display: 'flex',
             flexDirection: 'column',
-            gap: '20rem',
-            minHeight: '600px',
+            gap: '1rem',
             margin: 'auto',
-            paddingTop: '8rem',
-            paddingBottom: '8rem',
         }}>
             <Box sx={{position:'absolute', top: '95vh', width: '100%', textAlign: 'center'}}>
                 <KeyboardArrowDownRoundedIcon sx={{

--- a/packages/frontend/src/components/LandingPage/LandingPageHero.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageHero.tsx
@@ -112,8 +112,6 @@ export default ({}) => {
             <Box display='flex' flexDirection='column' sx={{
                 alignItems: 'center',
                 textAlign: 'center',
-                width: {xs: '100%', md: '600px'}, // not the same ax maxWidth 600px!, we want to make sure the carousel doesn't effect size on larger screens
-                minHeight: '600px'
             }}>
                 <Typography variant="h4" color={'lightShade.contrastText'}> {t('landing_page.hero.title')} </Typography>
                 <Box width='90%' display='flex' flexDirection='row' justifyContent='space-between' sx={{alignItems: 'center', paddingBottom: 3}}>

--- a/packages/frontend/src/components/LandingPage/LandingPagePricing.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPagePricing.tsx
@@ -39,7 +39,6 @@ export default () => {
                     <FadeUp key={i} delay={`${200+i*300}ms`}>
                         <Paper key={i} className='pricingOption' elevation={8} sx={{
                             width: '100%',
-                            maxWidth: '25rem',
                             display: 'flex',
                             flexDirection: 'column',
                             flexShrink: '0',

--- a/packages/frontend/src/components/LandingPage/LandingPageStats.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageStats.tsx
@@ -49,7 +49,7 @@ export default () => {
             margin: 'auto',
             width: '100%',
             maxWidth: '1300px',
-            gap: '10rem',
+            gap: '2rem',
             justifyContent: 'center',
         }}
         ref={containerRef}

--- a/packages/frontend/src/components/LandingPage/LandingPageTestimonials.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageTestimonials.tsx
@@ -36,8 +36,8 @@ export default () => {
                     backgroundImage: `url(${testimonial.image_url})`,
                     backgroundSize: 'cover',
                     borderRadius: '100%',
-                    width: '10rem',
-                    height: '10rem',
+                    width: '2rem',
+                    height: '2rem',
                     margin: 'auto',
                 }}/>
                 <Typography variant='h5' color={'darkShade.contrastText'} sx={{textAlign: 'center'}}>

--- a/packages/frontend/src/theme.tsx
+++ b/packages/frontend/src/theme.tsx
@@ -157,15 +157,15 @@ const brandPalette: PaletteOptions = {
 }
 
 const brandTypography: TypographyOptions = {
-  fontFamily: '"Nunito Sans", sans-serif',
-  button: {
-    fontFamily: '"Nunito Sans", sans-serif',
-    textTransform: 'none'
-  },
+   // fontFamily: 'Montserrat',
+   fontFamily: 'Montserrat, Verdana, sans-serif',
+   button:{
+     fontFamily: 'Montserrat, Verdana, sans-serif',
+   },
   ...Object.fromEntries(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(level => [
     level,
     {
-      fontFamily: '"Nunito Sans", sans-serif',
+      fontFamily: 'Montserrat, Verdana, sans-serif',
       marginTop: '1rem',
       marginBottom: '1rem',
     }

--- a/packages/frontend/src/theme.tsx
+++ b/packages/frontend/src/theme.tsx
@@ -157,41 +157,19 @@ const brandPalette: PaletteOptions = {
 }
 
 const brandTypography: TypographyOptions = {
-  // fontFamily: 'Montserrat',
-  fontFamily: 'Verdana, sans-serif',
-  button:{
-    fontFamily: 'Montserrat, Verdana, sans-serif',
+  fontFamily: '"Nunito Sans", sans-serif',
+  button: {
+    fontFamily: '"Nunito Sans", sans-serif',
+    textTransform: 'none'
   },
-  h1: {
-    fontFamily: 'Montserrat, Verdana, sans-serif',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-  },
-  h2: {
-    fontFamily: 'Montserrat, Verdana, sans-serif',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-  },
-  h3: {
-    fontFamily: 'Montserrat, Verdana, sans-serif',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-  },
-  h4: {
-    fontFamily: 'Montserrat, Verdana, sans-serif',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-  },
-  h5: {
-    fontFamily: 'Montserrat, Verdana, sans-serif',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-  },
-  h6: {
-    fontFamily: 'Montserrat, Verdana, sans-serif',
-    marginTop: '1rem',
-    marginBottom: '1rem',
-  }
+  ...Object.fromEntries(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(level => [
+    level,
+    {
+      fontFamily: '"Nunito Sans", sans-serif',
+      marginTop: '1rem',
+      marginBottom: '1rem',
+    }
+  ]))
 }
 
 const themes = {


### PR DESCRIPTION
## Description

- Removed *huge* gap value.

## Screenshots / Videos (frontend only) 


Old:
![bettervoting com_ (1)](https://github.com/user-attachments/assets/050f1388-2e98-4b61-9d82-08cfefbe0eab)
New:
![CleanShot 2024-12-22 at 11 30 58@2x](https://github.com/user-attachments/assets/b251d1db-fb04-4b3f-a3f4-1a09161ffde3)
![CleanShot 2024-12-22 at 11 31 35@2x](https://github.com/user-attachments/assets/2d42178f-e9a1-4775-abac-f50b55f8e610)
![CleanShot 2024-12-22 at 11 31 55@2x](https://github.com/user-attachments/assets/2909e57c-7f28-4247-902b-2e230e126f18)



> Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

## Related Issues

> For example, add ``fixes #10`` to close issue #10