### PR TITLE
fix: break any long word across lines.

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -49,6 +49,10 @@
   --dark-bkg-gray: #1F1F1F;
 }
 
+.MuiTypography-root {
+  overflow-wrap: break-word;
+}
+
 .racePageStepper .MuiStepConnector-line {
   opacity: 0;
 }


### PR DESCRIPTION
## Description

If a word is too long to fit in a visible block that contains it, with this change, the browser will break the word across lines. The problem of this not happening was noticed particularly with election names; however, the present proposed solution applies very broadly, probably to all messages the app displays. Technically, it applies to everything in CSS class "MuiTypography-root", which is probably everything.

I'm not sure whether the location of the new declaration is appropriate. Prior, there were no "Mui"- declarations there, and I may be abusing the intended pattern for administering a project's use of the Material User Interface (MUI) library.

## Screenshots

### Mobile

#### Before
![before_mobile](https://github.com/user-attachments/assets/2a08eadc-e3a4-4bc6-8147-2ee17be38cdf)

#### After
![after_mobile](https://github.com/user-attachments/assets/6738dc8e-1f2d-4125-bd3d-cd03790f51cf)

### Desktop

#### Before
![before](https://github.com/user-attachments/assets/be69632d-a95a-4182-b92d-8c0194ef575e)

#### After
![after](https://github.com/user-attachments/assets/f36a9b79-0918-4d59-930b-edcd28e3ef3b)

## Related Issues

Intended to resolve #485.