### PR TITLE
only trigger rerender after onblur, memoize i18next

### DIFF
--- a/packages/frontend/src/components/ElectionForm/Candidates/CandidateForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Candidates/CandidateForm.tsx
@@ -222,7 +222,15 @@ export default ({ onEditCandidate, candidate, index, onDeleteCandidate, disabled
                         fullWidth
                         variant='standard'
                         margin='normal'
-                        onChange={(e) => setLocalName(e.target.value)}
+                        onChange={(e) => {
+                            const newVal = e.target.value;
+                            setLocalName(newVal);
+                            // Flush immediately when typing into the empty "new candidate" slot
+                            // so the parent adds it to the list and a new empty slot appears
+                            if (candidate.candidate_name === '' && newVal !== '') {
+                                onEditCandidate({ ...candidate, candidate_name: newVal });
+                            }
+                        }}
                         inputRef={inputRef}
                         onKeyDown={onKeyDown}
                         onFocus={() => setFocused(true)}

--- a/packages/frontend/src/components/ElectionForm/Candidates/CandidateForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Candidates/CandidateForm.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from 'react'
+import { useLocalState } from '../../util'
 import { Candidate } from "@equal-vote/star-vote-shared/domain_model/Candidate"
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
@@ -189,7 +190,11 @@ export default ({ onEditCandidate, candidate, index, onDeleteCandidate, disabled
     // Track hover and focus so the UI (actions + textarea underline) appears on hover or when the textbox is focused
     const [hovered, setHovered] = useState(false);
     const [focused, setFocused] = useState(false);
-    const isEmpty = candidate.candidate_name === '';
+    const [localName, setLocalName, flushName] = useLocalState(
+        candidate.candidate_name,
+        v => onEditCandidate({ ...candidate, candidate_name: v })
+    );
+    const isEmpty = localName === '';
  
     return (
         <Paper
@@ -213,15 +218,15 @@ export default ({ onEditCandidate, candidate, index, onDeleteCandidate, disabled
                         // data-testid={`candidate-name-${index + 1}`}
                         disabled={disabled || special}
                         type="text"
-                        value={candidate.candidate_name}
+                        value={localName}
                         fullWidth
                         variant='standard'
                         margin='normal'
-                        onChange={(e) => onEditCandidate({ ...candidate, candidate_name: e.target.value })}
+                        onChange={(e) => setLocalName(e.target.value)}
                         inputRef={inputRef}
                         onKeyDown={onKeyDown}
                         onFocus={() => setFocused(true)}
-                        onBlur={() => setFocused(false)}
+                        onBlur={() => { setFocused(false); flushName(); }}
                         // show underline when hovered OR focused OR when the candidate name is empty; always hide if it's a special candidate
                         InputProps={{ disableUnderline: special || !(hovered || focused || isEmpty)}}
                         multiline

--- a/packages/frontend/src/components/ElectionForm/Details/ElectionDetailsForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Details/ElectionDetailsForm.tsx
@@ -71,7 +71,7 @@ export default function ElectionDetailsForm({editedElection, applyUpdate, errors
 
     const timeZone = editedElection.settings.time_zone ? editedElection.settings.time_zone : DateTime.now().zone.name
 
-    let {t} = useSubstitutedTranslation(editedElection.settings.term_type, {time_zone: timeZone});
+    const {t} = useSubstitutedTranslation(editedElection.settings.term_type, {time_zone: timeZone});
 
     const [enableStartEndTime, setEnableStartEndTime] = useState(isValidDate(editedElection.start_time) || isValidDate(editedElection.end_time))
     const [defaultStartTime, setDefaultStartTime] = useState(isValidDate(editedElection.start_time) ? editedElection.start_time : DateTime.now().setZone(timeZone).toJSDate())
@@ -153,8 +153,6 @@ export default function ElectionDetailsForm({editedElection, applyUpdate, errors
                                 label={t('election_details.time_zone')}
                                 onChange={(e) => {
                                     applyUpdate(election => { election.settings.time_zone = e.target.value as TimeZone })
-                                    const p = useSubstitutedTranslation(editedElection.settings.term_type, {time_zone: e.target.value});
-                                    t = p.t;
                                 }}
                             >
                                 <MenuItem value={DateTime.now().zone.name}>{DateTime.now().zone.name}</MenuItem>

--- a/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
@@ -3,7 +3,7 @@ import CandidateForm from "../Candidates/CandidateForm";
 import TextField from "@mui/material/TextField";
 import Typography from '@mui/material/Typography';
 import { Box, Button, Checkbox, FormControlLabel, FormHelperText, Link, Stack } from "@mui/material";
-import { AddIcon, MinusIcon, TransitionBox, useSubstitutedTranslation } from '../../util';
+import { AddIcon, MinusIcon, TransitionBox, useLocalState, useSubstitutedTranslation } from '../../util';
 import useConfirm from '../../ConfirmationDialogProvider';
 import useFeatureFlags from '../../FeatureFlagContextProvider';
 import { SortableList } from '~/components/DragAndDrop';
@@ -332,6 +332,15 @@ const TitleAndDescription = ({setErrors, errors, editedRace, applyRaceUpdate, op
     const { election, t } = useElection()
     const isDisabled = election.state !== 'draft';
 
+    const [localTitle, setLocalTitle, flushTitle] = useLocalState(
+        editedRace.title,
+        v => applyRaceUpdate(race => { race.title = v })
+    );
+    const [localDesc, setLocalDesc, flushDesc] = useLocalState(
+        editedRace.description,
+        v => applyRaceUpdate(race => { race.description = v })
+    );
+
     useEffect(() => {
         setShowDescription(editedRace.description != '')
     }, [open])
@@ -345,16 +354,17 @@ const TitleAndDescription = ({setErrors, errors, editedRace, applyRaceUpdate, op
                 label={t('wizard.title_label')}
                 type="text"
                 error={errors.raceTitle !== ''}
-                value={editedRace.title}
+                value={localTitle}
                 sx={{
                     m: 0,
                     boxShadow: 2,
                 }}
                 fullWidth
                 onChange={(e) => {
-                    setErrors({ ...errors, raceTitle: '' })
-                    applyRaceUpdate(race => { race.title = e.target.value })
+                    if (errors.raceTitle) setErrors({ ...errors, raceTitle: '' })
+                    setLocalTitle(e.target.value)
                 }}
+                onBlur={flushTitle}
             />
             <FormHelperText error sx={{ pl: 1, pt: 0 }}>
                 {errors.raceTitle}
@@ -378,16 +388,17 @@ const TitleAndDescription = ({setErrors, errors, editedRace, applyRaceUpdate, op
                     fullWidth
                     type="text"
                     error={errors.raceDescription !== ''}
-                    value={editedRace.description}
+                    value={localDesc}
                     minRows={3}
                     sx={{
                         m: 0,
                         boxShadow: 2,
                     }}
                     onChange={(e) => {
-                        setErrors({ ...errors, raceDescription: '' })
-                        applyRaceUpdate(race => { race.description = e.target.value })
+                        if (errors.raceDescription) setErrors({ ...errors, raceDescription: '' })
+                        setLocalDesc(e.target.value)
                     }}
+                    onBlur={flushDesc}
                 />
                 <FormHelperText error sx={{ pl: 1, pt: 0 }}>
                     {errors.raceDescription}

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -8,7 +8,19 @@ import { AddCircleOutlineRounded, ArrowForwardIos } from "@mui/icons-material";
 import { getEntry } from "@equal-vote/star-vote-shared/domain_model/Util";
 import { createHash } from "crypto-browserify";
 import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutlineRounded';
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// Holds a local copy of `value` for fast keystrokes, flushing to parent on blur.
+export const useLocalState = <T,>(value: T, onFlush: (v: T) => void): [T, (v: T) => void, () => void] => {
+    const [local, setLocal] = useState(value);
+    const localRef = useRef(local);
+    localRef.current = local;
+    useEffect(() => setLocal(value), [value]);
+    const flush = useCallback(() => {
+        if (localRef.current !== value) onFlush(localRef.current);
+    }, [value, onFlush]);
+    return [local, setLocal, flush];
+};
 
 const rLink = /\[(.*?)\]\((.*?)\)/;
 const rBold = /\*\*(.*?)\*\*/;
@@ -198,23 +210,30 @@ export const useSubstitutedTranslation = (electionTermType = 'election', v = {})
 
   const { t, i18n } = useTranslation()
 
-  const values = processValues({
+  const methodKey = v['methodKey'] ?? 'star';
+  const timeZone = v['time_zone'] ?? undefined;
+  // v is a new object literal each render, so useMemo would always re-run.
+  // Serialize it to a string so we get a stable dep that only changes when the contents change.
+  const vKey = JSON.stringify(v);
+
+  const values = useMemo(() => processValues({
     // Ignoring "error TS2698: Spread types may only be created from object types." since we know they'll return objects
     // @ts-ignore
     ...t('keyword'),
     // @ts-ignore
     ...t(`keyword.${electionTermType}`),
     // @ts-ignore
-    ...t(`keyword.${v['methodKey'] ?? 'star'}`),
+    ...t(`keyword.${methodKey}`),
     ...v, formatParams: {
       datetime: dt,
       datetime2: dt,
       listed_datetime: {
         year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric',
-        timeZoneName: undefined, timeZone: v['time_zone'] ?? undefined
+        timeZoneName: undefined, timeZone: timeZone,
       },
     }
-  })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [t, electionTermType, methodKey, vKey])
 
   const applySymbols = (txt, includeTips, newWindow) => {
     const applyLinks = (txt) => {

--- a/testing/tests/create-election.spec.ts
+++ b/testing/tests/create-election.spec.ts
@@ -14,16 +14,20 @@ test.describe('Create Election', () => {
         await page.getByRole('radio', { name: 'Just one' }).check();
         await page.getByRole('textbox', { name: 'Question Title' }).click();
         await page.getByRole('textbox', { name: 'Question Title' }).fill('Favorite Fruit');
+        await page.getByRole('textbox', { name: 'Question Title' }).blur();
         await page.getByRole('button', { name: 'Voting Method', exact: true }).click();
         await page.getByRole('radio', { name: 'Single-Winner' }).check();
         await page.getByRole('radio', { name: 'STAR Voting' }).check();
         await page.getByRole('button', { name: 'Choices' }).click();
         await page.getByRole('textbox', { name: 'Candidate 1 Name' }).click();
         await page.getByRole('textbox', { name: 'Candidate 1 Name' }).fill('Pear');
+        await page.getByRole('textbox', { name: 'Candidate 1 Name' }).blur();
         await page.getByRole('textbox', { name: 'Candidate 2 Name' }).click();
         await page.getByRole('textbox', { name: 'Candidate 2 Name' }).fill('Apple');
+        await page.getByRole('textbox', { name: 'Candidate 2 Name' }).blur();
         await page.getByRole('textbox', { name: 'Candidate 3 Name' }).click();
         await page.getByRole('textbox', { name: 'Candidate 3 Name' }).fill('Strawberry');
+        await page.getByRole('textbox', { name: 'Candidate 3 Name' }).blur();
         await page.getByRole('button', { name: 'Next' }).nth(2).click();
         await page.getByRole('button', { name: 'Publish Now' }).click();
 
@@ -84,6 +88,7 @@ test.describe('Create Election', () => {
         await page.getByRole('radio', { name: 'Just one' }).check();
         await page.getByRole('textbox', { name: 'Question Title' }).click();
         await page.getByRole('textbox', { name: 'Question Title' }).fill('Poll + Single Race + ID List');
+        await page.getByRole('textbox', { name: 'Question Title' }).blur();
         await page.getByRole('button', { name: 'Voting Method', exact: true }).click();
         await page.getByRole('radio', { name: 'Basic Multi-Winner' }).check();
         await page.getByRole('button', { name: 'Next' }).nth(1).click();
@@ -92,6 +97,7 @@ test.describe('Create Election', () => {
         await page.getByRole('textbox', { name: 'Candidate 1 Name' }).fill('A');
         await page.getByRole('textbox', { name: 'Candidate 1 Name' }).press('Tab');
         await page.getByRole('textbox', { name: 'Candidate 2 Name' }).fill('B');
+        await page.getByRole('textbox', { name: 'Candidate 2 Name' }).blur();
         await page.getByRole('button', { name: 'Next' }).nth(2).click();
         await page.getByRole('button', { name: 'See more options' }).click();
         await page.getByRole('radio', { name: 'Yes' }).check();

--- a/testing/tests/full-runthrough.spec.ts
+++ b/testing/tests/full-runthrough.spec.ts
@@ -29,7 +29,6 @@ test('Full Runthrough', async ({ page }) => {
 	await page.getByLabel('Enable Start/End Times?').click();
 	await page.getByLabel('Time Zone').click();
 	await page.getByRole('option', { name: 'Hawaii' }).click();
-	await page.getByRole('option', { name: 'Hawaii' }).click();
 	const endTimeInput = await page.getByRole('textbox', { name: 'End Time' });
 	const box = await endTimeInput.boundingBox();
 	if (!box) {

--- a/testing/tests/full-runthrough.spec.ts
+++ b/testing/tests/full-runthrough.spec.ts
@@ -71,6 +71,7 @@ test('Full Runthrough', async ({ page }) => {
 	for (let i = 1; i <= 6; i++) {
 		await expect(page.getByRole('textbox', { name: `Candidate ${i} Name` })).toBeEnabled();
 		await page.getByRole('textbox', { name: `Candidate ${i} Name` }).fill(`Candidate ${i}`);
+		await page.getByRole('textbox', { name: `Candidate ${i} Name` }).blur();
 	}
 	await page.getByRole('button', { name: 'Save' }).click();
 
@@ -80,10 +81,12 @@ test('Full Runthrough', async ({ page }) => {
 		.click({ timeout: 10000 });
 	const raceDialog = await page.getByRole('dialog', { name: 'Edit Race' });
 	await raceDialog.getByRole('textbox', { name: 'Title' }).fill('Race 2');
+	await raceDialog.getByRole('textbox', { name: 'Title' }).blur();
 	await raceDialog.getByRole('button', { name: 'Description' }).click();
 	await raceDialog
 		.getByRole('textbox', { name: 'Description' })
 		.fill('Race 2 Description');
+	await raceDialog.getByRole('textbox', { name: 'Description' }).blur();
 	await raceDialog.getByRole('button', { name: 'Voting Method' }).click();
 	await raceDialog.getByRole('radio', { name: 'Single-Winner' }).check();
 	await raceDialog.getByLabel('Ranked Robin').click();
@@ -91,12 +94,15 @@ test('Full Runthrough', async ({ page }) => {
 	for (let i = 1; i <= 10; i++) {
 		await raceDialog
 			.getByRole('textbox', { name: `Candidate ${i} Name` }).fill(`Candidate ${i}`);
+		await raceDialog
+			.getByRole('textbox', { name: `Candidate ${i} Name` }).blur();
 	}
 	await raceDialog.getByRole('button', { name: 'Drag Candidate Number 10' }).click();
 	await raceDialog.getByRole('button', { name: 'Delete Candidate Number 10' }).click();
 	await page.getByRole('button', { name: 'Submit' }).click(); // must be page since it's a separate popup
 	await expect(raceDialog.getByLabel('Candidate 11 Form')).not.toBeVisible();
 	await raceDialog.getByRole('textbox', { name: `Candidate 10 Name` }).fill(`Candidate 10`);
+	await raceDialog.getByRole('textbox', { name: `Candidate 10 Name` }).blur();
 	const dragSource = await raceDialog.getByRole('button', { name: 'Drag Candidate Number 10' });
 	const dragTarget = await raceDialog.getByRole('button', { name: 'Drag Candidate Number 6' });
 	await dragSource.dragTo(dragTarget);


### PR DESCRIPTION
Some text boxes are molasses, including the wizard (a whopping 1.5 seconds interaction-to-next-paint).  

Some of this is i18next, which can be better memoized, so I did this.

There are other things too though, including the measurement that MUI does for the text area resizing and so forth... an argument can be made that deepcopying the whole form is just too performance-intensive even though it does simplify the maintainability of the code.  That's a debate for another day.  

Anyway, in the short term, to avoid the most intense pain point, which is keystrokes, the most immediate solution is to not rerender the whole form on each keystroke, but only onblur of any textbox.   This PR does that at least for the wizard text boxes (`RaceForm`) so it is fast now (<50ms).    

If we like this pattern we can use it on `ElectionDetailsForm` as well. 

This PR is to address #1302 .
