### PR TITLE
feat(admin page): Make editable ballots and preliminary results mutually exclusive

### DIFF
--- a/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
+++ b/packages/frontend/src/components/ElectionForm/CreateElectionDialog.tsx
@@ -59,7 +59,7 @@ export const defaultElection: NewElection = {
             ip_address: false
         },
         ballot_updates: false,
-        public_results: true,
+        public_results: false,
         time_zone: DateTime.now().zone.name as TimeZone,
         random_candidate_order: false,
         require_instruction_confirmation: true,

--- a/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Grid from "@mui/material/Grid";
 import FormControlLabel from "@mui/material/FormControlLabel";
+import FormHelperText from "@mui/material/FormHelperText";
 import FormControl from "@mui/material/FormControl";
 import Typography from '@mui/material/Typography';
 import { Checkbox, FormGroup, Radio, RadioGroup, Dialog, DialogActions, DialogContent, DialogTitle, Paper, Box, IconButton, TextField, capitalize } from "@mui/material"
@@ -20,11 +21,18 @@ export default function ElectionSettings() {
     const min_rankings = 3;
     const max_rankings = Number(process.env.REACT_APP_MAX_BALLOT_RANKS) ? Number(process.env.REACT_APP_MAX_BALLOT_RANKS) : 8;
     const default_rankings = Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) ? Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) : 6;
+    const ballotUpdatesConditionsNotMet = !flags.isSet('BALLOT_UPDATES') || election.settings.voter_access === 'open';
 
     const {t} = useSubstitutedTranslation(election.settings.term_type, {min_rankings, max_rankings});
 
-    const [editedElectionSettings, setEditedElectionSettings] = useState(election.settings)
-    const [editedIsPublic, setEditedIsPublic] = useState(election.is_public)
+    const [editedElectionSettings, setEditedElectionSettings] = useState(election.settings);
+    const [editedIsPublic, setEditedIsPublic] = useState(election.is_public);
+    const [publicResults, setPublicResults] = useState(election.settings.public_results);
+    const [ballotUpdates, setBallotUpdates] = useState(election.settings.ballot_updates);
+    const [ballotUpdatesDisabled, setBallotUpdatesDisabled] = useState(ballotUpdatesConditionsNotMet);
+    const [publicResultsDisabled, setPublicResultsDisabled] = useState(false);
+    const [publicResultsDisabledMsg, setPublicResultsDisabledMsg] = useState(undefined);
+    const [ballotUpdatesDisabledMsg, setBallotUpdatesDisabledMsg] = useState(undefined);
 
     const applySettingsUpdate = (updateFunc: (settings: IElectionSettings) => void) => {
         const settingsCopy = structuredClone(editedElectionSettings)
@@ -64,18 +72,32 @@ export default function ElectionSettings() {
         disabled?: boolean
         checked?: boolean
         onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+        hidden?: boolean
+        helperText?: boolean
     }
-    const CheckboxSetting = ({setting, disabled=false, checked=undefined, onChange=undefined}: CheckboxSettingProps) => <>
-        <FormControlLabel disabled={disabled} control={
-            <Checkbox
-                id={setting}
-                name={t(`election_settings.${setting}`)}
-                checked={disabled? !!checked : (checked ?? !!editedElectionSettings[setting])}
-                onChange={onChange ?? ((e) => applySettingsUpdate(settings => { settings[setting] = e.target.checked; }))}
-                sx={{mb: 1}}
-            />}
-            label={t(`election_settings.${setting}`)}
-        />
+    const onChangeBallotUpdates = async(e) => {
+         setBallotUpdates(e.target.checked);
+         setPublicResultsDisabled(e.target.checked);
+         setPublicResultsDisabledMsg(e.target.checked);  
+    };
+    const onChangePublicResults = async(e) => {
+         setPublicResults(e.target.checked);
+         setBallotUpdatesDisabled(ballotUpdatesConditionsNotMet || e.target.checked);
+         setBallotUpdatesDisabledMsg(!ballotUpdatesConditionsNotMet && e.target.checked);
+    };
+    const CheckboxSetting = ({setting, disabled=false, checked=undefined, onChange=undefined, hidden=false, helperText=false}: CheckboxSettingProps) => <>
+            <FormControlLabel hidden = {hidden} disabled={disabled} control={
+                <Checkbox
+                    id={setting}
+                    name={t(`election_settings.${setting}`)}
+                    checked={disabled? !!checked : (checked ?? !!editedElectionSettings[setting])}
+                    onChange={onChange ?? ((e) => applySettingsUpdate(settings => { settings[setting] = e.target.checked; }))}
+                    sx={{mb: 1}}
+                    hidden={hidden}
+                />}
+                label={t(`election_settings.${setting}`)}
+            />
+        <FormHelperText hidden={!helperText} sx={{ mb:2, mt:0, lineHeight: 0, fontStyle: 'italic', textAlign: 'center' }}>{t(`disabled_msgs.${setting}`)}</FormHelperText>
     </>;
 
     return (
@@ -145,8 +167,9 @@ export default function ElectionSettings() {
                                 
 
                                 <CheckboxSetting setting='random_candidate_order'/>
-                                <CheckboxSetting setting='ballot_updates' disabled={!flags.isSet('BALLOT_UPDATES') || election.settings.voter_access === 'open'}/>
-                                <CheckboxSetting setting='public_results'/>
+                                { ballotUpdatesConditionsNotMet || <CheckboxSetting setting='ballot_updates' hidden={ballotUpdatesConditionsNotMet}
+                                    disabled={ballotUpdatesDisabled} checked={ballotUpdates} onChange={(e) => onChangeBallotUpdates(e)} helperText={ballotUpdatesDisabledMsg}/>}
+                                <CheckboxSetting setting='public_results' checked={publicResults} onChange={(e) => onChangePublicResults(e)} disabled={publicResultsDisabled} helperText={publicResultsDisabledMsg}/>
                                 <CheckboxSetting setting='random_ties' disabled checked/>
                                 <CheckboxSetting setting='voter_groups' disabled/>
                                 <CheckboxSetting setting='custom_email_invite' disabled/>

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -685,6 +685,10 @@ tabulation_logs:
 #### PRIORITY 4 : Info Bubbles ####
 #######################################
 
+disabled_msgs:
+    ballot_updates: not supported with preliminary results
+    public_results: not supported with vote editing
+
 # Info bubbles
 tips:
   public_archive: 


### PR DESCRIPTION


## Description
- Disable and uncheck editable ballots when preliminary results are enabled and vice versa
- Hide editable ballots for public elections or when the feature flag is not present
- turn off preliminary results by default

## Screenshots / Videos (frontend only) 


https://github.com/user-attachments/assets/d8c0eae2-ca6e-4c09-938d-70fd9e7b050b


## Related Issues

closes #989 