### PR TITLE
Updated Tie Breaker Warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12085,7 +12085,7 @@
         "identity-obj-proxy": "^3.0.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3",
-        "vite": "^5.1.5",
+        "vite": "^5.4.12",
         "vite-plugin-checker": "^0.6.4",
         "vite-plugin-env-compatible": "^2.0.1"
       }
@@ -14381,7 +14381,7 @@
         "socket.io-client": "^4.7.5",
         "typescript": "^5.3.3",
         "uuid": "^9.0.1",
-        "vite": "^5.1.5",
+        "vite": "^5.4.12",
         "vite-plugin-checker": "^0.6.4",
         "vite-plugin-env-compatible": "^2.0.1",
         "web-vitals": "^1.1.2"

--- a/packages/frontend/src/components/Election/Results/STAR/STARResultDetailedStepsWidget.tsx
+++ b/packages/frontend/src/components/Election/Results/STAR/STARResultDetailedStepsWidget.tsx
@@ -21,6 +21,11 @@ const STARResultDetailedStepsWidget = ({ results, rounds, t, filterRandomFromLog
     // this approach is a bit error prone, but it works for now
     if(filterRandomFromLogs) logs = logs.slice(0, logs.length-2);
     return <div className='detailedSteps'>
+        { showTieBreakerWarning && <Paper elevation={2} sx={{backgroundColor: 'theme.gray4', width: '90%', margin: 'auto', textAlign: 'left', padding: 3}}>
+            <b>{t('results.star.tiebreaker_note_title')}</b>️
+            <hr/>
+            {logs.slice(0, ).map((s,i) => <p key={i}>{s}</p>)}
+        </Paper> }
         {results.roundResults.map((round, r) => (
             <Box key={r}>
                 {rounds > 1 && <Typography variant="h4">{`Winner ${r + 1}`}</Typography>}
@@ -31,11 +36,7 @@ const STARResultDetailedStepsWidget = ({ results, rounds, t, filterRandomFromLog
                 </ol>
             </Box>
         ))}
-        { showTieBreakerWarning && <Paper elevation={2} sx={{backgroundColor: 'theme.gray4', width: '90%', margin: 'auto', textAlign: 'left', padding: 3}}>
-            <b>{t('results.star.tiebreaker_note_title')}</b>️
-            <hr/>
-            {logs.slice(0, ).map((s,i) => <p key={i}>{s}</p>)}
-        </Paper> }
+
     </div>
 }
 

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -271,8 +271,9 @@ results:
     detailed_steps_title: Tabulation Steps
     tiebreaker_note_title: A note on Tiebreakers
     tiebreaker_note_text: 
-      - Ties are broken using the [Offical Tiebreaker Protocol](https://starvoting.org/ties) whenever possible.
-      - Ties are 10 times less likely to occur with STAR Voting than with Choose-One Voting and generally resolve as the number of voters increases.
+      - This election required a tie breaker. Ties are significantly less likely to occur with STAR Voting than with Choose-One Voting or Ranked Choice Voting.
+      - Generally, ties will not be an issue as the number of voters increase; however, when ties do occur, BetterVoting follows a tiebreaker protocol in order to select the most representative winners.
+      - To understand how the tie was broken, we recommend [learning more about Star Voting's Official Tiebreaker Protocol](https://starvoting.org/ties) and then following the steps below to see how they were resolved for this election.
     equal_preferences_title: Distribution of Equal Preferences
     equal_preferences: Equal Preferences
     score_higher_than_runoff_title: Why is the top scoring candidate different from the winner?


### PR DESCRIPTION

## Description

Moved Tie breaker note up above the tabulation details and adjusted the tie breaker notes text.

## Screenshots / Videos (frontend only) 

![Screenshot 2025-03-12 at 17-14-46 __META_TITLE__](https://github.com/user-attachments/assets/46ce236f-7b50-4786-9c21-f56a61470429)


> Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

## Related Issues
Fixes #847
> For example, add ``fixes #10`` to close issue #10