### PR TITLE
feat: Only allow adding voters by email for email-list elections.

### DIFF
--- a/packages/backend/src/Controllers/Roll/addElectionRollController.ts
+++ b/packages/backend/src/Controllers/Roll/addElectionRollController.ts
@@ -24,10 +24,13 @@ const addElectionRoll = async (req: IElectionRequest & { body: { electionRoll: E
     expectPermission(req.user_auth.roles, permissions.canAddToElectionRoll)
     Logger.info(req, `${className}.addElectionRoll ${req.election.election_id}`);
     const history = [{
-        action_type: 'added',
+        action_type: "added",
         actor: req.user.email,
         timestamp: Date.now(),
     }]
+    if (req.election.settings.invitation === "email" && req.body.electionRoll.some((r: ElectionRollInput) => r.voter_id)) {
+        throw new BadRequest("User provided voterIds are not permitted for email list elections");
+    }
     
     // Generate all IDs in parallel first
     const idPromises: Promise<string>[] = req.body.electionRoll.map((rollInput: ElectionRollInput) => 

--- a/packages/frontend/src/components/Election/Admin/AddElectionRoll.tsx
+++ b/packages/frontend/src/components/Election/Admin/AddElectionRoll.tsx
@@ -21,7 +21,8 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
     const postRoll = usePostRolls(election.election_id)
     const fileReader = new FileReader()
     const [enableVoterID, setEnableVoterID] = useState(election.settings.voter_authentication.voter_id && election.settings.invitation !== 'email')
-    const [enableEmail, setEnableEmail] = useState(election.settings.voter_authentication.email || election.settings.invitation === 'email')
+    const emailListOnly = election.settings.invitation === 'email'
+    const [enableEmail, setEnableEmail] = useState(emailListOnly)
     const [enablePrecinct, setEnablePrecinct] = useState(false)
     const inputRef = useRef(null)
 
@@ -59,7 +60,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                     email: undefined,
                     precinct: undefined,
                 }
-                if (enableVoterID){
+                if (enableVoterID && !emailListOnly){
                     roll.voter_id = csvSplit[count]
                     count += 1
                 }   
@@ -117,7 +118,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                     </Typography>
 
                     <Typography align='center' component="p">
-                        Enter your voter roll data in the field below.<br/>(1 voter per row, no spaces)
+                        Enter your voter roll data in the field below.<br/>{`(1 ${emailListOnly ? "email" : "voter"} per row, no spaces)`}
                     </Typography>
 
                     { election.settings.voter_access == 'closed' && 
@@ -132,26 +133,31 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
 
                     <Grid item sx={{ p: 1 }}>
                         <FormGroup row>
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        id="enable-voter-id"
-                                        name="Voter ID"
-                                        checked={enableVoterID}
-                                        onChange={(e) => setEnableVoterID(e.target.checked)} />
-                                }
-                                label='Voter ID'
-                            />
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        id="enable-email"
-                                        name="Email"
-                                        checked={enableEmail}
-                                        onChange={(e) => setEnableEmail(e.target.checked)} />
-                                }
-                                label='Email'
-                            />
+                            {
+                                emailListOnly ||
+                                    <>
+                                        <FormControlLabel
+                                            control={
+                                                <Checkbox
+                                                    id="enable-voter-id"
+                                                    name="Voter ID"
+                                                    checked={enableVoterID}
+                                                    onChange={(e) => setEnableVoterID(e.target.checked)} />
+                                            }
+                                            label='Voter ID'
+                                        />
+                                        <FormControlLabel
+                                            control={
+                                                <Checkbox
+                                                    id="enable-email"
+                                                    name="Email"
+                                                    checked={enableEmail}
+                                                    onChange={(e) => setEnableEmail(e.target.checked)} />
+                                            }
+                                            label='Email'
+                                        />
+                                    </>
+                            }
                             {flags.isSet('PRECINCTS') &&
                                 <FormControlLabel
                                     control={
@@ -170,7 +176,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                         <TextField
                             id="email-list"
                             name="email-list"
-                            label="Voter Data"
+                            label={`Voter ${emailListOnly ? "Emails" : "Data"}`}
                             required
                             rows={3}
                             placeholder={
@@ -217,7 +223,8 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                             Upload CSV
                         </Typography>
                         <Typography align='center' component="p">
-                            Upload a csv file of your voter data. Files can include voter IDs, email addresses, and precincts. Files must include headers with the expected spelling:voter_id,email,precinct.
+                            {`Upload a csv file of your voter data. Files can include ${emailListOnly ? "email addresses" : "voter IDs, email addresses,"} \
+                             and precincts. Files must include headers with the expected spelling:${emailListOnly ? "" : "voter_id,"}email,precinct.`}
                         </Typography>
                     </Grid>
                     <Grid item sx={{ m: 1 }}>


### PR DESCRIPTION
## Description
When admin has selected an email-list restricted election, they are only permitted to add users by email and not voterId.
Updates admin voter page language, removes options, adds backend validation.

## Screenshots / Videos 

https://github.com/user-attachments/assets/fb2d5984-f2a0-4dc1-b0eb-d5ce64bafae1

https://github.com/user-attachments/assets/6141959b-a658-41af-904d-f55c589b6121

https://github.com/user-attachments/assets/e9d229bb-3a63-4afb-ba72-8c2e49ac5dc5

https://github.com/user-attachments/assets/43d87e63-fd1c-4550-bde1-e1f7be006e9f

https://github.com/user-attachments/assets/aefc9b83-d0bd-4394-ae88-6c863a874973


## Related Issues

fixes #1001 