### PR TITLE
Finalize Election grammar fix & confirmation snack

### DIFF
--- a/packages/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/packages/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -15,6 +15,7 @@ import structuredClone from '@ungap/structured-clone';
 import useAuthSession from '../../AuthSessionContextProvider';
 import useFeatureFlags from '../../FeatureFlagContextProvider';
 import ElectionAuthForm from '~/components/ElectionForm/Details/ElectionAuthForm';
+import useSnackbar from "~/components/SnackbarContext";
 
 type SectionProps = {
     text: {[key: string]: string}
@@ -28,6 +29,7 @@ const AdminHome = () => {
     const { election, refreshElection: fetchElection, permissions } = useElection()
     const {t} = useSubstitutedTranslation(election.settings.term_type, {time_zone: election.settings.time_zone});
     const { makeRequest } = useSetPublicResults(election.election_id)
+    const { setSnack } = useSnackbar()
     const togglePublicResults = async () => {
         const public_results = !election.settings.public_results
         await makeRequest({ public_results: public_results })
@@ -56,6 +58,13 @@ const AdminHome = () => {
             console.error(err)
         }
 
+        setSnack({
+            message: t('admin_home.finalize_snack'),
+            severity: 'success',
+            open: true,
+            autoHideDuration: 6000,
+        })
+        
         const currentTime = new Date();
         if (
             election.settings.voter_access === 'closed' &&
@@ -249,6 +258,7 @@ const AdminHome = () => {
         <Grid xs={12} sx={{ p: 1, pt: 3, pb: 0 }}>
             <Typography align='center' variant="body1" sx={{ pl: 2 }}>
                 {t('admin_home.finalize_description')}
+                {' '}
                 {t(election.start_time? 'admin_home.finalize_voting_begins_later' : 'admin_home.finalize_voting_begins_now')}
             </Typography>
             {/* I don't think this is true anymore */}

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1020,6 +1020,8 @@ admin_home:
     message: You can send emails from the voters tab at anytime. Would you like to notify your voters? 
     cancel: 'No, not now'
     submit: 'Yes, take me to the voters tab'
+
+  finalize_snack: 'Election successfully finalized!'
   
   duplicate_confirm:
     title: Confirm Duplicate Election


### PR DESCRIPTION
## Description

Add a confirmation snack after finalizing an election. Also add a missing space when describing the finalization process.

## Related Issues

Fixes #764 