### PR TITLE
fix: react router and react router dom are supposed to stay lockstep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
         "rimraf": "^5.0.5"
       },
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "*",
-        "@rspack/binding-darwin-x64": "*",
-        "@rspack/binding-linux-arm64-gnu": "*",
-        "@rspack/binding-linux-x64-gnu": "*",
-        "@rspack/binding-linux-x64-musl": "*"
+        "@rspack/binding-darwin-arm64": "latest",
+        "@rspack/binding-darwin-x64": "latest",
+        "@rspack/binding-linux-arm64-gnu": "latest",
+        "@rspack/binding-linux-x64-gnu": "latest",
+        "@rspack/binding-linux-x64-musl": "latest"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -7647,13 +7647,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "license": "MIT",
@@ -11596,27 +11589,19 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.0.2",
-      "license": "MIT",
+      "version": "6.30.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.2.tgz",
+      "integrity": "sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==",
       "dependencies": {
-        "history": "^5.1.0",
-        "react-router": "6.0.2"
+        "@remix-run/router": "1.23.1",
+        "react-router": "6.30.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
-      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "history": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
       }
     },
     "node_modules/react-slot-counter": {
@@ -14207,7 +14192,7 @@
         "react-icons": "^4.7.1",
         "react-ratings-declarative": "3.4.1",
         "react-router": "6.30.2",
-        "react-router-dom": "6.0.2",
+        "react-router-dom": "^6.30.2",
         "react-slot-counter": "^2.3.3",
         "recharts": "^2.6.2",
         "rewire": "^7.0.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -30,7 +30,7 @@
     "react-icons": "^4.7.1",
     "react-ratings-declarative": "3.4.1",
     "react-router": "6.30.2",
-    "react-router-dom": "6.0.2",
+    "react-router-dom": "^6.30.2",
     "react-slot-counter": "^2.3.3",
     "recharts": "^2.6.2",
     "rewire": "^7.0.0",


### PR DESCRIPTION
When I installed dev from scratch, the 6.30.2 6.0.2 discrepancy (introduced from a version bump on Jan 15) was causing my frontend to fail (show a mostly white screen with just a tiny green "feedback?" button 😂 ).  I believe this is the correct fix to package.json and package-lock.json.  But I am generally terrified of touching package-lock.json.  So.  I hope this doesn't break Everything.  

Conversely, I'm slightly surprised that the version bump on Jan 15 didn't break Everything 😂 because it broke my ability to build from scratch.  