### PR TITLE
Add Issue Life cycle document

### DIFF
--- a/docs/contributions/4_issue_lifecycle.md
+++ b/docs/contributions/4_issue_lifecycle.md
@@ -14,7 +14,7 @@ Team members can create issues directly in GitHub using one of our issue templat
 
 # Board Lanes
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/8QJwyjeS290?si=YzXSTD0LfnnU5nCC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<a href="https://www.youtube.com/watch?v=8QJwyjeS290"><img width="318" height="214" alt="image" src="https://github.com/user-attachments/assets/584205ee-2451-4cc1-9270-986a9b29571d" /><br/>Click for video</a>
 
 All issues end up in the board, and then progress as follows:
 


### PR DESCRIPTION
## Description

This document reflects the new process that we discussed during our 11/18 all hands meeting. [Rough slides](https://docs.google.com/presentation/d/10Dv4GzIMQEynIU2IuEqoWpyXhuLIJ3RSyWJFWANUlEE/edit?slide=id.g3a35e889f74_0_0#slide=id.g3a35e889f74_0_0) are also available from the meeting.

 This is a draft pull request, as I'd love to get multiple approvals to ensure the new process looks good to everyone.
 
 In the meantime I'll proceed to add the features mentioned in this document (issue templates, kanban board, milestones, etc)