### PR TITLE
feat: add on-assign bot to prompt for availability and ETA

### DIFF
--- a/.github/workflows/on-assign-message.yml
+++ b/.github/workflows/on-assign-message.yml
@@ -20,11 +20,15 @@ jobs:
             const assigner = context.payload.sender.login;
             const issueNumber = context.payload.issue.number;
             
+            console.log(`Assignment event: assignee=${assignee}, assigner=${assigner}`);
+            
             // Only post message if user self-assigned (assignee === assigner)
             if (assignee !== assigner) {
               console.log(`Skipping: Issue was assigned by ${assigner} to ${assignee} (not self-assigned)`);
               return;
             }
+            
+            console.log(`Self-assignment detected! Posting welcome message.`);
             
             const message = `👋 Hi @${assignee}! Thank you for taking on this issue!
 


### PR DESCRIPTION
## Summary
Implements automated welcome message when users self-assign issues per #1147.

## Changes
- Created GitHub Actions workflow triggered on `issues: assigned` event
- Posts welcome message asking assignee for:
  - Availability for the week
  - Estimated ETA for completion
- Only triggers on self-assignment (assignee === sender)
- Uses `github-script` action for inline implementation

## Testing
✅ Tested on fork with self-assignment - message posted correctly
✅ Added logging to verify sender/assignee comparison
⚠️ Could not test with another user assigning (no second account available)

According to [GitHub webhook documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads), `sender` is "The user that triggered the event", which should be the assigner for assignment events.

## Next Steps
After merge, add comment to #1144 to update developer onboarding template to mention this automated message.

Closes #1147