### PR TITLE
fix(security): prevent X-Forwarded-For IP spoofing

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -31,7 +31,9 @@ export default function makeApp() {
     }))
 
     // Set to trust proxy so we can resolve client IP address
-    app.enable('trust proxy')
+    // We trust internal network IPs (like the internal Azure infrastructure) as proxies.
+    // This tracks the real client IP regardless of the number of internal routing hops, while stripping spoofed headers.
+    app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'])
 
     app.use(iRequestMiddleware);
     app.use(loggerMiddleware);


### PR DESCRIPTION
## Description

This PR stops an IP spoofing vulnerability that let users forge their request origin and bypass the one vote per network setting. Before this PR, the backend indiscriminately trusted all proxy connections with `app.enable('trust proxy')`. This let anyone inject arbitrary IP addresses into their `X-Forwarded-For` HTTP headers, tricking the backend into believing they were voting from a different IP.

Because this application is hosted within Azure AKS, we will still trust `['loopback', 'linklocal', 'uniquelocal']` private subnets. If there are more hops that go through external IPs, please let me know. While my previously successful spoofs no longer work with this PR when testing locally (taking loopback out), I'm not sure if this would work in production so please review :)