### PR TITLE
Fixed Punctuation on About Page

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -822,8 +822,7 @@ about:
 
     It's also flexible to fit your voting scenario, whether it's a massive
     public poll, a high stakes board election, or just a casual poll
-    picking a restaurant
-    bettervoting.com can fit your needs and provide a secure, auditable election
+    picking a restaurant - bettervoting.com can fit your needs and provide a secure, auditable election.
   team_title: The Team
   leads_title: Our Leads
   leads:


### PR DESCRIPTION
## Description
Added a "-" and a "." on about page that were missing.

## Screenshots / Videos (frontend only) 

![image](https://github.com/user-attachments/assets/2d7c3bf6-b5d6-4071-bae9-da7dbf407e84)

> Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

## Related Issues

> For example, add ``fixes #10`` to close issue #10