### PR TITLE
fix(header): use scrollTo or anchor for wizard nav based on location

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -14,11 +14,26 @@ import { ReturnToClassicContext } from './ReturnToClassicDialog';
 import { useCookie } from '~/hooks/useCookie';
 import NavMenu from './NavMenu';
 import { PrimaryButton } from './styles';
+import { useLocation } from 'react-router-dom'
+
+export const createWizardNav = (heading: string, isLandingPage: boolean) => {
+    return isLandingPage ? 
+        {
+            text: heading,
+            onClick: () => scrollToElement(document.querySelector(`.wizard`)),
+        } : {
+            text: heading,
+            href: '/#wizard',
+            target: '_self',
+        }
+};
 
 const Header = () => {
     const flags = useFeatureFlags();
     const themeSelector = useThemeSelector()
     const authSession = useAuthSession()
+    const isLandingPage = useLocation().pathname === '/'
+
     // this is important for setting the default value
     useCookie('temp_id', makeID(ID_PREFIXES.VOTER, ID_LENGTHS.VOTER))
     const {t} = useSubstitutedTranslation();
@@ -67,10 +82,7 @@ const Header = () => {
         {
             text: 'Paper Ballots',
             items: [
-                {
-                    text: 'E-Voting w/ Paper Receipts',
-                    onClick: () => scrollToElement(document.querySelector(`.wizard`)),
-                },
+                createWizardNav('E-Voting w/ Paper Receipts', isLandingPage),
                 {
                     text: 'Print Ballots',
                     href: 'https://docs.google.com/presentation/d/1va-XEsUy0VI0jCTAHrQ_f9HNKex3VK9cm7WfF6jhUYM/edit',
@@ -93,10 +105,7 @@ const Header = () => {
             href: 'https://starvoting.org/case_studies',
             target: '_self',
         },
-        {
-            text: 'Create Election' ,
-            onClick: () => scrollToElement(document.querySelector(`.wizard`)),
-        },
+        createWizardNav('Create Election', isLandingPage),
     ];
 
     const returnToClassicContext = useContext(ReturnToClassicContext);
@@ -130,7 +139,7 @@ const Header = () => {
                                         </AccordionSummary>
                                         <AccordionDetails sx={{p: 0, m: 0, mt: '.5rem', background: '#eeeeee', width: '100%' }}>
                                             {item.items.map((subitem, i) => 
-                                                <MenuItem key={i} component={Link} href={subitem.href} target={subitem.target}>{subitem.text}</MenuItem>
+                                                <MenuItem key={i} component={Link} href={subitem.href} target={subitem.target} onClick={subitem.onClick}>{subitem.text}</MenuItem>
                                             )}
                                         </AccordionDetails>
                                     </Accordion>
@@ -172,6 +181,7 @@ const Header = () => {
                                     component={Link}
                                     href={subitem.href}
                                     target={subitem.target}
+                                    onClick={subitem.onClick}
                                 >
                                     {subitem.text}
                                 </MenuItem>
@@ -187,9 +197,16 @@ const Header = () => {
                             <MenuItem component={Link} href={authSession.accountUrl} target='_blank'>
                                 {t('nav.your_account')}
                             </MenuItem>
+                            {isLandingPage && 
                             <MenuItem component={Link} onClick={() => scrollToElement(document.querySelector(`.wizard`))}>
                                 {t('nav.new_election')}
                             </MenuItem>
+                            }
+                            {!isLandingPage && 
+                            <MenuItem component={Link} href="/#wizard">
+                                {t('nav.new_election')}
+                            </MenuItem>
+                            }
                             <MenuItem component={Link} href='/manage'>
                                 {t('nav.my_elections')}
                             </MenuItem>

--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -63,6 +63,8 @@ const LandingPage = () => {
                 </Typography>
             </Box>
             <LandingPageStats/>
+            {/* putting the anchor on the Wizard component scrolls too far */}
+            <div id='wizard'></div>
             <Wizard/>
             {featuredElectionIds.length > 0 && <LandingPageFeaturedElections electionIds={featuredElectionIds}/>}
             <LandingPageFeatures/>


### PR DESCRIPTION
## Description

Fixes https://github.com/Equal-Vote/bettervoting/issues/1191 by configuring the header nav to use a scrollTo if we're on the landing page or an anchor if we're not.

Also fixed the nested nav logic, which wasn't including `onClick` in subitems.

## Screenshots / Videos (frontend only) 

Minor annoyance (better than nothing): 

When using the anchor, it doesn't go to the same place as the scrollTo because that method is taking into account the height of the nav bar, but the anchor doesn't. 

ScrollTo on Mobile:

<img width="330" height="505" alt="image" src="https://github.com/user-attachments/assets/e9a4b2c1-5708-4248-b0bc-042ea83e5e61" />

vs. Anchor on Mobile:

<img width="338" height="485" alt="image" src="https://github.com/user-attachments/assets/031d91dd-4281-42fa-9e27-33b100c91c88" />

ScrollTo on Desktop:

<img width="843" height="327" alt="image" src="https://github.com/user-attachments/assets/e6778473-f7d1-4c9a-827a-0c06a9845074" />

vs anchor on desktop:

<img width="887" height="242" alt="image" src="https://github.com/user-attachments/assets/8da10a85-f8f2-43e6-980c-b0af55db7d0c" />

## Related Issues

fixes #1191 