### PR TITLE
fix(backend): handle missing awaits

### DIFF
--- a/packages/backend/src/Controllers/Roll/changeElectionRollController.ts
+++ b/packages/backend/src/Controllers/Roll/changeElectionRollController.ts
@@ -14,25 +14,25 @@ const className = "VoterRollState.Controllers";
 
 const approveElectionRoll = async (req: IElectionRequest, res: Response, next: NextFunction) => {
     Logger.info(req, `${className}.approveElectionRoll ${req.params.id}`);
-    changeElectionRollState(req, ElectionRollState.approved, [ElectionRollState.registered, ElectionRollState.flagged], permissions.canApproveElectionRoll)
+    await changeElectionRollState(req, ElectionRollState.approved, [ElectionRollState.registered, ElectionRollState.flagged], permissions.canApproveElectionRoll)
     res.status(200).json({})
 }
 
 const flagElectionRoll = async (req: IElectionRequest, res: Response, next: NextFunction) => {
     Logger.info(req, `${className}.flagElectionRoll ${req.params.id}`);
-    changeElectionRollState(req, ElectionRollState.flagged, [ElectionRollState.approved, ElectionRollState.registered, ElectionRollState.invalid], permissions.canFlagElectionRoll)
+    await changeElectionRollState(req, ElectionRollState.flagged, [ElectionRollState.approved, ElectionRollState.registered, ElectionRollState.invalid], permissions.canFlagElectionRoll)
     res.status(200).json({})
 }
 
 const invalidateElectionRoll = async (req: IElectionRequest, res: Response, next: NextFunction) => {
     Logger.info(req, `${className}.flagElectionRoll ${req.params.id}`);
-    changeElectionRollState(req, ElectionRollState.invalid, [ElectionRollState.flagged], permissions.canInvalidateBallot)
+    await changeElectionRollState(req, ElectionRollState.invalid, [ElectionRollState.flagged], permissions.canInvalidateBallot)
     res.status(200).json({})
 }
 
 const uninvalidateElectionRoll = async (req: IElectionRequest, res: Response, next: NextFunction) => {
     Logger.info(req, `${className}.flagElectionRoll ${req.params.id}`);
-    changeElectionRollState(req, ElectionRollState.flagged, [ElectionRollState.invalid], permissions.canInvalidateBallot)
+    await changeElectionRollState(req, ElectionRollState.flagged, [ElectionRollState.invalid], permissions.canInvalidateBallot)
     res.status(200).json({})
 }
 


### PR DESCRIPTION
## Description
This PR stops a flaw that could bring down the server. The backend previously told the database to update the roll state but did not await the outcome. Unhandled promise rejections broke the server if a user gave bad data like a missing voter ID.

Now, the handlers await the writes. Thrown errors are caught and given to the error middleware.

Local tests passed. Bad inputs now yield an HTTP error and leave the server running instead of killing the process.