### PR TITLE
Add per-voting-method breakdowns to global election stats

### DIFF
--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -110,6 +110,7 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
     const electionMethodMap: Record<string, ElectionMethodKey> = {};
     electionRaces?.forEach(e => {
         const methods = new Set((e.races as Race[]).map(r => r.voting_method));
+        if (methods.size === 0) return; // drafted elections with no races yet — skip
         let methodKey: ElectionMethodKey;
         if (methods.size > 1) {
             methodKey = 'multi_method';

--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -159,7 +159,6 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
             stats[`${methodKey}_elections`] += 1;
             stats[`${methodKey}_votes`] += Number(m['v']);
         });
-        });
 
     return stats;
 }

--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -4,6 +4,7 @@ import { BadRequest } from "@curveball/http-errors";
 import { IElectionRequest, IRequest } from "../../IRequest";
 import { Response, NextFunction } from 'express';
 import { Election, removeHiddenFields } from '@equal-vote/star-vote-shared/domain_model/Election';
+import { Race, VotingMethod, MethodTextKey, methodValueToTextKey } from '@equal-vote/star-vote-shared/domain_model/Race';
 import { expectPermission } from '../controllerUtils';
 import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
 
@@ -82,19 +83,19 @@ const queryElections = async (req: IElectionRequest, res: Response, next: NextFu
     });
 }
 
-const VOTING_METHOD_KEYS: Record<string, string> = {
-    'STAR': 'star',
-    'IRV': 'rcv',
-    'Approval': 'approval',
-    'RankedRobin': 'ranked_robin',
-    'STAR_PR': 'star_pr',
-    'Plurality': 'plurality',
-    'STV': 'stv',
-};
+type ElectionMethodKey = MethodTextKey | 'multi_method';
 
-const ALL_METHOD_KEYS = ['star', 'rcv', 'approval', 'ranked_robin', 'star_pr', 'plurality', 'stv', 'multi_method'];
+const ALL_METHOD_KEYS: ElectionMethodKey[] = [
+    ...(Object.values(methodValueToTextKey) as MethodTextKey[]),
+    'multi_method',
+];
 
