### PR TITLE
feat: add edit vote button to ballot when enabled & voted

### DIFF
--- a/packages/frontend/src/components/Election/ElectionHome.tsx
+++ b/packages/frontend/src/components/Election/ElectionHome.tsx
@@ -14,6 +14,8 @@ const ElectionHome = () => {
 
   const {t} = useSubstitutedTranslation(election.settings.term_type, {time_zone: election.settings.time_zone});
 
+  const canUpdateBallot = (voterAuth.has_voted == true && election.settings.ballot_updates);
+
   return (
     <>
       <DraftWarning/>
@@ -69,12 +71,13 @@ const ElectionHome = () => {
                 </Typography>
               </Box>}
             {
-              voterAuth.has_voted == false && voterAuth.authorized_voter && !voterAuth.required &&
+              (voterAuth.has_voted == false || canUpdateBallot) && voterAuth.authorized_voter && !voterAuth.required &&
 
               <Box display='flex' flexDirection='column' alignItems='center' gap={5} sx={{ p: 1}}>
                 <PrimaryButton fullWidth href={`/${String(election?.election_id)}/vote`} name='vote' >
                   <Typography align='center' variant="h3" component="h3" fontWeight='bold' sx={{ p: 2 }}>
-                    {t('election_home.vote')}
+                    {/*display edit ballot or vote text conditionally*/}
+                    {voterAuth.has_voted ? t('editable_ballots.edit_vote') : t('election_home.vote')}
                   </Typography>
                 </PrimaryButton>
                 {election.settings.public_results === true &&
@@ -109,7 +112,7 @@ const ElectionHome = () => {
               </Typography>
             </Box>
           }
-          {voterAuth.has_voted == true &&
+          {voterAuth.has_voted == true && !canUpdateBallot &&
             <Box display='flex' flexDirection='column' alignItems='center' gap={5} sx={{ p: 1}}>
               <Typography align='center' variant="h6" component="h6">
                 {t('election_home.ballot_submitted')}
@@ -118,7 +121,7 @@ const ElectionHome = () => {
           }
           {/* Show results button only if public_results enabled and voter has voted or election is closed */}
           {(election.settings.public_results === true &&
-            (election.state === 'open' && voterAuth.has_voted) || election.state === 'closed') &&
+            (election.state === 'open' && voterAuth.has_voted && !canUpdateBallot) || election.state === 'closed') &&
             <SecondaryButton href={`/${String(election?.election_id)}/results`} sx={{mx: 'auto', width: '90%', p:3}}>
               {t('election_home.view_results')}
             </SecondaryButton>

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -831,6 +831,9 @@ archived_warning:
     Unable to cast ballot: This {{election}} has been archived and is no longer accepting votes.
     Please contact your Election Administrator if you need assistance.
 
+editable_ballots:
+  edit_vote: Update Vote
+
 # Landing Page -> New Election Dialog
 election_creation:
   dialog_title: Create an Election or Poll


### PR DESCRIPTION
## Description

Modifies the main `ElectionHome` voting page when
1. authenticated user has already voted
2. the editable ballots feature is enabled by the election's admin

to provide an "Update Vote" button, instead of the "ballot submitted" message.

## Screenshots / Videos (frontend only) 

<img width="756" height="629" alt="image" src="https://github.com/user-attachments/assets/c116429c-7bae-4298-b15b-dc229966d2c5" />
<img width="430" height="1070" alt="image" src="https://github.com/user-attachments/assets/ce89082f-adbc-4d72-83f5-ea846c04b531" />


## Related Issues

closes #990 