### PR TITLE
feat: Restrict API ballot access to public results or closed elections.

### DIFF
--- a/packages/backend/src/Controllers/Ballot/getAnonymizedBallotsByElectionIDController.ts
+++ b/packages/backend/src/Controllers/Ballot/getAnonymizedBallotsByElectionIDController.ts
@@ -1,6 +1,6 @@
 import ServiceLocator from "../../ServiceLocator";
 import Logger from "../../Services/Logging/Logger";
-import { BadRequest } from "@curveball/http-errors";
+import { BadRequest, Unauthorized } from "@curveball/http-errors";
 import { expectPermission } from "../controllerUtils";
 import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
 import { IElectionRequest } from "../../IRequest";
@@ -15,6 +15,11 @@ export const getAnonymizedBallotsByElectionID = async (req: IElectionRequest, re
     Logger.debug(req, "getBallotsByElectionID: " + electionId);
     const election = req.election;
     if (!election.settings.public_results) {
+        if (election.state !== 'closed') {
+            const msg = `Ballot access only permited when public results are enabled or election has closed`;
+            Logger.info(req, msg);
+            throw new Unauthorized(msg)
+        }
         expectPermission(req.user_auth.roles, permissions.canViewBallots)
     }
 

--- a/packages/backend/src/Controllers/Ballot/getBallotsByElectionIDController.ts
+++ b/packages/backend/src/Controllers/Ballot/getBallotsByElectionIDController.ts
@@ -1,6 +1,6 @@
 import ServiceLocator from "../../ServiceLocator";
 import Logger from "../../Services/Logging/Logger";
-import { BadRequest } from "@curveball/http-errors";
+import { BadRequest, Unauthorized } from "@curveball/http-errors";
 import { expectPermission } from "../controllerUtils";
 import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
 import { IElectionRequest } from "../../IRequest";
@@ -13,6 +13,11 @@ const getBallotsByElectionID = async (req: IElectionRequest, res: Response, next
     Logger.debug(req, "getBallotsByElectionID: " + electionId);
 
     expectPermission(req.user_auth.roles, permissions.canViewBallots)
+    if (!req.election.settings.public_results && req.election.state !== 'closed') {
+        const msg = `Ballot access only permited when public results are enabled or election has closed`;
+        Logger.info(req, msg);
+        throw new Unauthorized(msg)
+    }
 
     const ballots = await BallotModel.getBallotsByElectionID(String(electionId), req);
     if (!ballots) {


### PR DESCRIPTION
## Description
Block GET APIs for ballots when results are not public if the election is not closed.

## Screenshots / Videos (frontend only) 

https://github.com/user-attachments/assets/b2fe0b10-1590-40ec-974c-efd565364c62



## Related Issues

fixes #1045 