### PR TITLE
feat: add direct URL support for opening Feedback popup

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -52,6 +52,7 @@ const App = () => {
             }}>
             <Routes>
               <Route path='/' element={<LandingPage />} />
+              <Route path='/Feedback' element={<LandingPage />} />   // creating a new route for feedback page while still loading the landing page
               <Route path='/About' element={<About />} />
               <Route path='/ElectionInvitations' element={<ElectionInvitations />} />
               <Route path='/ElectionsYouManage' element={<ElectionsYouManage />} />

--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -10,10 +10,21 @@ import useFeatureFlags from './FeatureFlagContextProvider';
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
 import LandingPageStats from './LandingPage/LandingPageStats';
 import { ReturnToClassicContext } from './ReturnToClassicDialog';
-import { useSubstitutedTranslation } from './util';
-
+import { openFeedback, useSubstitutedTranslation } from './util';
+import{useLocation} from 'react-router-dom';
 
 const LandingPage = () => {
+
+    const checkUrl = useLocation();
+    useEffect(() =>{
+        if(checkUrl.pathname === "/Feedback")
+        {
+            openFeedback();
+        }
+           
+    }, [checkUrl]);
+
+    
     const flags = useFeatureFlags();
 
     const boxRef = useRef(null);


### PR DESCRIPTION
## Description
- Added  `/Feedback` route that loads the Landing Page.
- Implemented automatic Feedback dialog popup trigger when navigating to `/Feedback` .
- Ensured existing Feedback button functionality remains unchanged.

## Videos (frontend only) 
- Video : https://youtu.be/7p3fTh13p0o

## Testing 
- Tested locally to confirm that visiting `/Feedback` opens the feedback popup.
- Verified that clicking the Feedback button still works as expected.

## Related Issues

Closes #799