### PR TITLE
fix: handle new election state transitions

### DIFF
--- a/packages/backend/src/Controllers/Election/editElectionController.ts
+++ b/packages/backend/src/Controllers/Election/editElectionController.ts
@@ -29,6 +29,12 @@ const editElection = async (req: IElectionRequest, res: Response, next: NextFunc
         Logger.info(req, `Body Election ${inputElection.election_id} != param ID ${req.params.id}`);
         throw new BadRequest("Election ID must match the URL Param")
     }
+
+    // re-opening an election should maintain mutual exclusion of ballot_updates and preliminary results
+    if (inputElection.settings.ballot_updates && inputElection.state === "open" && inputElection.settings.public_results) {
+        inputElection.settings.public_results = false;
+    }
+
     Logger.debug(req, `election ID = ${inputElection}`);
     var failMsg = `Failed to update election`;
 

--- a/packages/backend/src/Controllers/Election/setOpenStateController.ts
+++ b/packages/backend/src/Controllers/Election/setOpenStateController.ts
@@ -32,6 +32,11 @@ const setOpenState = async (req: IElectionRequest, res: Response, next: NextFunc
     }
     election.state = open ? "open" : "closed";
 
+    // re-opening an election should maintain mutual exclusion of ballot_updates and preliminary results
+    if (election.settings.ballot_updates && election.state === "open" && election.settings.public_results) {
+        election.settings.public_results = false;
+    }
+
     if (msg) {
         Logger.info(req, msg);
         throw new BadRequest(msg);

--- a/packages/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/packages/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -345,7 +345,7 @@ const AdminHome = () => {
         <Races />
         <Box sx={{width: '100%'}}>
             {(election.state === 'draft') && <TestBallotSection /> }
-            {(election.state !== 'draft' && election.state !== 'finalized') && <TogglePublicResultsSection/>}
+            {!['draft', 'finalized'].includes(election.state) && !(election.state === 'open' && election.settings.ballot_updates) && <TogglePublicResultsSection/>}
             {flags.isSet('ELECTION_ROLES') && <EditRolesSection />}
             <DuplicateElectionSection/>
             {(election.state === 'open') && !election.start_time && !election.end_time && <CloseElectionSection />}

--- a/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -35,8 +35,6 @@ export default function ElectionSettings() {
     const [publicResultsDisabled, setPublicResultsDisabled] = useState(election.settings.ballot_updates);
     const [ballotUpdatesDisabledMsg, setBallotUpdatesDisabledMsg] = useState(ballotUpdatesConditionsMet && election.settings.public_results);
 
-    console.log(`prelim: ${election.settings.public_results}`);
-    console.log(`open: ${election.settings.voter_access}`);
     // Sync state when election context changes
     const syncState = () => {
         setEditedElectionSettings(election.settings);
@@ -48,7 +46,7 @@ export default function ElectionSettings() {
     };
     useEffect(() => {
         syncState();
-    }, [election.election_id]);
+    }, [election]);
 
     const applySettingsUpdate = (updateFunc: (settings: IElectionSettings) => void) => {
         const settingsCopy = structuredClone(editedElectionSettings);
@@ -189,7 +187,8 @@ export default function ElectionSettings() {
                                 <CheckboxSetting setting='random_candidate_order' />
                                 { ballotUpdatesConditionsMet && <CheckboxSetting setting='ballot_updates' hidden={!ballotUpdatesConditionsMet}
                                     disabled={election.state !== 'draft' || ballotUpdatesDisabled} checked={ballotUpdates} onChange={onChangeBallotUpdates} helperText={ballotUpdatesDisabledMsg}/>}
-                                <CheckboxSetting setting='public_results' checked={publicResults} onChange={onChangePublicResults} disabled={election.state !== 'draft' || publicResultsDisabled} helperText={publicResultsDisabled}/>
+                                { ['draft', 'finalized', 'open'].includes(election.state) && <CheckboxSetting setting='public_results' checked={publicResults}
+                                    onChange={onChangePublicResults} disabled={election.state !== 'draft' || publicResultsDisabled} helperText={publicResultsDisabled}/>}
                                 <CheckboxSetting setting='require_instruction_confirmation'/>
                                 <CheckboxSetting setting='draggable_ballot'/>
                                 <CheckboxSetting setting='is_public'/>

--- a/packages/shared/src/domain_model/ElectionSettings.ts
+++ b/packages/shared/src/domain_model/ElectionSettings.ts
@@ -73,7 +73,7 @@ function authenticationValidation(obj:authentication): string | null {
 function settingsCompatiblityValidation(settings: ElectionSettings, electionState?: ElectionState): string {
     let errorMsg = ''
     if (settings.ballot_updates) {
-        if (settings.public_results && electionState != 'closed') {
+        if (settings.public_results && ['closed', 'archived'].includes(electionState ?? '')) {
             errorMsg += 'Preliminary results are not permitted when ballot updating is enabled.  ';
         }
         if (settings.voter_access == 'open') {


### PR DESCRIPTION
## Description
Handle conflicts between ballot updates election setting requirements and state transitions. Specifically:
1. The issue where you can't archive if the vote is editable
2. The make results public button is there and enabled even when the election is open and ballot is editable but then just fails on the backend
3. If you close the election with ballot updates enabled and then make results public, if you try to use the "open" button it also just fails from backend.

## Screenshots / Videos (frontend only) 

https://github.com/user-attachments/assets/82acfe79-cdec-44a7-b58d-5a42c873f1f5

<img width="1718" height="1216" alt="Screenshot 2025-11-10 at 1 15 41 PM" src="https://github.com/user-attachments/assets/62a9b697-1bd0-4b66-97e6-4604b8367e6e" />

