### PR TITLE
Reset stepper in racial dialog every time it is closed

### DIFF
--- a/packages/frontend/src/components/ElectionForm/Races/AddRace.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/AddRace.tsx
@@ -13,6 +13,9 @@ export default function AddRace() {
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
 
+    const [activeStep, setActiveStep] = useState(0);
+    const resetStep = () => setActiveStep(0);
+
     const { editedRace, errors, setErrors, applyRaceUpdate, onAddRace } = useEditRace(null, election.races.length)
 
     const onAdd = async () => {
@@ -35,13 +38,21 @@ export default function AddRace() {
                 disabled={election.state!=='draft'}>
                 Add
             </StyledButton>
-            <RaceDialog onSaveRace={onAdd} open={open} handleClose={handleClose} editedRace={editedRace}>
+            <RaceDialog
+              onSaveRace={onAdd}
+              open={open}
+              handleClose={handleClose}
+              editedRace={editedRace}
+              resetStep={resetStep}
+            >
                 <RaceForm
                     race_index={election.races.length}
                     editedRace={editedRace}
                     errors={errors}
                     setErrors={setErrors}
                     applyRaceUpdate={applyRaceUpdate}
+                    activeStep={activeStep}
+                    setActiveStep={setActiveStep}
                 />
             </RaceDialog>
         </Box>

--- a/packages/frontend/src/components/ElectionForm/Races/Race.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/Race.tsx
@@ -21,6 +21,9 @@ export default function Race({ race, race_index }) {
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
 
+    const [activeStep, setActiveStep] = useState(0);
+    const resetStep = () => setActiveStep(0);
+
     const onSave = async () => {
         const success = await onSaveRace()
         if (!success) return
@@ -73,13 +76,21 @@ export default function Race({ race, race_index }) {
                 </Box>
 
             </Box>
-            <RaceDialog onSaveRace={onSave} open={open} handleClose={handleClose} editedRace={editedRace}>
+            <RaceDialog
+              onSaveRace={onSave}
+              open={open}
+              handleClose={handleClose}
+              editedRace={editedRace}
+              resetStep={resetStep}
+            >
                 <RaceForm
                     race_index={race_index}
                     editedRace={editedRace}
                     errors={errors}
                     setErrors={setErrors}
                     applyRaceUpdate={applyRaceUpdate}
+                    activeStep={activeStep}
+                    setActiveStep={setActiveStep}
                 />
             </RaceDialog>
         </Paper >

--- a/packages/frontend/src/components/ElectionForm/Races/RaceDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/RaceDialog.tsx
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react';
 
 import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material"
 import { StyledButton } from '../../styles';
 import useElection from '../../ElectionContextProvider';
 
 
-export default function RaceDialog({ onSaveRace, open, handleClose, children, editedRace }) {
+export default function RaceDialog({
+  onSaveRace, open, handleClose, children, editedRace, resetStep
+}) {
     const { election } = useElection()
     const handleSave = () => onSaveRace()
 
@@ -15,6 +17,22 @@ export default function RaceDialog({ onSaveRace, open, handleClose, children, ed
         handleClose();
     }
 
+    useEffect(() => {
+      if (! open) resetStep();
+    }, [open]);
+
+    const dialogContentRef = useRef<HTMLDivElement>(null);
+
+    useEffect( () => {
+      if (open) {
+        setTimeout( () => {
+          if (dialogContentRef.current) {
+            dialogContentRef.current.scrollTop = 0;
+          }
+        }, 100);
+      };
+    }, [open]);
+
     return (
         <Dialog
             open={open}
@@ -22,7 +40,7 @@ export default function RaceDialog({ onSaveRace, open, handleClose, children, ed
             scroll={'paper'}
             keepMounted>
             <DialogTitle> Edit Race </DialogTitle>
-            <DialogContent>
+            <DialogContent ref={dialogContentRef}>
                 {children}
             </DialogContent>
             <DialogActions>

--- a/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
@@ -20,11 +20,13 @@ import useFeatureFlags from '../../FeatureFlagContextProvider';
 import { SortableList } from '~/components/DragAndDrop';
 import useSnackbar from '~/components/SnackbarContext';
 
-export default function RaceForm({ race_index, editedRace, errors, setErrors, applyRaceUpdate }) {
+export default function RaceForm({
+  race_index, editedRace, errors, setErrors, applyRaceUpdate,
+  activeStep, setActiveStep
+}) {
     const {t} = useSubstitutedTranslation();
     const flags = useFeatureFlags();
     const [showsAllMethods, setShowsAllMethods] = useState(false)
-    const [activeStep, setActiveStep] = useState(0)
     const { election } = useElection()
     const PR_METHODS = ['STV', 'STAR_PR'];
     const [methodFamily, setMethodFamily] = useState(


### PR DESCRIPTION
## Before

Let's say you go to add a race to an election you are working on, and let's say you go through the stepper to set the election type. Then you commit that change to add the race for real. Then say you go to add another race. The dialog would open with the stepper still on the second step.

## After

When you open the racial dialog for the second time, the stepper is reset to the first step.

## Screenshots / Videos (frontend only) 

I don't want to shoot my screen.

## Related Issues

Fixes #729 .