### PR TITLE
fix: Use voter_id for receipt email edit link instead of user_id

### DIFF
--- a/packages/backend/src/Controllers/Ballot/castVoteController.ts
+++ b/packages/backend/src/Controllers/Ballot/castVoteController.ts
@@ -272,7 +272,7 @@ async function handleCastVoteEvent(job: { id: string; data: CastVoteEvent; }):Pr
             throw new InternalServerError("Target Election null: " + ctx.contextId);
         }
         const url = ServiceLocator.globalData().mainUrl;
-        const receipt = Receipt(targetElection, event.userEmail, savedBallot, url)
+        const receipt = Receipt(targetElection, event.userEmail, savedBallot, url, roll)
         await EmailService.sendEmails([receipt])
     }
 }

--- a/packages/backend/src/Services/Email/EmailTemplates.ts
+++ b/packages/backend/src/Services/Email/EmailTemplates.ts
@@ -86,7 +86,7 @@ export function Blank(election: Election, voters: ElectionRoll[], url: string, e
   })
 }
 
-export function Receipt(election: Election, email: string, ballot: Ballot, url: string): Imsg {
+export function Receipt(election: Election, email: string, ballot: Ballot, url: string, roll: ElectionRoll): Imsg {
     return {
         ...emailSettings,
         to: email, // Change to your recipient
@@ -98,7 +98,7 @@ export function Receipt(election: Election, email: string, ballot: Ballot, url: 
             ${election.state === 'draft' ? "<h3>⚠️This was cast as a test ballot. All test ballots will be removed once the election is finalized, and at that time you will need to vote again.⚠️</h3>" : ''}
             <p>Thank you for voting in ${election.title}!<p>
             <p>You can <a clicktracking="off" href="${url}/${election.election_id}/ballot/${ballot.ballot_id}">verify your ballot and ballot status</a> at any time.</p>
-            ${election.settings.ballot_updates ? `<p>While the election is still open, you can <a clicktracking="off" href="${url}/${election.election_id}/id/${ballot.user_id}">update your vote</a></p>.` : ''}
+            ${election.settings.ballot_updates ? `<p>While the election is still open, you can <a clicktracking="off" href="${url}/${election.election_id}/id/${roll.voter_id}">update your vote</a></p>.` : ''}
           </div>    
         `),
     }


### PR DESCRIPTION
## Description
Use voter_id from voter roll to generate vote edit link in receipt email for editable ballot elections.

