### PR TITLE
add a link to help in About page 

### DIFF
--- a/packages/frontend/src/components/About.tsx
+++ b/packages/frontend/src/components/About.tsx
@@ -28,6 +28,13 @@ const About = () => {
           {t('about.description')}
         </Typography>
 
+        <Typography sx={{ mt: 2 }}>
+          For more information, visit our documentation at{' '}
+          <a href="https://docs.bettervoting.com" target="_blank" rel="noreferrer">
+            docs.bettervoting.com
+          </a>.
+        </Typography>
+
         <h1>{t('about.team_title')}</h1>
         <h2>{t('about.leads_title')}</h2>
         <ul>{t('about.leads').map((content, i) => <li key={i}>{content}</li>)}</ul>


### PR DESCRIPTION
so it is at least *possible* to navigate to help without logging in :)

I think this could either close or at least backburner #920 