### PR TITLE
feat(editable ballots): add update vote button to thank you page

### DIFF
--- a/packages/frontend/src/components/Election/Voting/Thanks.tsx
+++ b/packages/frontend/src/components/Election/Voting/Thanks.tsx
@@ -2,7 +2,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import ShareButton from "../ShareButton";
 import HowToVoteIcon from '@mui/icons-material/HowToVote';
-import { PrimaryButton } from "../../styles";
+import { PrimaryButton, SecondaryButton } from "../../styles";
 import useElection from '../../ElectionContextProvider';
 import { useSubstitutedTranslation } from '~/components/util';
 import DraftWarning from '../DraftWarning';
@@ -11,18 +11,6 @@ const Thanks = () => {
     
     const { election, voterAuth } = useElection()
     const {t} = useSubstitutedTranslation(election.settings.term_type)
-
-    function MainButton({href, text} : {href: string, text : string}) {
-        return <Box sx={{ width: '100%',  p: 1, px:{xs: 5, sm: 1} }}>
-            <PrimaryButton
-                type='button'
-                fullWidth
-                href={href} >
-                {text}
-            </PrimaryButton>
-        </Box>
-    }
-
     return <>
         <DraftWarning/>
         {election &&
@@ -54,17 +42,25 @@ const Thanks = () => {
                 }
 
                 <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', flexDirection: { xs: 'column', sm: 'column' } }} >
-                    {election.state == 'open' && election.settings.ballot_updates &&
-                        MainButton({
-                            href: (voterAuth?.authorized_voter ? `/${String(election?.election_id)}/vote` : `/${String(election?.election_id)}`),
-                            text: t('editable_ballots.edit_vote')
-                        })
-                    }
                     {['draft', 'open', 'closed'].includes(election.state) && election.settings.public_results === true &&
-                        MainButton({
-                            href: `/${election.election_id}/results`,
-                            text: t('ballot_submitted.results')
-                        })
+                        <Box sx={{ width: '100%',  p: 1, px:{xs: 5, sm: 1} }}>
+                            <PrimaryButton
+                                type='button'
+                                fullWidth
+                                href={`/${election.election_id}/results`} >
+                                {t('ballot_submitted.results')}
+                            </PrimaryButton>
+                        </Box>
+                    }
+                    {election.state == 'open' && election.settings.ballot_updates &&
+                        <Box sx={{ width: '100%',  p: 1, px:{xs: 5, sm: 1} }}>
+                            <SecondaryButton
+                                type='button'
+                                fullWidth
+                                href={ (voterAuth?.authorized_voter ? `/${String(election?.election_id)}/vote` : `/${String(election?.election_id)}`)} >
+                                {t('editable_ballots.edit_vote')}
+                            </SecondaryButton>
+                        </Box>
                     }
                     {election.settings.voter_access !== 'closed' &&
                         <Box sx={{ width: '100%', p: 1, px:{xs: 5, sm: 1}  }}>


### PR DESCRIPTION
## Description
From the voting thank you page (`Thanks.tsx`), if editable ballots are enabled for the election, a button allows users to update their vote. If they are still authenticated, the button links to the `VotePage` itself, otherwise it links back to `ElectionHome`.

## Screenshots / Videos (frontend only) 

<img width="2518" height="1291" alt="image" src="https://github.com/user-attachments/assets/bcebd86a-a29e-474e-875d-e06971d81dd5" />
<img width="640" height="1318" alt="localhost_3000_g6274j_thanks" src="https://github.com/user-attachments/assets/1bfe6eda-b304-43fe-a3ee-6609e18cb193" />


## Related Issues

closes #988 