### PR TITLE
Free height of part of race form

### DIFF
--- a/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
@@ -340,7 +340,7 @@ export default function RaceForm({
                                     </Typography>
                                 </Box>
                                 <Box sx={{
-                                    height: showsAllMethods? 0 : '163px', // copied the value from auto
+                                    height: showsAllMethods? 0 : 'auto',
                                     opacity: showsAllMethods? 0 : 1,
                                     overflow: 'hidden',
                                     transition: 'height .4s, opacity .7s',


### PR DESCRIPTION
## Description

Removes fixed height from part of race form, but at the cost of a height transition. The opacity transition remains.

## Before

![image](https://github.com/user-attachments/assets/402cf94a-c2a9-4dbf-a1fd-eccd148a56e8)

## After

![image](https://github.com/user-attachments/assets/9a4bd8f8-6e72-4320-bf3e-63b65d521390)

## Related Issues

fixes #842