### PR TITLE
fix: stop sending repeated or empty electionId requests

### DIFF
--- a/packages/frontend/sample.env
+++ b/packages/frontend/sample.env
@@ -9,7 +9,7 @@ REACT_APP_KEYCLOAK_URL=http://localhost:8080/realms/Dev/protocol/openid-connect
 # REACT_APP_KEYCLOAK_URL=https://keycloak.prod.equal.vote/realms/Prod/protocol/openid-connect
 
 #### FRONTEND FEATURES ####
-REACT_APP_FEATURED_ELECTIONS='' # currently disabled
+REACT_APP_FEATURED_ELECTIONS=''
 REACT_APP_MAX_BALLOT_RANKS=10
 REACT_APP_DEFAULT_BALLOT_RANKS=6
 

--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -15,6 +15,7 @@ import QuickPoll from './ElectionForm/QuickPoll';
 import { PrimaryButton } from './styles';
 import LandingPageSupport from './LandingPage/LandingPageSupport';
 import LandingPageCarousel from './LandingPage/LandingPageCarousel';
+import LandingPageFeaturedElections from './LandingPage/LandingPageFeaturedElections';
 
 const LandingPage = () => {
 
@@ -67,8 +68,7 @@ const LandingPage = () => {
                 <Typography variant="h4" color={'lightShade.contrastText'}> {t('landing_page.hero.title')} </Typography>
                 <LandingPageCarousel />
             </Box>
-            {/* temporarily disabling because it was sending continuous requests to the backend for some reason */}
-            {/*<LandingPageFeatureElections electionIds={(process.env.REACT_APP_FEATURED_ELECTIONS ?? '').split(',')}/>*/}
+            <LandingPageFeaturedElections electionIds={(process.env.REACT_APP_FEATURED_ELECTIONS ?? '').split(',')}/>
             <LandingPageStats/>
             <QuickPoll/>
             <LandingPageFeatures/>

--- a/packages/frontend/src/components/LandingPage/FeaturedElection.tsx
+++ b/packages/frontend/src/components/LandingPage/FeaturedElection.tsx
@@ -17,6 +17,7 @@ export default ({electionId}) => {
     const { data, isPending, error, makeRequest: fetchElections } = useGetElection(electionId);
 
     useEffect(() => {
+        if (!electionId) return;
         //isMounted is used to prevent memory leaks by ensuring that the component is still mounted before updating the state
         let isMounted = true;
 
@@ -31,7 +32,7 @@ export default ({electionId}) => {
         return () => {
             isMounted = false;
         };
-    }, [fetchElections]);
+    }, [electionId]);
 
     return <Card className='featuredElection' onClick={() => navigate(`/${electionId}`)} elevation={8} sx={{
         width: '100%',


### PR DESCRIPTION
## Description
Guard against empty or malformed electionId values in REACT_APP_FEATURED_ELECTIONS that led to repeated or unnecessary backend requests.

## Screenshots / Videos (frontend only) 
No more errors seen.

Without featured elections:
![image](https://github.com/user-attachments/assets/4c6fb26a-1691-4149-a64f-38e938a59f52)


With featured elections:
![image](https://github.com/user-attachments/assets/65449be3-068d-41ea-849d-b5854eb75bc7)


## Related Issues
fixes issue #694