### PR TITLE
Update documentation to refelct migration from vite to rspack

### DIFF
--- a/docs/contributions/developers/1_local_setup.md
+++ b/docs/contributions/developers/1_local_setup.md
@@ -67,7 +67,7 @@ Here's some videos to quickly get up to speed on the core skills
 
 ### Additional Reading
 
-We compile our typescript using Vite, you can learn more in the [Vite](https://vitejs.dev/) and [Vite Awesome Repo](https://github.com/vitejs/awesome-vite).
+We compile and bundle our frontend using Rspack, you can learn more in the [Rspack website](https://rspack.rs/) and [Github Repo](https://github.com/web-infra-dev/rspack).
 
 To learn more React, check out the [React documentation](https://reactjs.org/).
 

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -31,6 +31,6 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 This allows you to see the built version of local code.
 ## Learn More
 
-You can learn more in the [Vite](https://vitejs.dev/) and [Vite Awesome Repo](https://github.com/vitejs/awesome-vite).
+You can learn more in the [Rspack website](https://rspack.rs/) and [Github Repo](https://github.com/web-infra-dev/rspack).
 
 To learn React, check out the [React documentation](https://reactjs.org/).


### PR DESCRIPTION
## Description
Documentation still reflects previous bundler (Vite). Updating document to instead refer to current bundler (Rspack)