-const innerGetGlobalElectionStats = async (req: IRequest) => {
+type GlobalElectionStats =
+    { elections: number; votes: number; legacy_elections: number; legacy_votes: number } &
+    Record<`${ElectionMethodKey}_votes`, number> &
+    Record<`${ElectionMethodKey}_elections`, number>;
+
+const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectionStats> => {
     Logger.info(req, `getGlobalElectionStats `);
 
     const [electionVotes, electionRaces, sourcedFromPrior] = await Promise.all([
@@ -106,12 +107,18 @@ const innerGetGlobalElectionStats = async (req: IRequest) => {
     const priorElections = sourcedFromPrior?.map(e => e.election_id) ?? [];
 
     // Build election_id -> method_key map; elections with multiple distinct methods are 'multi_method'
-    const electionMethodMap: Record<string, string> = {};
+    const electionMethodMap: Record<string, ElectionMethodKey> = {};
     electionRaces?.forEach(e => {
-        const methods = new Set((e.races as any[]).map(r => r.voting_method));
-        const methodKey = methods.size > 1
-            ? 'multi_method'
-            : (VOTING_METHOD_KEYS[[...methods][0] as string] ?? 'other');
+        const methods = new Set((e.races as Race[]).map(r => r.voting_method));
+        let methodKey: ElectionMethodKey;
+        if (methods.size > 1) {
+            methodKey = 'multi_method';
+        } else {
+            const vm = [...methods][0] as VotingMethod;
+            const key = methodValueToTextKey[vm];
+            if (!key) throw new Error(`Unknown voting method: ${vm} for election ${e.election_id}`);
+            methodKey = key;
+        }
         electionMethodMap[e.election_id] = methodKey;
     });
 
@@ -121,30 +128,25 @@ const innerGetGlobalElectionStats = async (req: IRequest) => {
     // legacy_* holds pre-existing counts from classic star.vote; the per-method breakdowns
     // cover only current elections, so: votes = legacy_votes + sum(method_votes),
     // and: elections = legacy_elections + sum(method_elections)
-    const stats: Record<string, number> = {
+    const stats = {
         elections: legacyElections,
         votes: legacyVotes,
         legacy_elections: legacyElections,
         legacy_votes: legacyVotes,
-    };
-
-    for (const key of ALL_METHOD_KEYS) {
-        stats[`${key}_elections`] = 0;
-        stats[`${key}_votes`] = 0;
-    }
+        ...Object.fromEntries(ALL_METHOD_KEYS.flatMap(k => [[`${k}_votes`, 0], [`${k}_elections`, 0]])),
+    } as GlobalElectionStats;
 
     electionVotes
         ?.filter(m => !priorElections.includes(m['election_id']))
         ?.forEach((m) => {
             const count = Number(m['v']);
-            stats['votes'] += count;
-            if (count >= 2) stats['elections'] += 1;
+            stats.votes += count;
+            if (count >= 2) stats.elections += 1;
 
-            const methodKey = electionMethodMap[m['election_id']] ?? 'other';
-            if (stats[`${methodKey}_votes`] !== undefined) {
-                stats[`${methodKey}_votes`] += count;
-                if (count >= 2) stats[`${methodKey}_elections`] += 1;
-            }
+            const methodKey = electionMethodMap[m['election_id']];
+            if (!methodKey) throw new Error(`No voting method found for election ${m['election_id']}`);
+            stats[`${methodKey}_votes`] += count;
+            if (count >= 2) stats[`${methodKey}_elections`] += 1;
         });
 
     return stats;

--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -7,6 +7,7 @@ import { Election, removeHiddenFields } from '@equal-vote/star-vote-shared/domai
 import { Race, VotingMethod, MethodTextKey, methodValueToTextKey } from '@equal-vote/star-vote-shared/domain_model/Race';
 import { expectPermission } from '../controllerUtils';
 import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
+import { sharedConfig } from '@equal-vote/star-vote-shared/config';
 
 
 var ElectionsModel = ServiceLocator.electionsDb();
@@ -105,11 +106,16 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
     ]);
 
     const priorElections = sourcedFromPrior?.map(e => e.election_id) ?? [];
+    const devElections: string[] = [];
 
     // Build election_id -> method_key map; elections with multiple distinct methods are 'multi_method'
     const electionMethodMap: Record<string, ElectionMethodKey> = {};
     electionRaces?.forEach(e => {
         const methods = new Set((e.races as Race[]).map(r => r.voting_method));
+        if(sharedConfig.DEV_USERS.includes(e.owner_id) && !sharedConfig.REAL_ELECTIONS_FROM_DEVS.includes(e.election_id)) {
+            devElections.push(e.election_id);
+            return;
+        }
         if (methods.size === 0) return; // drafted elections with no races yet — skip
         let methodKey: ElectionMethodKey;
         if (methods.size > 1) {
@@ -139,17 +145,19 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
     } as GlobalElectionStats;
 
     electionVotes
+        ?.filter(m => !devElections.includes(m['election_id']))
         ?.filter(m => !priorElections.includes(m['election_id']))
+        ?.filter(m => m['v'] >= 2)
         ?.forEach((m) => {
-            const count = Number(m['v']);
-            stats.votes += count;
-            if (count >= 2) stats.elections += 1;
+            stats.elections += 1;
+            // Number() is required for some reason
+            stats.votes += Number(m['v']);
 
             const methodKey = electionMethodMap[m['election_id']];
             // there's some garbage elections with an invalid voting method of "STAR VOting" (proper term is "STAR"). We can skip those
             if (!methodKey) return; // throw new Error(`No voting method found for election ${m['election_id']}`);
-            stats[`${methodKey}_votes`] += count;
-            if (count >= 2) stats[`${methodKey}_elections`] += 1;
+            stats[`${methodKey}_elections`] += 1;
+            stats[`${methodKey}_votes`] += Number(m['v']);
         });
 
     return stats;

--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -82,30 +82,70 @@ const queryElections = async (req: IElectionRequest, res: Response, next: NextFu
     });
 }
 
+const VOTING_METHOD_KEYS: Record<string, string> = {
+    'STAR': 'star',
+    'IRV': 'rcv',
+    'Approval': 'approval',
+    'RankedRobin': 'ranked_robin',
+    'STAR_PR': 'star_pr',
+    'Plurality': 'plurality',
+    'STV': 'stv',
+};
+
+const ALL_METHOD_KEYS = ['star', 'rcv', 'approval', 'ranked_robin', 'star_pr', 'plurality', 'stv', 'multi_method'];
+
 const innerGetGlobalElectionStats = async (req: IRequest) => {
     Logger.info(req, `getGlobalElectionStats `);
 
-    let electionVotes = await ElectionsModel.getBallotCountsForAllElections(req);
+    const [electionVotes, electionRaces, sourcedFromPrior] = await Promise.all([
+        ElectionsModel.getBallotCountsForAllElections(req),
+        ElectionsModel.getElectionRacesForAllElections(req),
+        ElectionsModel.getElectionsSourcedFromPrior(req),
+    ]);
 
-    let sourcedFromPrior = await ElectionsModel.getElectionsSourcedFromPrior(req);
-    let priorElections = sourcedFromPrior?.map(e => e.election_id) ?? [];
+    const priorElections = sourcedFromPrior?.map(e => e.election_id) ?? [];
 
-    let stats = {
-        elections: Number(process.env.CLASSIC_ELECTION_COUNT ?? 0),
-        votes: Number(process.env.CLASSIC_VOTE_COUNT ?? 0),
+    // Build election_id -> method_key map; elections with multiple distinct methods are 'multi_method'
+    const electionMethodMap: Record<string, string> = {};
+    electionRaces?.forEach(e => {
+        const methods = new Set((e.races as any[]).map(r => r.voting_method));
+        const methodKey = methods.size > 1
+            ? 'multi_method'
+            : (VOTING_METHOD_KEYS[[...methods][0] as string] ?? 'other');
+        electionMethodMap[e.election_id] = methodKey;
+    });
+
+    const legacyVotes = Number(process.env.CLASSIC_VOTE_COUNT ?? 0);
+    const legacyElections = Number(process.env.CLASSIC_ELECTION_COUNT ?? 0);
+
+    // legacy_* holds pre-existing counts from classic star.vote; the per-method breakdowns
+    // cover only current elections, so: votes = legacy_votes + sum(method_votes),
+    // and: elections = legacy_elections + sum(method_elections)
+    const stats: Record<string, number> = {
+        elections: legacyElections,
+        votes: legacyVotes,
+        legacy_elections: legacyElections,
+        legacy_votes: legacyVotes,
     };
+
+    for (const key of ALL_METHOD_KEYS) {
+        stats[`${key}_elections`] = 0;
+        stats[`${key}_votes`] = 0;
+    }
 
     electionVotes
         ?.filter(m => !priorElections.includes(m['election_id']))
-        ?.map(m => m['v'])
-        ?.forEach((count) => {
-            stats['votes'] = stats['votes'] + Number(count);
-            if(count >= 2){
-                stats['elections'] = stats['elections'] + 1;
+        ?.forEach((m) => {
+            const count = Number(m['v']);
+            stats['votes'] += count;
+            if (count >= 2) stats['elections'] += 1;
+
+            const methodKey = electionMethodMap[m['election_id']] ?? 'other';
+            if (stats[`${methodKey}_votes`] !== undefined) {
+                stats[`${methodKey}_votes`] += count;
+                if (count >= 2) stats[`${methodKey}_elections`] += 1;
             }
-            return stats;
-        }
-    );
+        });
 
     return stats;
 }

--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -149,15 +149,16 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
         ?.filter(m => !priorElections.includes(m['election_id']))
         ?.filter(m => m['v'] >= 2)
         ?.forEach((m) => {
-            stats.elections += 1;
-            // Number() is required for some reason
-            stats.votes += Number(m['v']);
-
             const methodKey = electionMethodMap[m['election_id']];
             // there's some garbage elections with an invalid voting method of "STAR VOting" (proper term is "STAR"). We can skip those
             if (!methodKey) return; // throw new Error(`No voting method found for election ${m['election_id']}`);
+
+            stats.elections += 1;
+            // Number() is required for some reason
+            stats.votes += Number(m['v']);
             stats[`${methodKey}_elections`] += 1;
             stats[`${methodKey}_votes`] += Number(m['v']);
+        });
         });
 
     return stats;

--- a/packages/backend/src/Controllers/Election/getElectionsController.ts
+++ b/packages/backend/src/Controllers/Election/getElectionsController.ts
@@ -117,7 +117,8 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
         } else {
             const vm = [...methods][0] as VotingMethod;
             const key = methodValueToTextKey[vm];
-            if (!key) throw new Error(`Unknown voting method: ${vm} for election ${e.election_id}`);
+            // there's some garbage elections with an invalid voting method of "STAR VOting" (proper term is "STAR"). We can skip those
+            if (!key) return; //throw new Error(`Unknown voting method: ${vm} for election ${e.election_id}`);
             methodKey = key;
         }
         electionMethodMap[e.election_id] = methodKey;
@@ -145,7 +146,8 @@ const innerGetGlobalElectionStats = async (req: IRequest): Promise<GlobalElectio
             if (count >= 2) stats.elections += 1;
 
             const methodKey = electionMethodMap[m['election_id']];
-            if (!methodKey) throw new Error(`No voting method found for election ${m['election_id']}`);
+            // there's some garbage elections with an invalid voting method of "STAR VOting" (proper term is "STAR"). We can skip those
+            if (!methodKey) return; // throw new Error(`No voting method found for election ${m['election_id']}`);
             stats[`${methodKey}_votes`] += count;
             if (count >= 2) stats[`${methodKey}_elections`] += 1;
         });

--- a/packages/backend/src/Models/Elections.ts
+++ b/packages/backend/src/Models/Elections.ts
@@ -162,14 +162,14 @@ export default class ElectionsDB implements IElectionStore {
             .catch(dneCatcher);
     }
 
-    getElectionRacesForAllElections(ctx: ILoggingContext): Promise<Pick<Election, 'election_id' | 'races'>[] | null> {
+    getElectionRacesForAllElections(ctx: ILoggingContext): Promise<Pick<Election, 'election_id' | 'owner_id' | 'races'>[] | null> {
         Logger.debug(ctx, `${tableName}.getElectionRacesForAllElections`);
         return this._postgresClient
             .selectFrom(tableName)
-            .select(['election_id', 'races'])
+            .select(['election_id', 'owner_id', 'races'])
             .where('head', '=', true)
             .execute()
-            .catch(dneCatcher) as Promise<Pick<Election, 'election_id' | 'races'>[] | null>;
+            .catch(dneCatcher) as Promise<Pick<Election, 'election_id' | 'owner_id' | 'races'>[] | null>;
     }
 
     // TODO: this function should probably be in the ballots model

--- a/packages/backend/src/Models/Elections.ts
+++ b/packages/backend/src/Models/Elections.ts
@@ -162,6 +162,16 @@ export default class ElectionsDB implements IElectionStore {
             .catch(dneCatcher);
     }
 
+    getElectionRacesForAllElections(ctx: ILoggingContext): Promise<Pick<Election, 'election_id' | 'races'>[] | null> {
+        Logger.debug(ctx, `${tableName}.getElectionRacesForAllElections`);
+        return this._postgresClient
+            .selectFrom(tableName)
+            .select(['election_id', 'races'])
+            .where('head', '=', true)
+            .execute()
+            .catch(dneCatcher) as Promise<Pick<Election, 'election_id' | 'races'>[] | null>;
+    }
+
     // TODO: this function should probably be in the ballots model
     getBallotCountsForAllElections(ctx: ILoggingContext): Promise<IVoteCount[] | null> {
         Logger.debug(ctx, `${tableName}.getAllElectionsWithBallotCounts`);

--- a/packages/backend/src/Routes/elections.routes.ts
+++ b/packages/backend/src/Routes/elections.routes.ts
@@ -323,10 +323,10 @@ electionsRouter.delete('/Election/:id', asyncHandler(deleteElection))
  *                 star_pr_votes:
  *                   type: number
  *                   description: Votes cast in STAR PR elections
- *                 plurality_elections:
+ *                 choose_one_elections:
  *                   type: number
  *                   description: Elections using Plurality voting
- *                 plurality_votes:
+ *                 choose_one_votes:
  *                   type: number
  *                   description: Votes cast in Plurality elections
  *                 stv_elections:

--- a/packages/backend/src/Routes/elections.routes.ts
+++ b/packages/backend/src/Routes/elections.routes.ts
@@ -266,8 +266,8 @@ electionsRouter.delete('/Election/:id', asyncHandler(deleteElection))
   */
  electionsRouter.post('/QueryElections', asyncHandler(queryElections))
  
- /** 
- * 
+ /**
+ *
  * @swagger
  * /GlobalElectionStats:
  *   get:
@@ -283,10 +283,64 @@ electionsRouter.delete('/Election/:id', asyncHandler(deleteElection))
  *               properties:
  *                 elections:
  *                   type: number
- *                   description: Number of elections
+ *                   description: Total elections (legacy_elections + sum of per-method elections)
  *                 votes:
  *                   type: number
- *                   description: Number of votes
+ *                   description: Total votes cast (legacy_votes + sum of per-method votes)
+ *                 legacy_elections:
+ *                   type: number
+ *                   description: Elections imported from classic star.vote
+ *                 legacy_votes:
+ *                   type: number
+ *                   description: Votes imported from classic star.vote
+ *                 star_elections:
+ *                   type: number
+ *                   description: Elections using STAR voting
+ *                 star_votes:
+ *                   type: number
+ *                   description: Votes cast in STAR elections
+ *                 rcv_elections:
+ *                   type: number
+ *                   description: Elections using Ranked Choice Voting (IRV)
+ *                 rcv_votes:
+ *                   type: number
+ *                   description: Votes cast in RCV elections
+ *                 approval_elections:
+ *                   type: number
+ *                   description: Elections using Approval voting
+ *                 approval_votes:
+ *                   type: number
+ *                   description: Votes cast in Approval elections
+ *                 ranked_robin_elections:
+ *                   type: number
+ *                   description: Elections using Ranked Robin voting
+ *                 ranked_robin_votes:
+ *                   type: number
+ *                   description: Votes cast in Ranked Robin elections
+ *                 star_pr_elections:
+ *                   type: number
+ *                   description: Elections using STAR Proportional Representation
+ *                 star_pr_votes:
+ *                   type: number
+ *                   description: Votes cast in STAR PR elections
+ *                 plurality_elections:
+ *                   type: number
+ *                   description: Elections using Plurality voting
+ *                 plurality_votes:
+ *                   type: number
+ *                   description: Votes cast in Plurality elections
+ *                 stv_elections:
+ *                   type: number
+ *                   description: Elections using Single Transferable Vote
+ *                 stv_votes:
+ *                   type: number
+ *                   description: Votes cast in STV elections
+ *                 multi_method_elections:
+ *                   type: number
+ *                   description: Elections with races using multiple different voting methods
+ *                 multi_method_votes:
+ *                   type: number
+ *                   description: Votes cast in multi-method elections
  *  */
  electionsRouter.get('/GlobalElectionStats', asyncHandler(getGlobalElectionStats))
 /** 

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -74,17 +74,7 @@ export function hashString(inputString: string) {
     return createHash('sha256').update(inputString).digest('hex')
 }
 
-// mapping from method frontend version to backend version
-// TODO: we need make these consistent
-export const methodValueToTextKey = {
-    STAR_PR: 'star_pr',
-    STAR: 'star',
-    RankedRobin: 'ranked_robin',
-    Approval: 'approval',
-    STV: 'stv',
-    Plurality: 'choose_one',
-    IRV: 'rcv',
-};
+export { methodValueToTextKey } from '@equal-vote/star-vote-shared/domain_model/Race';
 
 export const formatPercent = (f: number): string => {
   if(0 < f && f < .01) return '<1%';

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -301,9 +301,6 @@ export const openFeedback = () => {
   (button as HTMLButtonElement).click();
 };
 
-
-
-
 export function scrollToElement(e) {
   setTimeout(() => {
     // TODO: I feel like there's got to be an easier way to do this

--- a/packages/shared/src/config/SharedConfig.ts
+++ b/packages/shared/src/config/SharedConfig.ts
@@ -20,4 +20,28 @@ export const sharedConfig = {
     FF_PRECINCTS: 'false',
     FF_THEMES: 'false',
     FF_ALL_STATS: 'false',
+    DEV_USERS: [
+        'bc111019-40b1-41ad-9cc4-c292d3a8dc84', // Arend -  primary
+        'df7d74a1-a2f6-48a7-b386-64705d1ec629', // Arend
+        '153a6be8-9fcb-49f4-bc7c-35c4567f8b90', // Arend
+        '61ff6b6d-b609-4f4e-a522-60aa8ef3bb55', // Arend
+        '408e5aa0-38ac-4fc5-94bb-06fa299904e5', // Arend
+        'f3da6b1c-7c0b-4f79-95cf-495a65c6fabe', // Mike - gmail
+        '96b21554-7534-491b-a238-6d9e369ab66b', // Mike - equal vote
+        'b1145db5-7fc1-4adf-b148-49563d2c5942', // Mike - hotmail
+        '867bb64d-4ba7-45e6-b1cf-b96a35c8c59a', // Adam - primary
+        'f6f04943-9303-4228-88fb-b8437e6a7868', // Adam - star2.user1
+        '19656010-8bb8-4a8c-b277-3d36b750bea8', // Adam - star2.user3
+        'bef10055-d4b3-4596-99ef-7849c54ab209', // Adam - star2.user6
+        'd6ff970c-6aba-428b-9b2a-b1365ef91126', // Adam - star2.user55
+        '34318994-805f-427f-8b4c-7f9308b36234', // Jon
+        '64540740-adeb-45d1-a1a2-bf95784acccd', // Jackson
+        'f390dfb3-cc26-4f54-94a3-3a6dd54693b6', // Evans
+        '2a2733a1-46fe-41b2-b459-388d97b92c51', // Evans
+    ],
+    REAL_ELECTIONS_FROM_DEVS: [
+        // Real elections under Arend's account
+        'pres24', 
+        'meta_pets', 
+    ]
 };

--- a/packages/shared/src/config/SharedConfig.ts
+++ b/packages/shared/src/config/SharedConfig.ts
@@ -43,5 +43,6 @@ export const sharedConfig = {
         // Real elections under Arend's account
         'pres24', 
         'meta_pets', 
+        'pet',
     ]
 };

--- a/packages/shared/src/domain_model/Race.ts
+++ b/packages/shared/src/domain_model/Race.ts
@@ -5,6 +5,18 @@ import { candidateValidation } from "./Candidate";
 
 const validVotingMethods = ['STAR', 'STAR_PR', 'Approval', 'RankedRobin', 'IRV', 'Plurality', 'STV'] as const;
 export type VotingMethod = typeof validVotingMethods[number];
+
+export const methodValueToTextKey = {
+    STAR: 'star',
+    STAR_PR: 'star_pr',
+    Approval: 'approval',
+    RankedRobin: 'ranked_robin',
+    IRV: 'rcv',
+    Plurality: 'choose_one',
+    STV: 'stv',
+} as const satisfies Record<VotingMethod, string>;
+
+export type MethodTextKey = typeof methodValueToTextKey[VotingMethod];
 export interface Race {
     race_id:        Uid; // short mnemonic for the race
     title:          string; // display caption for the race


### PR DESCRIPTION
## Arend Summary

I worked on this because I was curious to see the breakdown of which election methods were most popular on BetterVoting. While I was at it, I also scrubbed dev accounts from the stats on the landing page. 

Here's the final stats I found (just inspected through the dev console, it's not visible in the frontend)

<img width="517" height="324" alt="image" src="https://github.com/user-attachments/assets/8f974b22-7b19-415d-b6f7-e155f5499e54" />

## Bot Summary
- Extends the `/GlobalElectionStats` API response with per-voting-method vote and election counts (e.g. `star_votes`, `rcv_elections`, `multi_method_elections`, etc.)
- Moves `methodValueToTextKey` to `packages/shared` (`Race.ts`) and re-exports it from the frontend `util.tsx` to eliminate duplication
- Adds `DEV_USERS` and `REAL_ELECTIONS_FROM_DEVS` lists to `sharedConfig` to filter dev/test elections from the stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes #1123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global election statistics now include per-voting-method breakdowns (star, rcv, approval, ranked_robin, star_pr, choose_one, stv, multi_method) plus separate legacy totals.
  * Frontend now uses a shared canonical mapping for voting-method keys.

* **Behavior Change**
  * Developer-owned test elections are excluded from totals unless explicitly whitelisted.

* **Documentation**
  * API schema and descriptions for GlobalElectionStats updated to list new fields.

* **Chores**
  * Added config entries for dev users and whitelisted dev elections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->