### PR TITLE
Issue #754: Abstention Issue

### DIFF
--- a/packages/frontend/src/components/Election/Voting/VotePage.tsx
+++ b/packages/frontend/src/components/Election/Voting/VotePage.tsx
@@ -189,7 +189,7 @@ const VotePage = () => {
   }
 
   let pageIsUnderVote = (page) => {
-    return page.candidates.reduce((prev, c) => prev && (c.score == 0 || c.score == null), true)
+    return page.candidates.every(c => c.score == null);
   }
 
   return (


### PR DESCRIPTION
Ballots with mix of zeros and blanks no longer count as abstention

## Description
Ballots with mix of zeros and blanks should not count as abstention. This fixes the immediate issue but also raises another issue of votes left blank should not be counted as '0'.

## Screenshots / Videos (frontend only) 
![image](https://github.com/user-attachments/assets/b2969428-32bb-4c91-890e-e0757a6d31d3)
![image](https://github.com/user-attachments/assets/615519b7-ad6c-421a-b44c-417d04fb7ec1)

> Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

## Related Issues

> For example, add ``fixes #10`` to close issue #10