### PR TITLE
fix(frontend): Avoid rendering featured elections component on landin…

### DIFF
--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -29,7 +29,8 @@ const LandingPage = () => {
     const flags = useFeatureFlags();
 
     const boxRef = useRef(null);
-
+    const featuredElectionIds = process.env.REACT_APP_FEATURED_ELECTIONS.split('').filter(Boolean)
+    
     //It looks like atTop wasn't being used anywhere, so I'm just removing this chunk for now
 
     // const [atTop, setAtTop] = useState(true);
@@ -69,7 +70,7 @@ const LandingPage = () => {
             </Box>
             <LandingPageStats/>
             <QuickPoll/>
-            <LandingPageFeaturedElections electionIds={(process.env.REACT_APP_FEATURED_ELECTIONS ?? '').split(',')}/>
+            {featuredElectionIds.length > 0 && <LandingPageFeaturedElections electionIds={featuredElectionIds}/>}
             <LandingPageFeatures/>
             <LandingPageSignUpBar />
             {flags.isSet('ELECTION_TESTIMONIALS') && <LandingPageTestimonials/>}

--- a/packages/frontend/src/components/LandingPage/LandingPageFeaturedElections.tsx
+++ b/packages/frontend/src/components/LandingPage/LandingPageFeaturedElections.tsx
@@ -4,7 +4,6 @@ import { useSubstitutedTranslation } from '../util'
 
 const LandingPageFeaturedElections = ({ electionIds }: { electionIds: string[] }) => {
     const { t } = useSubstitutedTranslation();
-
     return <Box sx={{
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
…g page if none available

## Description
Avoids rendering the featured elections component on the landing page if there are no featured election IDs in context.

## Screenshots / Videos (frontend only) 
![image](https://github.com/user-attachments/assets/70acfbf2-4237-4482-9a03-c887a9271cf4)

## Related Issues

fixes #870 