### PR TITLE
Add close/open election functionality

### DIFF
--- a/packages/backend/src/Controllers/Election/index.ts
+++ b/packages/backend/src/Controllers/Election/index.ts
@@ -9,5 +9,6 @@ export * from './getElectionResultsController';
 export * from './getElectionsController';
 export * from './sandboxController';
 export * from './sendInvitesController';
+export * from './setOpenStateController';
 export * from './setPublicResultsController';
 export * from './sendEmailController';

--- a/packages/backend/src/Controllers/Election/setOpenStateController.ts
+++ b/packages/backend/src/Controllers/Election/setOpenStateController.ts
@@ -1,0 +1,52 @@
+import ServiceLocator from '../../ServiceLocator';
+import Logger from '../../Services/Logging/Logger';
+import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
+import { expectPermission } from "../controllerUtils";
+import { BadRequest, InternalServerError } from "@curveball/http-errors";
+import { Election } from '@equal-vote/star-vote-shared/domain_model/Election';
+import { IElectionRequest } from "../../IRequest";
+import { Response, NextFunction } from 'express';
+
+const ElectionsModel = ServiceLocator.electionsDb();
+
+const className = "election.Controllers";
+
+const setOpenState = async (req: IElectionRequest, res: Response, next: NextFunction) => {
+    Logger.info(req, `${className}.archive ${req.election.election_id}`);
+    expectPermission(req.user_auth.roles, permissions.canEditElectionState)
+
+    const election: Election = req.election
+    const open = req.body.open
+
+    let msg;
+    if (typeof open !== 'boolean') {
+        msg = "open setting not provided or incorrect type";
+    } else if (election.state !== 'closed' && election.state !== 'open') {
+        msg = "Cannot close/open an election that is not open or closed";
+    } else if (open && election.state === 'open') {
+        msg = "Cannot open an election that is already open";
+    } else if (!open && election.state === 'closed') {
+        msg = "Cannot close an election that is already closed";
+    } else if (election.start_time || election.end_time) {
+        msg = "Cannot open or close an election with scheduled start and end times";
+    }
+    election.state = open ? "open" : "closed";
+
+    if (msg) {
+        Logger.info(req, msg);
+        throw new BadRequest(msg);
+    }
+
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, "Open or close election");
+    if (!updatedElection) {
+        const failMsg = `Failed to set election state to ${election.state}`;
+        Logger.info(req, failMsg);
+        throw new InternalServerError(failMsg);
+    }
+
+    res.status(200).json({ election: updatedElection });
+}
+
+export {
+    setOpenState,
+}

--- a/packages/backend/src/OpenApi/swagger.json
+++ b/packages/backend/src/OpenApi/swagger.json
@@ -4063,6 +4063,67 @@
         }
       }
     },
+    "/Election/{id}/setOpenState": {
+      "post": {
+        "summary": "Change an election's state from open to closed, or from closed to open",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "tags": [
+          "Elections"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The election ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "open": {
+                    "type": "boolean",
+                    "description": "True if reopening a closed election; false if closing an open election",
+                    "required": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Election state changed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "election": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/Election"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Election not found"
+          }
+        }
+      }
+    },
     "/Election/{id}/sendInvites": {
       "post": {
         "summary": "Send invitations for an election",

--- a/packages/backend/src/Routes/elections.routes.ts
+++ b/packages/backend/src/Routes/elections.routes.ts
@@ -19,6 +19,7 @@ import {
     getSandboxResults,
     sendInvitationController,
     sendInvitationsController,
+    setOpenState,
     setPublicResults,
     sendEmailsController,
     queryElections,
@@ -491,6 +492,47 @@ electionsRouter.post('/Election/:id/setPublicResults',asyncHandler(setPublicResu
  *         description: Election not found 
 */
 electionsRouter.post('/Election/:id/archive', asyncHandler(archiveElection))
+
+ /** 
+ * @swagger
+ * /Election/{id}/setOpenState:
+ *   post:
+ *     summary: Change an election's state from open to closed, or from closed to open
+ *     security:
+ *      - ApiKeyAuth: []
+ *     tags: [Elections]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The election ID
+ *     requestBody:
+ *      content:
+ *        application/json:
+ *          schema:
+ *           type: object
+ *           properties:
+ *            open:
+ *             type: boolean
+ *             description: True if reopening a closed election; false if closing an open election
+ *             required: true
+ *     responses:
+ *       200:
+ *         description: Election state changed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 election:
+ *                   type: object
+ *                   $ref: '#/components/schemas/Election'
+ *       404:
+ *         description: Election not found 
+*/
+electionsRouter.post('/Election/:id/setOpenState', asyncHandler(setOpenState))
 
 /** 
  * @swagger

--- a/packages/frontend/src/hooks/useAPI.ts
+++ b/packages/frontend/src/hooks/useAPI.ts
@@ -106,6 +106,10 @@ export const useArchiveEleciton = (election_id: string) => {
     return useFetch<undefined, { election: Election }>(`/API/Election/${election_id}/archive`, 'post')
 }
 
+export const useSetOpenState = (election_id: string) => {
+    return useFetch<{ open: boolean }, { election: Election }>(`/API/Election/${election_id}/setOpenState`, 'post')
+}
+
 export const useApproveRoll = (election_id: string) => {
     return useFetch<{ electionRollEntry: ElectionRoll }, object>(`/API/Election/${election_id}/rolls/approve`, 'post')
 }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1045,6 +1045,19 @@ admin_home:
     title: Confirm Archive {{capital_election}}
     message: Are you sure you wish to archive this {{election}}? This action cannot be undone.
 
+  close:
+    description: Close
+    subtext: Closes the {{election}}, preventing new votes
+    button: Close
+
+  open:
+    description: Open
+    subtext: Opens the {{election}}, allowing votes
+    button: Open
+
+  close_snack: 'Election successfully closed!'
+  open_snack: 'Election successfully opened!'
+
   share:
     description: Share {{capital_election}}
     # Button is defined in the top level share section


### PR DESCRIPTION
Allows election admins to close and open an election, as long as a start/end time is NOT set

## Description
Adds open/close button to admin page to cycle between these two states for elections without set start and end times.
Completes action items from PR #974

## Screenshots / Videos (frontend only) 

https://github.com/user-attachments/assets/5489b659-4ac9-4fa2-b857-b80db5b4577d


https://github.com/user-attachments/assets/2fc13888-13e5-4122-ba89-02e43e51cffb


## Related Issues

closes #812 