### PR TITLE
fix: trim empty rows when adding voters to roll

### DIFF
--- a/packages/backend/src/Controllers/Roll/addElectionRollController.ts
+++ b/packages/backend/src/Controllers/Roll/addElectionRollController.ts
@@ -26,10 +26,7 @@ const addElectionRoll = async (req: IElectionRequest & { body: { electionRoll: E
 
     // Filter out empty roll entries (where all fields are empty)
     req.body.electionRoll = req.body.electionRoll.filter((rollInput: ElectionRollInput) => {
-        const hasVoterId = rollInput.voter_id && rollInput.voter_id.trim().length > 0;
-        const hasEmail = rollInput.email && rollInput.email.trim().length > 0;
-        const hasPrecinct = rollInput.precinct && rollInput.precinct.trim().length > 0;
-        return hasVoterId || hasEmail || hasPrecinct;
+        return rollInput.voter_id?.trim() || rollInput.email?.trim() || rollInput.precinct?.trim();
     });
 
     // Prevent creating voters by voter_id when using email invitations

--- a/packages/frontend/src/components/About.tsx
+++ b/packages/frontend/src/components/About.tsx
@@ -41,7 +41,7 @@ const About = () => {
           sx={{ maxWidth: 800 }}
         >
           {t('about.contributors').map(({github_user_name, github_image_id}) => (
-            <a href={`https://github.com/${github_user_name}`} target = "_blank" aria-label={`${github_user_name} github profile`} key={github_user_name}>
+            <a href={`https://github.com/${github_user_name}`} target = "_blank" aria-label={`${github_user_name} github profile`} key={github_user_name} rel="noreferrer">
               <Box
                 component="img"
                 src={`https://avatars.githubusercontent.com/u/${github_image_id}?v=4`}

--- a/packages/frontend/src/components/Election/Admin/AddElectionRoll.tsx
+++ b/packages/frontend/src/components/Election/Admin/AddElectionRoll.tsx
@@ -38,7 +38,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
     const onSubmit = async (e) => {
         e.preventDefault()
         try {
-            const rows = voterIDList.split('\n').filter(row => row.trim().length > 0)
+            const rows = voterIDList.split('\n').filter(row => row.trim())
             const rolls = []
             const expectedCounts = Number(enableVoterID) + Number(enableEmail) + Number(enablePrecinct)
             rows.forEach((row) => {
@@ -94,7 +94,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                 alert('Invalid headers')
                 return
             }
-            const csvRows = text.slice(text.indexOf("\n") + 1).split("\n").filter(row => row.trim().length > 0);
+            const csvRows = text.slice(text.indexOf("\n") + 1).split("\n").filter(row => row.trim());
             const rolls = csvRows.map(i => {
                 const values = i.split(",");
                 const obj = csvHeader.reduce((object, header, index) => {
@@ -104,9 +104,7 @@ const AddElectionRoll = ({ onClose }: { onClose: () => void }) => {
                 return obj;
             }).filter(roll => {
                 // Filter out rolls where all fields are empty
-                return (roll.voter_id && roll.voter_id.trim().length > 0) || 
-                       (roll.email && roll.email.trim().length > 0) || 
-                       (roll.precinct && roll.precinct.trim().length > 0);
+                return roll.voter_id?.trim() || roll.email?.trim() || roll.precinct?.trim();
             });
             submitRolls(rolls)
         };

--- a/packages/frontend/src/components/Election/Results/STAR/STARResultDetailedStepsWidget.tsx
+++ b/packages/frontend/src/components/Election/Results/STAR/STARResultDetailedStepsWidget.tsx
@@ -15,8 +15,8 @@ const STARResultDetailedStepsWidget = ({ results, rounds, t, filterRandomFromLog
         'tabulation_logs.star.runoff_win',
         'tabulation_logs.star.runoff_tiebreak',
     ];
-    let roundLogGroups = results.roundResults.map(round => {
-        let logGroups = [];
+    const roundLogGroups = results.roundResults.map(round => {
+        const logGroups = [];
         let group = [];
         round.logs.forEach((log) => {
             if(typeof log === 'string'){

--- a/packages/frontend/src/components/Election/Voting/DraggableIRVBallotView.tsx
+++ b/packages/frontend/src/components/Election/Voting/DraggableIRVBallotView.tsx
@@ -94,7 +94,7 @@ export default function DraggableIRVBallotView() {
     if (from === 'unranked' && to === 'unranked') return;
 
     // Remove id if coming from ranked
-    let base = rankedOrder.filter(x => x !== id);
+    const base = rankedOrder.filter(x => x !== id);
 
     if (to === 'unranked') {
       // Dropped into available: commit removal

--- a/packages/frontend/src/components/EnhancedTable.tsx
+++ b/packages/frontend/src/components/EnhancedTable.tsx
@@ -255,7 +255,7 @@ const headCellPool = {
     filterType: 'search',
     formatter: id => <>
       {id.startsWith('v-') && '(no account)'}
-      {!id.startsWith('v-') && <a target='_blank' href={`https://keycloak.prod.equal.vote/admin/master/console/#/Prod/users/${id}/settings`}>{limit(id, 6)}</a>}
+      {!id.startsWith('v-') && <a target='_blank' href={`https://keycloak.prod.equal.vote/admin/master/console/#/Prod/users/${id}/settings`} rel="noreferrer">{limit(id, 6)}</a>}
     </>
   },
   votes: {


### PR DESCRIPTION
## Description

Fixes #1026

Currently, including empty lines when adding new voters results in blank voters being added to the roll. This PR filters out empty/whitespace-only rows to prevent this issue.

## Changes

### Frontend (`AddElectionRoll.tsx`)
- **Manual text entry**: Filter empty/whitespace-only rows before processing
- **CSV upload**: Filter empty rows and roll objects where all fields are empty

### Backend (`addElectionRollController.ts`)
- Add validation to filter out empty roll entries (defense-in-depth)
- Prevents empty voters from reaching the database even if frontend filters are bypassed

## Testing

- ✅ No linter errors
- Existing Playwright tests should continue to pass
- Manual testing: Adding voters with empty lines will now skip those lines

## Implementation Details

Empty row detection:
- Row is empty if `trim().length === 0`
- Roll object is empty if voter_id, email, and precinct are all falsy after trimming