### PR TITLE
fix: prevent host header injection in email links

### DIFF
--- a/packages/backend/src/Controllers/Election/sendEmailController.ts
+++ b/packages/backend/src/Controllers/Election/sendEmailController.ts
@@ -136,7 +136,7 @@ const sendEmailsController = async (req: IElectionRequest, res: Response, next: 
 
     const Jobs: email_request_event[] = []
     const reqId = req.contextId ? req.contextId : randomUUID();
-    const url = req.protocol + '://' + req.get('host')
+    const url = ServiceLocator.globalData().mainUrl;
     electionRoll.forEach(roll => {
         Jobs.push(
             {

--- a/packages/backend/src/Controllers/Election/sendInvitesController.ts
+++ b/packages/backend/src/Controllers/Election/sendInvitesController.ts
@@ -66,7 +66,7 @@ const sendInvitationsController = async (req: IElectionRequest, res: Response, n
 async function sendBatchEmailInvites(req: any, electionRoll: ElectionRoll[], election: Election) {
     const Jobs: SendInviteEvent[] = []
     const reqId = req.contextId ? req.contextId : randomUUID();
-    const url = req.protocol + '://' + req.get('host')
+    const url = ServiceLocator.globalData().mainUrl;
     electionRoll.forEach(roll => {
         Jobs.push(
             {
@@ -97,7 +97,7 @@ const sendInvitationController = async (req: any, res: any, next: any) => {
     if (!(req.election.settings.voter_access === 'closed' && req.election.settings.invitation === 'email')) {
         throw new BadRequest('Email invitations not enabled')
     }
-    const url = req.protocol + '://' + req.get('host')
+    const url = ServiceLocator.globalData().mainUrl;
 
     const electionId = req.election.election_id;
     const election = req.election

--- a/packages/backend/src/Services/Email/EmailTemplates.ts
+++ b/packages/backend/src/Services/Email/EmailTemplates.ts
@@ -24,7 +24,7 @@ export function makeEmails(election: Election, voters: ElectionRoll[], url: stri
         return formatMarkdown(body, {
             allowButtons: true,
             buttonContext: {
-                voteUrl: `${url}/${election.election_id}/${election.settings.voter_authentication.voter_id === true && 'id/' + voter_id}`,
+                voteUrl: `${url}/${election.election_id}${election.settings.voter_authentication.voter_id ? '/id/' + voter_id : ''}`,
                 electionHomeUrl: `${url}/${election.election_id}`
             }
         });
@@ -65,7 +65,7 @@ export function Invites(election: Election, voters: ElectionRoll[], url: string,
 
           <p>Click the button to vote:</p>
 
-          ${makeButton('Vote', `${url}/${election.election_id}/${election.settings.voter_authentication.voter_id === true && 'id/' + voter.voter_id}`)}
+          ${makeButton('Vote', `${url}/${election.election_id}${election.settings.voter_authentication.voter_id ? '/id/' + voter.voter_id : ''}`)}
 
           <p>This link is unique to you, be careful not to share this email with others</p>
         `)

--- a/packages/backend/src/Services/GlobalData.ts
+++ b/packages/backend/src/Services/GlobalData.ts
@@ -3,6 +3,8 @@ export default class GlobalData {
   mainUrl:string;
 
   constructor() {
-    this.mainUrl = process.env.MAIN_URL || "https://bettervoting.com";
+    let url = process.env.MAIN_URL || "https://bettervoting.com";
+    if (url.endsWith('/')) url = url.slice(0, -1);
+    this.mainUrl = url;
   }
 }


### PR DESCRIPTION
## Description
This PR patches a latent Host Header Injection vulnerability in the outbound email generation logic. While the production infrastructure currently shields the live server from this attack by enforcing explicit Host headers, the controllers implicitly trusted the client-supplied `Host` header at the application layer. Without the external infrastructure mitigation, this would allow anyone to hijack the email origin and inject their own domains into the hyperlinks of mass email campaigns using SendGrid.
* Removes insecure `req.get('host')` usage from email controllers
* Email base URLs now securely default to `ServiceLocator.globalData().mainUrl`
* Added trailing slash stripping to prevent potential double-slash bugs
* Rewrote `&&` string interpolations into strict ternary operators in `EmailTemplates.ts` to prevent missing voter IDs from generating broken `/false` URLs.