### PR TITLE
Feat/disable admin page for non logged in users

### DIFF
--- a/packages/frontend/src/components/Election/Admin/AdminHome.tsx
+++ b/packages/frontend/src/components/Election/Admin/AdminHome.tsx
@@ -53,8 +53,8 @@ const AdminHome = () => {
 
     const isLoggedIn = authSession.isLoggedIn()
     if (!isLoggedIn) return <Box width='100%'>
-        <Typography align='center' variant="body1" sx={{ color: 'error.main', pl: 2 }}>
-            {t('admin_home.permissions_error')}
+        <Typography align='center' variant="h5" sx={{ color: 'error.main', pl: 2 }}>
+            {t('admin_home.not_signed_in_error')}
         </Typography>
     </Box>
 

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1030,6 +1030,7 @@ admin_home:
   description_unset: (no description)
 
   permissions_error: You do not have the correct permissions for this action
+  not_signed_in_error: You need to sign in for this action
 
   roles:
     description: Add people to help run your {{election}}


### PR DESCRIPTION
## Description
If a user visits an admin page while not logged on, they will see an error message.  

## Screenshots / Videos (frontend only) 

<img width="2396" height="1662" alt="image" src="https://github.com/user-attachments/assets/30a53995-1999-411f-b14f-6b6107130023" />
## Related Issues

Fixes #1118