### PR TITLE
Sendgrid signature verification

### DIFF
--- a/packages/backend/src/Controllers/sendGridWebhookController.ts
+++ b/packages/backend/src/Controllers/sendGridWebhookController.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express';
+import crypto from 'crypto';
 import { IRequest } from '../IRequest';
 import Logger from '../Services/Logging/Logger';
 import { logSafeHash } from '../Services/Logging/logSafeHash';
@@ -17,15 +18,33 @@ export const sendGridWebhookController = (req: IRequest, res: Response) => {
     const timestamp = String(req.headers['x-twilio-email-event-webhook-timestamp'] ?? 'missing');
     Logger.info(req, `SendGridWebhook signature=${signature} timestamp=${timestamp}`);
 
+    let events: SendGridEvent[];
     try {
-        const events: SendGridEvent[] = JSON.parse(rawBody.toString('utf8'));
-        const summary = events.map(e => `event=${e.event} email=${logSafeHash(e.email)}`).join('; ');
-        Logger.info(req, `SendGridWebhook events: ${summary}`);
+        events = JSON.parse(rawBody.toString('utf8'));
     } catch {
         Logger.warn(req, `SendGridWebhook: could not parse body`);
+        res.status(400).send('Bad request');
+        return;
     }
 
-    // TODO: verify signature using SENDGRID_WEBHOOK_VERIFICATION_KEY env var
-    // verification checks: ECDSA signature over (timestamp + raw body) matches public key
+    const redactedEvents = events.map(({ email, unique_args, ...rest }) => ({ ...rest, email: logSafeHash(email) }));
+    Logger.info(req, `SendGridWebhook events: ${JSON.stringify(redactedEvents)}`);
+
+    const verificationKey = 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5qOZpcaMe4gniCO5t9fSMq0MtkKvVL0qoqUX6Al/sKQK4OLhACy2WJzwYEm6MJm6djEk8GpTkjoTP9hu5ogSOQ==';
+
+    const publicKey = crypto.createPublicKey({
+        key: Buffer.from(verificationKey, 'base64'),
+        format: 'der',
+        type: 'spki',
+    });
+    const payload = timestamp + rawBody.toString('utf8');
+    const valid = crypto.verify(null, Buffer.from(payload), publicKey, Buffer.from(signature, 'base64'));
+
+    if (!valid) {
+        Logger.warn(req, `SendGridWebhook: invalid signature`);
+        res.status(403).send('Invalid signature');
+        return;
+    }
+
     res.status(200).send('OK');
 };

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -42,6 +42,9 @@ export default function makeApp() {
     const frontendPath = '../../../../packages/frontend/build/';
     
     const path = require('path');
+    // SendGrid webhook must be registered before express.json() to preserve the raw body for signature verification
+    app.post('/API/SendGridWebhook', express.raw({ type: 'application/json' }), sendGridWebhookController);
+
     app.use(express.json());
     //Routes
     app.use('/API', getUser, electionsRouter)
@@ -50,7 +53,6 @@ export default function makeApp() {
     // app.use('/debug',debugRouter)
     app.use('/API/Docs', swaggerUi.serve, swaggerUi.setup(swagger));
     app.post('/API/Token', asyncHandler(getUserToken));
-    app.post('/API/SendGridWebhook', express.raw({ type: 'application/json' }), sendGridWebhookController);
 
     // NOTE: I've removed express.static because it doesn't allow me to inject meta tags
     // https://stackoverflow.com/questions/51120214/how-to-modify-static-file-content-with-express-static


### PR DESCRIPTION
We now have the sendgrid public key used for this webhook.  This PR commits it and uses it to verify.  There should be no problem with committing this public key as far as I can tell.  

Also: sendgrid webhook information was being json'd too early (preventing signature verification).  Should work with this fix 🤞 .