### PR TITLE
fix: update Duplicate text to "create a copy"

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1040,7 +1040,7 @@ admin_home:
 
   duplicate:
     description: Duplicate
-    subtext: Create copy of this {{election}}
+    subtext: Create a copy of this {{election}}
     button: Duplicate
 
   view_results:


### PR DESCRIPTION
## Description

Changes text from "create copy of this election" to "create a copy of this election". Tested locally.

## Screenshots / Videos (frontend only) 

<img width="856" height="367" alt="Screenshot 2025-11-19 at 3 38 31 PM" src="https://github.com/user-attachments/assets/b2ce29b6-849e-4e04-9b66-73a391c06ec8" />

## Related Issues

Closes #1096