### PR TITLE
fix(account): prevent custom auth_key spoofing and algorithm confusion

### DIFF
--- a/packages/backend/src/Services/Account/AccountService.ts
+++ b/packages/backend/src/Services/Account/AccountService.ts
@@ -6,8 +6,6 @@ import { InternalServerError } from "@curveball/http-errors";
 import { IRequest } from '../../IRequest';
 import AccountServiceUtils from './AccountServiceUtils';
 
-var jwt = require('jsonwebtoken');
-
 export default class AccountService {
     authConfig;
     private privateKey:string;
@@ -97,6 +95,9 @@ export default class AccountService {
     extractUserFromRequest = (req:IRequest, customKey?:string) => {
         const token = customKey ? req.cookies.custom_id_token : req.cookies.id_token;
         if (token){
+            if (customKey) {
+                Logger.debug(req, "using custom authKey");
+            }
             const key = customKey ? customKey : this.publicKey;
             return AccountServiceUtils.extractUserFromRequest(req, token, key);
         }

--- a/packages/backend/src/Services/Account/AccountServiceUtils.ts
+++ b/packages/backend/src/Services/Account/AccountServiceUtils.ts
@@ -1,4 +1,3 @@
-import { Election } from "@equal-vote/star-vote-shared/domain_model/Election";
 import { IRequest } from "../../IRequest";
 import Logger from "../Logging/Logger";
 
@@ -11,17 +10,12 @@ export default class AccountServiceUtils {
         token: string,
         key: string
     ) => {
-        const inputElection: Election | undefined = req.body.Election;
-        if (inputElection && inputElection.auth_key && inputElection.auth_key != "") {
-            Logger.debug(
-                req,
-                "have input election with custom authKey",
-                inputElection.auth_key
-            );
-            key = inputElection.auth_key;
-        }
+        // TODO: migrate to storing an explicitly-defined auth_algorithm value in the election db
+        const isCustomKeyAsymmetric = key.includes('-----BEGIN PUBLIC KEY') || key.includes('-----BEGIN CERTIFICATE');
+        const algorithms = isCustomKeyAsymmetric ? ['RS256'] : ['HS256'];
+
         try {
-            return jwt.verify(token, key);
+            return jwt.verify(token, key, { algorithms });
         } catch (e: any) {
             Logger.warn(req, "JWT Verify Error: ", e.message);
             throw new Unauthorized();

--- a/packages/backend/src/Services/Account/__mocks__/AccountService.ts
+++ b/packages/backend/src/Services/Account/__mocks__/AccountService.ts
@@ -1,4 +1,3 @@
-import { InternalServerError, Unauthorized } from "@curveball/http-errors";
 import { IRequest } from '../../../IRequest';
 import Logger from "../../Logging/Logger";
 import AccountServiceUtils from "../AccountServiceUtils";
@@ -24,6 +23,9 @@ export default class AccountService {
             return jwt.decode(token);
         }
         if (token){
+            if (customKey) {
+                Logger.debug(req, "using custom authKey");
+            }
             const key = customKey ? customKey : this.privateKey;
             return AccountServiceUtils.extractUserFromRequest(req, token, key);
         }


### PR DESCRIPTION
## Description
This PR stops an authentication bypass flaw that let anyone forge their own JWT verification keys. Before this PR, the backend insecurely took the auth_key straight from the incoming JSON body. This let anyone sign their own tokens and attach the corresponding public key to their request body.

To fix this, the auth_key override was removed. The desired custom key feature should still work with electionSpecificAuth and accountService.extractUserFromRequest.

Main changes:

* Removed the vulnerable inputElection payload extraction block from AccountServiceUtils.ts
* Specified allowed algorithms and created a quick heuristic to detect if the provided key is symmetric or asymmetric
* Cleaned up unused dependencies left behind

My previously successful attempts to get the server to accept my spoofed JWT no longer work with this PR.