### PR TITLE
fix: remove permission enforcement for getBallotByBallotId as it brea…

### DIFF
--- a/packages/backend/src/Controllers/Ballot/getBallotByBallotIDController.ts
+++ b/packages/backend/src/Controllers/Ballot/getBallotByBallotIDController.ts
@@ -1,7 +1,6 @@
 import ServiceLocator from "../../ServiceLocator";
 import Logger from "../../Services/Logging/Logger";
 import { BadRequest } from "@curveball/http-errors";
-import { expectPermission } from "../controllerUtils";
 import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
 import { IElectionRequest } from "../../IRequest";
 import { Response, NextFunction } from 'express';
@@ -15,8 +14,6 @@ const getBallotByBallotID = async (req: IElectionRequest, res: Response, next: N
         throw new BadRequest('No Ballot ID provided')
     }
     Logger.debug(req, "getBallotByBallotID: " + ballot_id);
-
-    expectPermission(req.user_auth.roles, permissions.canViewBallots)
 
     const ballot = await BallotModel.getBallotByID(ballot_id, req);
     if (!ballot) {


### PR DESCRIPTION
…ks email receipt link to view ballot for voter that is not logged in

## Description
Link to view  ballot in confirmation email is broken for anyone who is not logged in.  Rolling back this permission enforcement until we can think through how to support logged out use case.

## Screenshots / Videos (frontend only) 

<img width="332" height="719" alt="image" src="https://github.com/user-attachments/assets/79320c09-7a0b-462c-8e9e-dd9f95a24102" />

