### PR TITLE
Fix for contact email being truncated in "Election Settings"

### DIFF
--- a/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
+++ b/packages/frontend/src/components/ElectionForm/ElectionSettings.tsx
@@ -148,6 +148,7 @@ export default function ElectionSettings() {
                                         value={editedElectionSettings.contact_email ? editedElectionSettings.contact_email : ''}
                                         onChange={(e) => applySettingsUpdate((settings) => { settings.contact_email = e.target.value })}
                                         variant='standard'
+                                        fullWidth
                                         sx={{ mt: -1, display: 'block'}}
                                     />}
                                     label={t(`election_settings.contact_email`)}


### PR DESCRIPTION
## Description
In the "Election Settings" window, the contact email was truncated

## Screenshots / Videos (frontend only) 
<img width="884" height="1382" alt="image" src="https://github.com/user-attachments/assets/1b5f8943-e185-4243-8a20-a7a8907c74ad" />

> Be sure to include both desktop and mobile views (mobile could be as low as 320 px wide) 

## Related Issues

Fixes #1077

> For example, add ``fixes #10`` to close issue #10