### PR TITLE
address molasses keystrokes

### DIFF
--- a/packages/frontend/src/components/DragAndDrop/SortableList.tsx
+++ b/packages/frontend/src/components/DragAndDrop/SortableList.tsx
@@ -23,11 +23,7 @@ import "./SortableList.css";
 import { DragHandle, SortableItem } from "./SortableItem";
 import {SortableOverlay}  from "./SortableOverlay";
 
-interface BaseItem {
-  id: UniqueIdentifier;
-}
-
-interface Props<T extends BaseItem> {
+interface Props<T> {
   items: T[];
   identifierKey: keyof T;
   onChange(items: T[]): void;
@@ -59,7 +55,7 @@ interface Props<T extends BaseItem> {
  *   )}
  * />
  */
-export function SortableList<T extends BaseItem>({
+export function SortableList<T>({
   items,
   identifierKey,
   onChange,
@@ -105,7 +101,7 @@ export function SortableList<T extends BaseItem>({
         </ul>
       </SortableContext>
       <SortableOverlay>
-        {activeItem ? renderItem(activeItem, items.findIndex(item => item[identifierKey] === activeItem.id)) : null}
+        {activeItem ? renderItem(activeItem, items.findIndex(item => item[identifierKey] === activeItem[identifierKey])) : null}
       </SortableOverlay>
     </DndContext>
   );

--- a/packages/frontend/src/components/ElectionForm/Candidates/CandidateForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Candidates/CandidateForm.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from 'react'
+import { memo, useRef, useState, useCallback, useEffect } from 'react'
 import { Candidate } from "@equal-vote/star-vote-shared/domain_model/Candidate"
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
@@ -178,18 +178,29 @@ interface CandidateFormProps {
     onDeleteCandidate: () => void,
     disabled: boolean,
     special: boolean, // special candidates include none of the above and write in, and they can be deleted, but not edited
-    inputRef: (el: React.MutableRefObject<HTMLInputElement[]>) => React.MutableRefObject<HTMLInputElement[]>,
+    inputRef: (el: HTMLInputElement | null) => void,
     onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void,
     electionState: string
 }
 
-export default ({ onEditCandidate, candidate, index, onDeleteCandidate, disabled, special, inputRef, onKeyDown, electionState}: CandidateFormProps) => {
+function CandidateForm({ onEditCandidate, candidate, index, onDeleteCandidate, disabled, special, inputRef, onKeyDown, electionState}: CandidateFormProps) {
     const [open, setOpen] = useState(false);
     const [linkOpen, setLinkOpen] = useState(false);
     // Track hover and focus so the UI (actions + textarea underline) appears on hover or when the textbox is focused
     const [hovered, setHovered] = useState(false);
     const [focused, setFocused] = useState(false);
     const isEmpty = candidate.candidate_name === '';
+    const renderCountRef = useRef(0);
+    renderCountRef.current += 1;
+
+    console.log('[RaceForm] CandidateForm render', {
+        renderCount: renderCountRef.current,
+        index,
+        candidateId: candidate.candidate_id,
+        candidateName: candidate.candidate_name,
+        disabled,
+        special,
+    });
  
     return (
         <Paper
@@ -259,3 +270,10 @@ export default ({ onEditCandidate, candidate, index, onDeleteCandidate, disabled
         </Paper >
     )
 }
+
+export default memo(CandidateForm, (prevProps, nextProps) => (
+    prevProps.candidate === nextProps.candidate &&
+    prevProps.index === nextProps.index &&
+    prevProps.disabled === nextProps.disabled &&
+    prevProps.special === nextProps.special
+));

--- a/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/RaceForm.tsx
@@ -1,398 +1,725 @@
-import React, { MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import CandidateForm from "../Candidates/CandidateForm";
 import TextField from "@mui/material/TextField";
-import Typography from '@mui/material/Typography';
-import { Box, Button, Checkbox, FormControlLabel, FormHelperText, Link, Stack } from "@mui/material";
-import { AddIcon, MinusIcon, TransitionBox, useSubstitutedTranslation } from '../../util';
+import { Box, Button, Checkbox, FormControlLabel, FormHelperText, Stack } from "@mui/material";
+import { AddIcon, MinusIcon, TransitionBox } from '../../util';
 import useConfirm from '../../ConfirmationDialogProvider';
-import useFeatureFlags from '../../FeatureFlagContextProvider';
 import { SortableList } from '~/components/DragAndDrop';
 import { makeDefaultRace, RaceErrors, useEditRace } from './useEditRace';
 import { makeUniqueIDSync, ID_PREFIXES, ID_LENGTHS, NOTA_ID } from '@equal-vote/star-vote-shared/utils/makeID';
-import VotingMethodSelector from './VotingMethodSelector';
+import VotingMethodSelector, { VotingMethodSelectorHandle } from './VotingMethodSelector';
 import useElection from '~/components/ElectionContextProvider';
-import { SecondaryButton, PrimaryButton, FileDropBox, LinkButton, Tip } from '~/components/styles';
+import { PrimaryButton, FileDropBox, LinkButton, Tip } from '~/components/styles';
 import RaceDialog from './RaceDialog';
 import { Candidate } from '@equal-vote/star-vote-shared/domain_model/Candidate';
+import { Race as IRace } from '@equal-vote/star-vote-shared/domain_model/Race';
 import { getImage, postImage } from '../Candidates/PhotoUtil';
 
 interface RaceFormProps {
     raceIndex?: number,
     styling: 'Wizard' | 'Dialog',
-    onConfirm?: Function,
-    onCancel?: Function,
+    onConfirm?: (editedRace: IRace) => void | Promise<void>,
+    onCancel?: () => void,
     dialogOpen?: boolean,
+}
+
+interface TitleAndDescriptionValue {
+    description?: string,
+    title: string,
+}
+
+interface TitleAndDescriptionHandle {
+    getValue: () => TitleAndDescriptionValue,
+}
+
+interface CandidatesSectionValue {
+    candidates: Candidate[],
+    enable_write_in?: boolean,
+}
+
+type CandidateRowKind = 'candidate' | 'draft' | 'nota';
+
+interface CandidateRowItem {
+    id: string,
+    initialCandidate: Candidate,
+    kind: CandidateRowKind,
+}
+
+interface CandidatesSectionHandle {
+    getValue: () => CandidatesSectionValue,
+}
+
+interface CandidateEditorRowHandle {
+    getValue: () => Candidate,
+}
+
+interface InnerRaceFormProps {
+    candidatesRef: React.RefObject<CandidatesSectionHandle | null>,
+    errors: RaceErrors,
+    initialRace: IRace,
+    onClearError: (field: keyof RaceErrors) => void,
+    onSetError: (field: keyof RaceErrors, message: string) => void,
+    open?: boolean,
+    titleAndDescriptionRef: React.RefObject<TitleAndDescriptionHandle | null>,
+    votingMethodRef: React.RefObject<VotingMethodSelectorHandle | null>,
 }
 
 export const RACE_FORM_GAP = 2;
 
 export default function RaceForm({
-    raceIndex=undefined,
+    raceIndex = undefined,
     styling,
-    onConfirm=() => {},
-    onCancel=() => {},
-    dialogOpen=undefined,
+    onConfirm = async () => {},
+    onCancel = () => {},
+    dialogOpen = undefined,
 }: RaceFormProps) {
-    const {election} = useElection();
+    const { election } = useElection();
+    const initialRace = useMemo(() => (
+        raceIndex == undefined ? makeDefaultRace() : election.races[raceIndex]
+    ), [dialogOpen, election.races, raceIndex]);
     const editRace = useEditRace(
         raceIndex == undefined ? null : election.races[raceIndex],
-        0,
+        raceIndex ?? 0,
         dialogOpen,
-    )
+    );
+
+    const titleAndDescriptionRef = useRef<TitleAndDescriptionHandle>(null);
+    const votingMethodRef = useRef<VotingMethodSelectorHandle>(null);
+    const candidatesRef = useRef<CandidatesSectionHandle>(null);
+
+    const clearError = useCallback((field: keyof RaceErrors) => {
+        editRace.setErrors((prev) => {
+            if ((prev[field] ?? '') === '') {
+                return prev;
+            }
+
+            return {
+                ...prev,
+                [field]: '',
+            };
+        });
+    }, [editRace.setErrors]);
+
+    const setError = useCallback((field: keyof RaceErrors, message: string) => {
+        editRace.setErrors((prev) => {
+            if ((prev[field] ?? '') === message) {
+                return prev;
+            }
+
+            return {
+                ...prev,
+                [field]: message,
+            };
+        });
+    }, [editRace.setErrors]);
+
+    const collectRace = useCallback((): IRace => ({
+        ...initialRace,
+        ...titleAndDescriptionRef.current?.getValue(),
+        ...votingMethodRef.current?.getValue(),
+        ...candidatesRef.current?.getValue(),
+    }), [initialRace]);
+
+    const handleConfirm = useCallback(async () => {
+        const editedRace = collectRace();
+        if (!editRace.validateRace(editedRace)) {
+            return;
+        }
+
+        await onConfirm(editedRace);
+    }, [collectRace, editRace, onConfirm]);
 
     return (
         <>
             {styling == 'Dialog' &&
                 <RaceDialog
-                    onSaveRace={() => editRace.validateRace() && onConfirm(editRace.editedRace)}
+                    onSaveRace={handleConfirm}
                     open={dialogOpen}
-                    handleClose={() => onCancel()}
+                    handleClose={onCancel}
                 >
-                    {/* I can't absorb it into FormComponent because of Component Identity Instability*/}
-                    <Box sx={{width: {xs: '250px', sm: '500px'}, padding: 1, minHeight: '500px'}}>
-                        <InnerRaceForm {...editRace} open={dialogOpen}/>
+                    <Box sx={{ width: { xs: '250px', sm: '500px' }, padding: 1, minHeight: '500px' }}>
+                        <InnerRaceForm
+                            candidatesRef={candidatesRef}
+                            errors={editRace.errors}
+                            initialRace={initialRace}
+                            onClearError={clearError}
+                            onSetError={setError}
+                            open={dialogOpen}
+                            titleAndDescriptionRef={titleAndDescriptionRef}
+                            votingMethodRef={votingMethodRef}
+                        />
                     </Box>
                 </RaceDialog>
             }
             {styling == 'Wizard' && <>
-                <InnerRaceForm {...editRace}/>
-                <Box display='flex' flexDirection='row' justifyContent='flex-end' gap={1} sx={{mt: 3}}>
-                    <PrimaryButton onClick={() => editRace.validateRace() && onConfirm(editRace.editedRace)}>Next</PrimaryButton>
+                <InnerRaceForm
+                    candidatesRef={candidatesRef}
+                    errors={editRace.errors}
+                    initialRace={initialRace}
+                    onClearError={clearError}
+                    onSetError={setError}
+                    titleAndDescriptionRef={titleAndDescriptionRef}
+                    votingMethodRef={votingMethodRef}
+                />
+                <Box display='flex' flexDirection='row' justifyContent='flex-end' gap={1} sx={{ mt: 3 }}>
+                    <PrimaryButton onClick={handleConfirm}>Next</PrimaryButton>
                 </Box>
             </>}
         </>
-    )
+    );
 }
 
-const InnerRaceForm = ({setErrors, errors, editedRace, applyRaceUpdate, open=true}) => {
-    const flags = useFeatureFlags();
-    const { election, t } = useElection()
+const InnerRaceForm = ({
+    candidatesRef,
+    errors,
+    initialRace,
+    onClearError,
+    onSetError,
+    open = true,
+    titleAndDescriptionRef,
+    votingMethodRef,
+}: InnerRaceFormProps) => {
+    const { election } = useElection();
     const isDisabled = election.state !== 'draft';
-    const [] = useState(false);
 
-    // Dialog should default to candidates being expanded, Wizard should not
-    const [candidatesExpaneded, setCandidatesExpanded] = useState(editedRace.candidates.length > 0);
-
-    const confirm = useConfirm();
-    const inputRefs = useRef([]);
-    const ephemeralCandidates = useMemo(() => {
-        // Get all existing candidate IDs
-        const existingIds = new Set(editedRace.candidates.map(c => c.candidate_id));
-
-        const hasCollision = (id: string) => existingIds.has(id);
-
-        const newId = makeUniqueIDSync(
-            ID_PREFIXES.CANDIDATE,
-            ID_LENGTHS.CANDIDATE,
-            hasCollision
-        );
-
-        return [
-            ...editedRace.candidates.filter(c => c.candidate_id !== NOTA_ID),
-            {
-                candidate_id: newId,
-                candidate_name: ''
-            },
-            ...editedRace.candidates.filter(c => c.candidate_id === NOTA_ID),
-        ];
-    }, [editedRace.candidates]);
-
-    const onEditCandidate = useCallback((candidate, uiIndex) => {
-        applyRaceUpdate(race => {
-            if(uiIndex === newCandidateIndex){
-                race.candidates.splice(newCandidateIndex, 0, candidate) // this could be a push, or if there's nota or write in then this would be an insert
-            }else{
-                // the uiIndexToActualIndex is unnecessary here since we know uiIndex and index will always match for this case, but I'm still adding the function for clarity
-                race.candidates[uiIndexToActualIndex(uiIndex)] = candidate;
-            }
-        });
-
-        setErrors((prev: RaceErrors) => ({ ...prev, candidates: ''}));
-    }, [applyRaceUpdate, setErrors]);
-
-    useEffect(() => {
-        setCandidatesExpanded(editedRace.candidates.length > 1)
-    }, [open])
-    
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleChangeCandidates = useCallback((newCandidateList: any[]) => {
-        // removing the newCandidateIndex will update the ephemeral order to match the actual one
-        newCandidateList.splice(newCandidateIndex, 1)
-        applyRaceUpdate(race => {
-            race.candidates = newCandidateList;
-        }
-        );
-    }, [applyRaceUpdate]);
-
-    const onDeleteCandidate = useCallback(async (uiIndex) => {
-        let index = uiIndexToActualIndex(uiIndex);
-        if (editedRace.candidates.length < 2) {
-            setErrors(prev => ({ ...prev, candidates: 'At least 2 candidates are required' }));
-            return;
-        }
-
-        const confirmed = await confirm({ title: 'Confirm Delete Candidate', message: 'Are you sure?' });
-        if (confirmed) {
-            applyRaceUpdate(race => {
-                race.candidates.splice(index, 1);
-            });
-        }
-    }, [confirm, editedRace.candidates.length, applyRaceUpdate, setErrors]);
-
-    // Handle tab and shift+tab to move focus between candidates
-    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>, index: number) => {
-        const target = event.target as HTMLInputElement;
-        if (event.key === 'Tab' && event.shiftKey) {
-            // Move focus to the previous candidate
-            event.preventDefault();
-            const prevIndex = index - 1;
-            if (prevIndex >= 0 && inputRefs.current[prevIndex]) {
-                inputRefs.current[prevIndex].focus();
-            }
-        } else if (event.key === 'Enter' || event.key === 'Tab') {
-            event.preventDefault();
-            const nextIndex = index + 1;
-            if (nextIndex < ephemeralCandidates.length && inputRefs.current[nextIndex]) {
-                inputRefs.current[nextIndex].focus();
-            }
-        } else if (event.key === 'Backspace' && target.value === '' && index > 0) {
-            // Move focus to the previous candidate when backspacing on an empty candidate
-            event.preventDefault();
-            inputRefs.current[index - 1].focus();
-            //this makes it so the candidate is deleted without the "are you sure?" dialog when backspacing on an empty candidate
-            applyRaceUpdate(race => {
-                race.candidates.splice(index, 1);
-            })
-        }
-    }, [ephemeralCandidates.length, applyRaceUpdate]);
-
-    const Precincts = () => <>
-        <TextField
-            id={`race-precincts`}
-            name="precincts"
-            label="Precincts"
-            disabled={isDisabled}
-            fullWidth
-            multiline
-            type="text"
-            value={editedRace.precincts ? editedRace.precincts.join('\n') : ''}
-            sx={{
-                m: 1,
-                boxShadow: 2,
-            }}
-            onChange={(e) => applyRaceUpdate(race => {
-                race.precincts = e.target.value ? e.target.value.split('\n') : undefined;
-            })}
+    return <Box display='flex' flexDirection='column' alignItems='stretch' gap={RACE_FORM_GAP} sx={{ textAlign: 'left' }}>
+        <TitleAndDescription
+            ref={titleAndDescriptionRef}
+            initialRace={initialRace}
+            isDisabled={isDisabled}
+            open={open}
+            onClearError={onClearError}
+            raceDescriptionError={errors.raceDescription}
+            raceTitleError={errors.raceTitle}
         />
-    </>
 
-    const candidateItems = election.state === 'draft' ? ephemeralCandidates : editedRace.candidates;
+        <VotingMethodSelector
+            ref={votingMethodRef}
+            election={election}
+            error={errors.votingMethod}
+            initialRace={initialRace}
+            isDisabled={isDisabled}
+            onClearError={onClearError}
+            open={open}
+        />
 
-    // NOTA is listed below the new candidate in the ephemeral list
-    const maxSpecialCandidates = 1;
-    const numSpecialCandidates = editedRace.candidates.filter(c => c.candidate_id === NOTA_ID).length;
-    const newCandidateIndex = election.state === 'draft' ? ephemeralCandidates.length - 1 - numSpecialCandidates : undefined;
+        <CandidatesSection
+            ref={candidatesRef}
+            error={errors.candidates}
+            initialRace={initialRace}
+            isDisabled={isDisabled}
+            onClearError={onClearError}
+            onSetError={onSetError}
+            open={open}
+        />
+    </Box>;
+};
 
-    const uiIndexToActualIndex = (uiIndex) => {
-        // we only use the ephemeral list when we're in draft, otherwise the ui will match editedRace.candidates
-        if(election.state != 'draft') return uiIndex;
-        if(uiIndex === newCandidateIndex) throw "There is no mapping for the new candidate, this function shouldn't be used for that case"
-        // the ephemeral list has a temp candidate inserted at the end before nota, so we need to offset accordingly
-        if(uiIndex > newCandidateIndex) return uiIndex-1;
-        return uiIndex;
-    }
-
-    const handlePhotoDrop = async (e) =>  {
-        // load file data
-        let names = []
-        let promises = []
-        // forEach doesn't exist on fileList type
-        // I'm keeping the loops separate since all the files need to be retrieved from dataTransfer before any await functions are called
-        for(let i = 0; i < e.dataTransfer.files.length; i++){ 
-            let f = e.dataTransfer.files[i];
-
-            let parts = f.name.split('\.');
-            parts.pop(); // drop extension
-            names.push(parts.join('.'))
-
-            promises.push(getImage(URL.createObjectURL(f)).then(img => postImage(img)))
-        }
-
-        // get photos
-        let photos = (await Promise.all(promises)).map(res => res.photo_filename);
-
-        // create candidates
-        const existingIds = new Set(editedRace.candidates.map(c => c.candidate_id));
-        let newCandidates = names.map((n, i) => {
-            const hasCollision = (id: string) => existingIds.has(id);
-
-            const newId = makeUniqueIDSync(
-                ID_PREFIXES.CANDIDATE,
-                ID_LENGTHS.CANDIDATE,
-                hasCollision
-            );
-
-            return {
-                candidate_id: newId,
-                candidate_name: names[i],
-                photo_filename: photos[i],
-            } as Candidate;
-        })
-
-        // I can't use onEditCandidate since it can't be called multiple times
-        applyRaceUpdate(race => {
-            if(race.candidates.length == 1 && race.candidates[0].candidate_name == '') race.candidates.pop();
-            newCandidates.forEach(c => race.candidates.push(c))
-        });
-    }
-
-
-    return <Box display='flex' flexDirection='column' alignItems='stretch' gap={RACE_FORM_GAP} sx={{textAlign: 'left'}}>
-        <TitleAndDescription setErrors={setErrors} errors={errors} editedRace={editedRace} applyRaceUpdate={applyRaceUpdate} open={open}/>
-
-        <VotingMethodSelector election={election} editedRace={editedRace} isDisabled={isDisabled} setErrors={setErrors} errors={errors} applyRaceUpdate={applyRaceUpdate} open={open}/>
-
-        <FileDropBox onlyShowOnDrag helperText={'Add from photo(s)'} onDrop={handlePhotoDrop}>
-            <Button
-                // it's hacky, but opacity 0.8 does helps take the edge off the bold a bit
-                sx={{mr: "auto", textDecoration: 'none', textTransform: 'none', color: 'black', fontSize: '1.125rem', opacity: 0.86}}
-                onClick={() => setCandidatesExpanded((e) => !e)}
-            >
-                {candidatesExpaneded? <MinusIcon prefix/> :<AddIcon prefix/>} {t('race_form.candidates_title')}
-            </Button>
-            <FormHelperText error sx={{ pl: 1, pt: 0 }}>
-                {errors.candidates}
-            </FormHelperText>
-
-            <Box sx={{
-                position: 'relative',
-                height: candidatesExpaneded? `${
-                    candidateItems.length*66 - 11 +
-                    40*(maxSpecialCandidates-numSpecialCandidates) +
-                    58 // hard coded value for write-ins checkbox
-                }px` : 0,
-                transition: 'height 0.5s',
-            }}>
-                <TransitionBox absolute enabled={candidatesExpaneded}>
-                    <Stack spacing={2}>
-                        <SortableList
-                            items={candidateItems}
-                            identifierKey="candidate_id"
-                            indexIsValid={index => index < newCandidateIndex}
-                            onChange={handleChangeCandidates}
-                            renderItem={(candidate, index) => (
-                                <SortableList.Item id={candidate.candidate_id}>
-                                    <CandidateForm
-                                        key={candidate.candidate_id}
-                                        onEditCandidate={(newCandidate) => onEditCandidate(newCandidate, index)}
-                                        candidate={candidate}
-                                        index={index}
-                                        onDeleteCandidate={() => onDeleteCandidate(index)}
-                                        disabled={election.state !== 'draft'}
-                                        special={index > newCandidateIndex}
-                                        inputRef={(el: React.MutableRefObject<HTMLInputElement[]>) => inputRefs.current[index] = el}
-                                        onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => handleKeyDown(event, index)}
-                                        electionState={election.state} />
-                                </SortableList.Item>
-                            )}
-                        />
-                        {election.state == 'draft' && !editedRace.candidates.some((c) => c.candidate_id === NOTA_ID) && <Box>
-                            <LinkButton onClick={()=>{onEditCandidate({
-                                candidate_id: NOTA_ID,
-                                candidate_name: 'None of the Above',
-                            }, candidateItems.length-1)}} sx={{
-                                ml: 1,
-                            }}>Add "None of the Above"</LinkButton>
-                            <Tip name='nota'/>
-                        </Box>}
-                        <FormControlLabel
-                            disabled={isDisabled}
-                            control={
-                                <Checkbox
-                                    id="enable-write-in"
-                                    checked={!!editedRace.enable_write_in}
-                                    onChange={(e) => applyRaceUpdate(race => { race.enable_write_in = e.target.checked; })}
-                                />
-                            }
-                            label="Allow write-ins"
-                            sx={{ pl: 1  }}
-                        />
-                    </Stack>
-                </TransitionBox>
-                
-            </Box>
-
-            
-        </FileDropBox>
-    </Box>
+interface TitleAndDescriptionProps {
+    initialRace: IRace,
+    isDisabled: boolean,
+    onClearError: (field: keyof RaceErrors) => void,
+    open?: boolean,
+    raceDescriptionError?: string,
+    raceTitleError?: string,
 }
 
-const TitleAndDescription = ({setErrors, errors, editedRace, applyRaceUpdate, open}) => {
-    const [showDescription, setShowDescription] = useState(editedRace.description != '');
-    const { election, t } = useElection()
-    const isDisabled = election.state !== 'draft';
+const TitleAndDescription = forwardRef<TitleAndDescriptionHandle, TitleAndDescriptionProps>(function TitleAndDescription({
+    initialRace,
+    isDisabled,
+    onClearError,
+    open,
+    raceDescriptionError = '',
+    raceTitleError = '',
+}, ref) {
+    const { t } = useElection();
+    const [title, setTitle] = useState(initialRace.title);
+    const [description, setDescription] = useState(initialRace.description ?? '');
+    const [showDescription, setShowDescription] = useState(initialRace.description != '');
 
     useEffect(() => {
-        setShowDescription(editedRace.description != '')
-    }, [open])
+        setTitle(initialRace.title);
+        setDescription(initialRace.description ?? '');
+        setShowDescription(initialRace.description != '');
+    }, [initialRace, open]);
+
+    useImperativeHandle(ref, () => ({
+        getValue: () => ({
+            description,
+            title,
+        }),
+    }), [description, title]);
 
     return <>
         <Box>
             <TextField
-                id={`race-title`}
+                id='race-title'
                 disabled={isDisabled}
                 name="title"
                 label={t('wizard.title_label')}
                 type="text"
-                error={errors.raceTitle !== ''}
-                value={editedRace.title}
+                error={raceTitleError !== ''}
+                value={title}
                 sx={{
                     m: 0,
                     boxShadow: 2,
                 }}
                 fullWidth
                 onChange={(e) => {
-                    setErrors({ ...errors, raceTitle: '' })
-                    applyRaceUpdate(race => { race.title = e.target.value })
+                    onClearError('raceTitle');
+                    setTitle(e.target.value);
                 }}
             />
             <FormHelperText error sx={{ pl: 1, pt: 0 }}>
-                {errors.raceTitle}
+                {raceTitleError}
             </FormHelperText>
         </Box>
 
         <Box>
             <Button
-                sx={{textDecoration: 'none', textTransform: 'none', color: 'black', fontSize: '1.125rem', opacity: 0.86}}
-                onClick={() => setShowDescription(d => !d)}
+                sx={{ textDecoration: 'none', textTransform: 'none', color: 'black', fontSize: '1.125rem', opacity: 0.86 }}
+                onClick={() => setShowDescription((current) => !current)}
             >
-                {showDescription? <MinusIcon prefix/> : <AddIcon prefix/>} Description (Optional)
+                {showDescription ? <MinusIcon prefix /> : <AddIcon prefix />} Description (Optional)
             </Button>
             {showDescription && <>
                 <TextField
-                    id={`race-description`}
+                    id='race-description'
                     name="description"
                     label="Description"
                     disabled={isDisabled}
                     multiline
                     fullWidth
                     type="text"
-                    error={errors.raceDescription !== ''}
-                    value={editedRace.description}
+                    error={raceDescriptionError !== ''}
+                    value={description}
                     minRows={3}
                     sx={{
                         m: 0,
                         boxShadow: 2,
                     }}
                     onChange={(e) => {
-                        setErrors({ ...errors, raceDescription: '' })
-                        applyRaceUpdate(race => { race.description = e.target.value })
+                        onClearError('raceDescription');
+                        setDescription(e.target.value);
                     }}
                 />
                 <FormHelperText error sx={{ pl: 1, pt: 0 }}>
-                    {errors.raceDescription}
+                    {raceDescriptionError}
                 </FormHelperText>
             </>}
         </Box>
-    </>
+    </>;
+});
+
+interface CandidateEditorRowProps {
+    canDelete: boolean,
+    disabled: boolean,
+    index: number,
+    item: CandidateRowItem,
+    onClearError: () => void,
+    onDeleteCommittedRow: (id: string) => void,
+    onPromoteDraft: (draftId: string, candidate: Candidate) => void,
+    registerInputRef: (id: string, el: HTMLInputElement | null) => void,
+    focusNext: (id: string) => void,
+    focusPrevious: (id: string) => void,
+    setCandidateError: (message: string) => void,
 }
+
+const CandidateEditorRow = React.memo(forwardRef<CandidateEditorRowHandle, CandidateEditorRowProps>(function CandidateEditorRow({
+    canDelete,
+    disabled,
+    index,
+    item,
+    onClearError,
+    onDeleteCommittedRow,
+    onPromoteDraft,
+    registerInputRef,
+    focusNext,
+    focusPrevious,
+    setCandidateError,
+}, ref) {
+    const confirm = useConfirm();
+    const [candidate, setCandidate] = useState(item.initialCandidate);
+
+    useEffect(() => {
+        setCandidate(item.initialCandidate);
+    }, [item.initialCandidate]);
+
+    useImperativeHandle(ref, () => ({
+        getValue: () => candidate,
+    }), [candidate]);
+
+    const onEditCandidate = useCallback((nextCandidate: Candidate) => {
+        const updatedCandidate = {
+            ...candidate,
+            ...nextCandidate,
+            candidate_id: item.id,
+        };
+
+        setCandidate(updatedCandidate);
+        onClearError();
+
+        if (item.kind === 'draft' && candidate.candidate_name === '' && updatedCandidate.candidate_name.trim() !== '') {
+            onPromoteDraft(item.id, updatedCandidate);
+        }
+    }, [candidate, item.id, item.kind, onClearError, onPromoteDraft]);
+
+    const onDeleteCandidate = useCallback(async () => {
+        if (!canDelete) {
+            setCandidateError('At least 2 candidates are required');
+            return;
+        }
+
+        const confirmed = await confirm({ title: 'Confirm Delete Candidate', message: 'Are you sure?' });
+        if (confirmed) {
+            onClearError();
+            onDeleteCommittedRow(item.id);
+        }
+    }, [canDelete, confirm, item.id, onClearError, onDeleteCommittedRow, setCandidateError]);
+
+    const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+        const target = event.target as HTMLInputElement;
+
+        if (event.key === 'Tab' && event.shiftKey) {
+            event.preventDefault();
+            focusPrevious(item.id);
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === 'Tab') {
+            event.preventDefault();
+            focusNext(item.id);
+            return;
+        }
+
+        if (event.key === 'Backspace' && target.value === '' && index > 0 && item.kind === 'candidate') {
+            event.preventDefault();
+            focusPrevious(item.id);
+            if (canDelete) {
+                onClearError();
+                onDeleteCommittedRow(item.id);
+            } else {
+                setCandidateError('At least 2 candidates are required');
+            }
+        }
+    }, [canDelete, focusNext, focusPrevious, index, item.id, item.kind, onClearError, onDeleteCommittedRow, setCandidateError]);
+
+    return (
+        <CandidateForm
+            onEditCandidate={onEditCandidate}
+            candidate={candidate}
+            index={index}
+            onDeleteCandidate={onDeleteCandidate}
+            disabled={disabled}
+            special={item.kind === 'nota'}
+            inputRef={(element) => registerInputRef(item.id, element)}
+            onKeyDown={onKeyDown}
+            electionState="draft"
+        />
+    );
+}), (prevProps, nextProps) => (
+    prevProps.item === nextProps.item &&
+    prevProps.index === nextProps.index &&
+    prevProps.canDelete === nextProps.canDelete &&
+    prevProps.disabled === nextProps.disabled
+));
+
+interface CandidatesSectionProps {
+    error?: string,
+    initialRace: IRace,
+    isDisabled: boolean,
+    onClearError: (field: keyof RaceErrors) => void,
+    onSetError: (field: keyof RaceErrors, message: string) => void,
+    open?: boolean,
+}
+
+const CandidatesSection = forwardRef<CandidatesSectionHandle, CandidatesSectionProps>(function CandidatesSection({
+    error = '',
+    initialRace,
+    isDisabled,
+    onClearError,
+    onSetError,
+    open,
+}, ref) {
+    const { election, t } = useElection();
+    const isDraft = election.state === 'draft';
+    const [candidatesExpanded, setCandidatesExpanded] = useState(initialRace.candidates.length > 0);
+    const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+    const rowRefs = useRef<Record<string, CandidateEditorRowHandle | null>>({});
+    const createItems = useCallback((race: IRace) => {
+        const existingIds = new Set(race.candidates.map((candidate) => candidate.candidate_id));
+        const draftId = makeUniqueIDSync(
+            ID_PREFIXES.CANDIDATE,
+            ID_LENGTHS.CANDIDATE,
+            (id: string) => existingIds.has(id),
+        );
+
+        return [
+            ...race.candidates
+                .filter((candidate) => candidate.candidate_id !== NOTA_ID)
+                .map((candidate) => ({
+                    id: candidate.candidate_id,
+                    initialCandidate: candidate,
+                    kind: 'candidate' as const,
+                })),
+            {
+                id: draftId,
+                initialCandidate: {
+                    candidate_id: draftId,
+                    candidate_name: '',
+                },
+                kind: 'draft' as const,
+            },
+            ...race.candidates
+                .filter((candidate) => candidate.candidate_id === NOTA_ID)
+                .map((candidate) => ({
+                    id: candidate.candidate_id,
+                    initialCandidate: candidate,
+                    kind: 'nota' as const,
+                })),
+        ];
+    }, []);
+    const [items, setItems] = useState<CandidateRowItem[]>(() => createItems(initialRace));
+    const [enableWriteIn, setEnableWriteIn] = useState(!!initialRace.enable_write_in);
+    const renderCountRef = useRef(0);
+    renderCountRef.current += 1;
+    console.log('[RaceForm] CandidatesSection render', {
+        renderCount: renderCountRef.current,
+        items: items.map((item) => ({
+            id: item.id,
+            kind: item.kind,
+        })),
+        enableWriteIn,
+    });
+
+    useEffect(() => {
+        setCandidatesExpanded(initialRace.candidates.length > 1);
+        setItems(createItems(initialRace));
+        setEnableWriteIn(!!initialRace.enable_write_in);
+        inputRefs.current = {};
+        rowRefs.current = {};
+    }, [createItems, initialRace, open]);
+
+    const getCollectedCandidates = useCallback(() => (
+        items
+            .filter((item) => item.kind !== 'draft')
+            .map((item) => rowRefs.current[item.id]?.getValue() ?? item.initialCandidate)
+    ), [items]);
+
+    useImperativeHandle(ref, () => ({
+        getValue: () => ({
+            candidates: getCollectedCandidates(),
+            enable_write_in: enableWriteIn,
+        }),
+    }), [enableWriteIn, getCollectedCandidates]);
+
+    const clearCandidatesError = useCallback(() => {
+        onClearError('candidates');
+    }, [onClearError]);
+
+    const registerInputRef = useCallback((id: string, element: HTMLInputElement | null) => {
+        inputRefs.current[id] = element;
+    }, []);
+
+    const registerRowRef = useCallback((id: string, handle: CandidateEditorRowHandle | null) => {
+        rowRefs.current[id] = handle;
+    }, []);
+
+    const focusRelative = useCallback((id: string, delta: number) => {
+        const currentIndex = items.findIndex((item) => item.id === id);
+        const targetIndex = currentIndex + delta;
+        if (targetIndex >= 0 && targetIndex < items.length) {
+            inputRefs.current[items[targetIndex].id]?.focus();
+        }
+    }, [items]);
+
+    const getDraftIndex = useCallback((candidateItems: CandidateRowItem[]) => (
+        candidateItems.findIndex((item) => item.kind === 'draft')
+    ), []);
+
+    const getCommittedCandidateCount = useMemo(() => (
+        items.filter((item) => item.kind !== 'draft').length
+    ), [items]);
+
+    const onPromoteDraft = useCallback((draftId: string, candidate: Candidate) => {
+        clearCandidatesError();
+        setItems((currentItems) => {
+            const nextItems = [...currentItems];
+            const currentDraftIndex = nextItems.findIndex((item) => item.id === draftId);
+            if (currentDraftIndex === -1) {
+                return currentItems;
+            }
+
+            const existingIds = new Set(nextItems.map((item) => item.id));
+            existingIds.delete(draftId);
+
+            nextItems[currentDraftIndex] = {
+                id: draftId,
+                initialCandidate: candidate,
+                kind: 'candidate',
+            };
+
+            const nextDraftId = makeUniqueIDSync(
+                ID_PREFIXES.CANDIDATE,
+                ID_LENGTHS.CANDIDATE,
+                (id: string) => existingIds.has(id),
+            );
+            nextItems.splice(currentDraftIndex + 1, 0, {
+                id: nextDraftId,
+                initialCandidate: {
+                    candidate_id: nextDraftId,
+                    candidate_name: '',
+                },
+                kind: 'draft',
+            });
+            return nextItems;
+        });
+    }, [clearCandidatesError]);
+
+    const onDeleteCommittedRow = useCallback((id: string) => {
+        clearCandidatesError();
+        setItems((currentItems) => currentItems.filter((item) => item.id !== id));
+    }, [clearCandidatesError]);
+
+    const handleChangeCandidates = useCallback((newItems: CandidateRowItem[]) => {
+        clearCandidatesError();
+        setItems(newItems);
+    }, [clearCandidatesError]);
+
+    const handlePhotoDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
+        clearCandidatesError();
+
+        const names: string[] = [];
+        const promises: Array<Promise<{ photo_filename: string }>> = [];
+
+        for (let i = 0; i < e.dataTransfer.files.length; i++) {
+            const file = e.dataTransfer.files[i];
+            const parts = file.name.split('.');
+            parts.pop();
+            names.push(parts.join('.'));
+            promises.push(getImage(URL.createObjectURL(file)).then((img) => postImage(img)));
+        }
+
+        const photos = (await Promise.all(promises)).map((response) => response.photo_filename);
+
+        setItems((currentItems) => {
+            const nextItems = [...currentItems];
+            const existingIds = new Set(nextItems.map((item) => item.id));
+            const draftIndex = getDraftIndex(nextItems);
+            const newItems = names.map((candidateName, index) => {
+                const newId = makeUniqueIDSync(
+                    ID_PREFIXES.CANDIDATE,
+                    ID_LENGTHS.CANDIDATE,
+                    (id: string) => existingIds.has(id),
+                );
+                existingIds.add(newId);
+
+                return {
+                    id: newId,
+                    initialCandidate: {
+                        candidate_id: newId,
+                        candidate_name: candidateName,
+                        photo_filename: photos[index],
+                    },
+                    kind: 'candidate' as const,
+                };
+            });
+
+            nextItems.splice(draftIndex, 0, ...newItems);
+            return nextItems;
+        });
+    }, [clearCandidatesError, getDraftIndex]);
+
+    const maxSpecialCandidates = 1;
+    const numSpecialCandidates = items.filter((item) => item.kind === 'nota').length;
+    const draftIndex = getDraftIndex(items);
+
+    return <FileDropBox onlyShowOnDrag helperText='Add from photo(s)' onDrop={handlePhotoDrop}>
+        <Button
+            sx={{ mr: "auto", textDecoration: 'none', textTransform: 'none', color: 'black', fontSize: '1.125rem', opacity: 0.86 }}
+            onClick={() => setCandidatesExpanded((current) => !current)}
+        >
+            {candidatesExpanded ? <MinusIcon prefix /> : <AddIcon prefix />} {t('race_form.candidates_title')}
+        </Button>
+        <FormHelperText error sx={{ pl: 1, pt: 0 }}>
+            {error}
+        </FormHelperText>
+
+        <Box sx={{
+            position: 'relative',
+            height: candidatesExpanded ? `${
+                items.length * 66 - 11 +
+                40 * (maxSpecialCandidates - numSpecialCandidates) +
+                58
+            }px` : 0,
+            transition: 'height 0.5s',
+        }}>
+            <TransitionBox absolute enabled={candidatesExpanded}>
+                <Stack spacing={2}>
+                    <SortableList
+                        items={items}
+                        identifierKey="id"
+                        indexIsValid={(index) => index < draftIndex}
+                        onChange={handleChangeCandidates}
+                        renderItem={(item, index) => (
+                            <SortableList.Item id={item.id}>
+                                <CandidateEditorRow
+                                    key={item.id}
+                                    ref={(handle) => registerRowRef(item.id, handle)}
+                                    item={item}
+                                    index={index}
+                                    canDelete={getCommittedCandidateCount > 2}
+                                    disabled={isDisabled}
+                                    onClearError={clearCandidatesError}
+                                    onDeleteCommittedRow={onDeleteCommittedRow}
+                                    onPromoteDraft={onPromoteDraft}
+                                    registerInputRef={registerInputRef}
+                                    focusPrevious={(id) => focusRelative(id, -1)}
+                                    focusNext={(id) => focusRelative(id, 1)}
+                                    setCandidateError={(message) => onSetError('candidates', message)}
+                                />
+                            </SortableList.Item>
+                        )}
+                    />
+                    {isDraft && !items.some((item) => item.kind === 'nota') && <Box>
+                        <LinkButton
+                            onClick={() => setItems((currentItems) => {
+                                if (currentItems.some((item) => item.kind === 'nota')) {
+                                    return currentItems;
+                                }
+
+                                return [...currentItems, {
+                                    id: NOTA_ID,
+                                    initialCandidate: {
+                                        candidate_id: NOTA_ID,
+                                        candidate_name: 'None of the Above',
+                                    },
+                                    kind: 'nota',
+                                }];
+                            })}
+                            sx={{ ml: 1 }}
+                        >
+                            Add "None of the Above"
+                        </LinkButton>
+                        <Tip name='nota' />
+                    </Box>}
+                    <FormControlLabel
+                        disabled={isDisabled}
+                        control={
+                            <Checkbox
+                                id="enable-write-in"
+                                checked={enableWriteIn}
+                                onChange={(e) => {
+                                    clearCandidatesError();
+                                    setEnableWriteIn(e.target.checked);
+                                }}
+                            />
+                        }
+                        label="Allow write-ins"
+                        sx={{ pl: 1 }}
+                    />
+                </Stack>
+            </TransitionBox>
+        </Box>
+    </FileDropBox>;
+});

--- a/packages/frontend/src/components/ElectionForm/Races/VotingMethodSelector.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/VotingMethodSelector.tsx
@@ -1,73 +1,119 @@
-import { Edit, ExpandLess, ExpandMore } from "@mui/icons-material";
-import { Box, Button, FormControlLabel, FormHelperText, IconButton, Radio, RadioGroup, TextField, Typography } from "@mui/material"
-import { useEffect, useState } from "react";
-import { PrimaryButton, SecondaryButton } from "~/components/styles";
-import { AddIcon, methodValueToTextKey, TransitionBox, useSubstitutedTranslation } from "~/components/util"
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import EditIcon from '@mui/icons-material/Edit';
+import { Box, Button, FormControlLabel, FormHelperText, IconButton, Radio, RadioGroup, TextField, Typography } from "@mui/material";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { Election, NewElection } from "@equal-vote/star-vote-shared/domain_model/Election";
+import { Race as IRace, VotingMethod } from "@equal-vote/star-vote-shared/domain_model/Race";
+import { PrimaryButton, SecondaryButton } from "~/components/styles";
+import { AddIcon, methodValueToTextKey, TransitionBox, useSubstitutedTranslation } from "~/components/util";
+import { RaceErrors } from "./useEditRace";
 
 type MethodStep = 'unset' | 'family' | 'num_winners' | 'method' | 'done';
+type MethodFamily = 'single_winner' | 'bloc_multi_winner' | 'proportional_multi_winner' | undefined;
+
 const stepIndex = {
-    'unset': 0,
-    'family': 1,
-    'num_winners': 2,
-    'method': 3,
-    'done': 4
+    unset: 0,
+    family: 1,
+    num_winners: 2,
+    method: 3,
+    done: 4,
 };
 
-export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceUpdate, open}) => {
-    const { t } = useSubstitutedTranslation();
-    const PR_METHODS = ['STV', 'STAR_PR'];
-    const [methodStep, innerSetMethodStep] = useState<MethodStep>(editedRace.voting_method == undefined? 'unset' : 'done');
-    // I have to have a non-undefined default to avoid warnings that slow down the UI
-    const [inputtedWinners, setInputtedWinners] = useState(String(editedRace.num_winners ?? 1));
-    const [showAllMethods, setShowAllMethods] = useState(false)
-    const [methodFamily, setMethodFamily] = useState(
-        editedRace.voting_method == undefined ? 
-            undefined
-        : (
-            editedRace.num_winners == 1 ?
-                'single_winner'
-                : (
-                    PR_METHODS.includes(editedRace.voting_method) ?
-                        'proportional_multi_winner'
-                        :
-                        'bloc_multi_winner'
-                )
-        )
-    )
+const PR_METHODS: VotingMethod[] = ['STV', 'STAR_PR'];
 
-    useEffect(() => {
-        if(open){
-            setMethodStep(editedRace.voting_method == undefined? 'unset' : 'done')
-        }
-    }, [open])
-
-    const setMethodStep = (step: MethodStep) => {
-        setErrors({...errors, votingMethod: ''})
-        applyRaceUpdate(race => {
-            if(step == 'unset' || step == 'family'){
-                race.num_winners = undefined;
-                setMethodFamily(undefined);
-                setInputtedWinners('');
-            }
-            if(step == 'unset' || step == 'family' || step == 'num_winners' || step == 'method'){
-                race.voting_method = undefined;
-                setShowAllMethods(false);
-            }
-        });
-        setTimeout(() => {
-            innerSetMethodStep(step)
-        }, 100);
+const getMethodFamily = (votingMethod: VotingMethod | undefined, numWinners: number | undefined): MethodFamily => {
+    if (votingMethod === undefined || numWinners === undefined) {
+        return undefined;
     }
 
-    const MethodBullet = ({ value, disabled }: { value: string, disabled: boolean }) => <>
-        <FormControlLabel value={value} disabled={disabled} control={
-            <Radio onClick={() => setMethodStep('done')}/>
-        } label={t(`edit_race.methods.${methodValueToTextKey[value]}.title`)} sx={{ mb: 0, pb: 0 }} />
+    if (numWinners === 1) {
+        return 'single_winner';
+    }
+
+    return PR_METHODS.includes(votingMethod) ? 'proportional_multi_winner' : 'bloc_multi_winner';
+};
+
+export interface VotingMethodValue {
+    num_winners: number | undefined,
+    voting_method: VotingMethod | undefined,
+}
+
+export interface VotingMethodSelectorHandle {
+    getValue: () => VotingMethodValue,
+}
+
+interface VotingMethodSelectorProps {
+    election: Election | NewElection,
+    error?: RaceErrors['votingMethod'],
+    initialRace: IRace,
+    isDisabled: boolean,
+    onClearError: (field: keyof RaceErrors) => void,
+    open?: boolean,
+}
+
+const VotingMethodSelector = forwardRef<VotingMethodSelectorHandle, VotingMethodSelectorProps>(function VotingMethodSelector({
+    election,
+    error = '',
+    initialRace,
+    isDisabled,
+    onClearError,
+    open,
+}, ref) {
+    const { t } = useSubstitutedTranslation();
+    const [methodStep, setMethodStepState] = useState<MethodStep>(initialRace.voting_method == undefined ? 'unset' : 'done');
+    const [votingMethod, setVotingMethod] = useState<VotingMethod | undefined>(initialRace.voting_method);
+    const [numWinners, setNumWinners] = useState<number | undefined>(initialRace.num_winners);
+    const [inputtedWinners, setInputtedWinners] = useState(initialRace.num_winners == undefined ? '' : String(initialRace.num_winners));
+    const [showAllMethods, setShowAllMethods] = useState(false);
+    const [methodFamily, setMethodFamily] = useState<MethodFamily>(getMethodFamily(initialRace.voting_method, initialRace.num_winners));
+
+    useEffect(() => {
+        setMethodStepState(initialRace.voting_method == undefined ? 'unset' : 'done');
+        setVotingMethod(initialRace.voting_method);
+        setNumWinners(initialRace.num_winners);
+        setInputtedWinners(initialRace.num_winners == undefined ? '' : String(initialRace.num_winners));
+        setShowAllMethods(false);
+        setMethodFamily(getMethodFamily(initialRace.voting_method, initialRace.num_winners));
+    }, [initialRace, open]);
+
+    useImperativeHandle(ref, () => ({
+        getValue: () => ({
+            num_winners: numWinners,
+            voting_method: votingMethod,
+        }),
+    }), [numWinners, votingMethod]);
+
+    const clearError = () => onClearError('votingMethod');
+
+    const setMethodStep = (step: MethodStep) => {
+        clearError();
+
+        if (step === 'unset' || step === 'family') {
+            setNumWinners(undefined);
+            setMethodFamily(undefined);
+            setInputtedWinners('');
+        }
+
+        if (step === 'unset' || step === 'family' || step === 'num_winners' || step === 'method') {
+            setVotingMethod(undefined);
+            setShowAllMethods(false);
+        }
+
+        setMethodStepState(step);
+    };
+
+    const MethodBullet = ({ value, disabled }: { value: VotingMethod, disabled: boolean }) => <>
+        <FormControlLabel
+            value={value}
+            disabled={disabled}
+            control={<Radio onClick={() => setMethodStep('done')} />}
+            label={t(`edit_race.methods.${methodValueToTextKey[value]}.title`)}
+            sx={{ mb: 0, pb: 0 }}
+        />
         <FormHelperText sx={{ pl: 4, mt: -1 }}>
             {t(`edit_race.methods.${methodValueToTextKey[value]}.description`)}
         </FormHelperText>
-    </>
+    </>;
 
     const FamilyPage = () => <>
         <Typography id="num-winners-label" gutterBottom component="p">
@@ -78,13 +124,20 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
             name="method-family-radio-buttons-group"
             value={methodFamily}
             onChange={(e) => {
-                // HACK: calling setMethodStep first beacause only the final applyRaceUpdate will apply
-                setMethodStep(e.target.value === 'single_winner' ? 'method' : 'num_winners');
-                applyRaceUpdate(race => {
-                    race.num_winners = e.target.value === 'single_winner'? 1 : 2;
-                    setInputtedWinners('' + race.num_winners)
-                });
-                setMethodFamily(e.target.value)
+                const nextMethodFamily = e.target.value as Exclude<MethodFamily, undefined>;
+                clearError();
+                setMethodFamily(nextMethodFamily);
+
+                if (nextMethodFamily === 'single_winner') {
+                    setNumWinners(1);
+                    setInputtedWinners('1');
+                    setMethodStepState('method');
+                    return;
+                }
+
+                setNumWinners(2);
+                setInputtedWinners('2');
+                setMethodStepState('num_winners');
             }}
         >
             <FormControlLabel
@@ -109,10 +162,10 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
                 sx={{ mb: 0, pb: 0 }}
             />
         </RadioGroup>
-    </>
+    </>;
 
     const NumWinnersPage = () => <>
-        <Box display='flex' flexDirection='row' gap={3} sx={{width: '100%'}}>
+        <Box display='flex' flexDirection='row' gap={3} sx={{ width: '100%' }}>
             <Typography id="num-winners-label" gutterBottom component="p" sx={{ marginTop: 2 }}>
                 {t('edit_race.number_of_winners')}:
             </Typography>
@@ -123,7 +176,7 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
                     inputProps: {
                         min: 2,
                         "aria-labelledby": "num-winners-label",
-                    }
+                    },
                 }}
                 fullWidth
                 value={inputtedWinners}
@@ -134,35 +187,38 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
                     my: 1,
                 }}
                 onChange={(e) => {
+                    clearError();
                     setInputtedWinners(e.target.value);
 
-                    if(e.target.value == '' || parseInt(e.target.value) < 1){
+                    if (e.target.value === '' || parseInt(e.target.value) < 1) {
+                        setNumWinners(undefined);
                         return;
                     }
 
-                    if(e.target.value != '') applyRaceUpdate(race => { race.num_winners =  parseInt(e.target.value) });
+                    setNumWinners(parseInt(e.target.value));
                 }}
             />
         </Box>
-        <Box display='flex' flexDirection='row' justifyContent='flex-end' gap={1} sx={{width: '100%'}}>
-            <SecondaryButton onClick={() => {
-                setMethodStep('family')
-            }}>Back</SecondaryButton>
-            <PrimaryButton disabled={inputtedWinners == '' || parseInt(inputtedWinners) < 1} onClick={() => {
-                setMethodStep('method')
-            }}>Next</PrimaryButton>
+        <Box display='flex' flexDirection='row' justifyContent='flex-end' gap={1} sx={{ width: '100%' }}>
+            <SecondaryButton onClick={() => setMethodStep('family')}>Back</SecondaryButton>
+            <PrimaryButton disabled={inputtedWinners === '' || parseInt(inputtedWinners) < 1} onClick={() => setMethodStepState('method')}>
+                Next
+            </PrimaryButton>
         </Box>
-    </>
+    </>;
 
     const VotingMethodPage = () => <>
         <Typography>Which Voting Method?</Typography>
         <RadioGroup
             aria-labelledby="voting-method-radio-group"
             name="voter-method-radio-buttons-group"
-            value={editedRace.voting_method}
-            onChange={(e) => applyRaceUpdate(race => { race.voting_method = e.target.value; })}
+            value={votingMethod}
+            onChange={(e) => {
+                clearError();
+                setVotingMethod(e.target.value as VotingMethod);
+            }}
         >
-            {methodFamily == 'proportional_multi_winner' ?
+            {methodFamily === 'proportional_multi_winner' ?
                 <MethodBullet value='STAR_PR' disabled={isDisabled} />
                 : <>
                     <MethodBullet value='STAR' disabled={isDisabled} />
@@ -174,16 +230,17 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
                 display='flex'
                 justifyContent="left"
                 alignItems="center"
-                sx={{ width: '100%', ml: -1 }}>
+                sx={{ width: '100%', ml: -1 }}
+            >
                 {showAllMethods &&
                     <IconButton aria-labelledby='more-options' disabled={election.state != 'draft'} onClick={() => setShowAllMethods(false)}>
                         <ExpandMore />
                     </IconButton>}
                 {!showAllMethods &&
-                    <IconButton aria-label='more-options' disabled={election.state != 'draft'} onClick={() => setShowAllMethods(true) }>
+                    <IconButton aria-label='more-options' disabled={election.state != 'draft'} onClick={() => setShowAllMethods(true)}>
                         <ExpandLess />
                     </IconButton>}
-                <Typography variant="body1" id={'more-options'} >
+                <Typography variant="body1" id='more-options'>
                     More Options
                 </Typography>
             </Box>
@@ -192,20 +249,16 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
                 opacity: showAllMethods ? 1 : 0,
                 overflow: 'hidden',
                 transition: 'height .4s, opacity .7s',
-                textAlign: 'left', // this is necessary to keep the items under more options aligned left
+                textAlign: 'left',
             }}>
                 <Box
                     display='flex'
                     justifyContent="left"
                     alignItems="center"
-                    sx={{ width: '100%', pl: 4, mt: -1 }}>
+                    sx={{ width: '100%', pl: 4, mt: -1 }}
+                />
 
-                    {/*<FormHelperText >
-                        These voting methods do not guarantee every voter an equally powerful vote if there are more than two candidates.
-                    </FormHelperText>*/}
-                </Box>
-
-                {methodFamily == 'proportional_multi_winner' ?
+                {methodFamily === 'proportional_multi_winner' ?
                     <MethodBullet value='STV' disabled={isDisabled} />
                     : <>
                         <MethodBullet value='Plurality' disabled={isDisabled} />
@@ -214,52 +267,51 @@ export default ({election, editedRace, isDisabled, setErrors, errors, applyRaceU
             </Box>
         </RadioGroup>
         <Box display='flex' flexDirection='row' justifyContent='flex-end' gap={1}>
-            <SecondaryButton onClick={() => {
-                setMethodStep(methodFamily === 'single_winner' ? 'family' : 'num_winners')
-            }}>Back</SecondaryButton>
+            <SecondaryButton onClick={() => setMethodStep(methodFamily === 'single_winner' ? 'family' : 'num_winners')}>Back</SecondaryButton>
         </Box>
-    </>
+    </>;
 
-    const pad = 0; // 30 // may add this back later
+    const pad = 0;
 
     return <Box>
         <Button
-            // it's hacky, but opacity 0.8 does helps take the edge off the bold a bit
-            sx={{mr: "auto", textDecoration: 'none', textTransform: 'none', color: 'black', fontSize: '1.125rem', opacity: 0.86, textAlign: 'left'}}
+            sx={{ mr: "auto", textDecoration: 'none', textTransform: 'none', color: 'black', fontSize: '1.125rem', opacity: 0.86, textAlign: 'left' }}
             disabled={methodStep != 'unset' && methodStep != 'done'}
             onClick={() => setMethodStep('family')}
         >
-            {methodStep == 'done' && <EditIcon sx={{scale: 1, mr: 1}}/>}
+            {methodStep == 'done' && <EditIcon sx={{ scale: 1, mr: 1 }} />}
             {methodStep != 'done' ? <>
-                <AddIcon prefix/> Voting Method
+                <AddIcon prefix /> Voting Method
             </> : <>
-                {editedRace.voting_method == undefined ? '___' : t(`methods.${methodValueToTextKey[editedRace.voting_method]}.full_name`)} with&nbsp;
-                {editedRace.num_winners == undefined ? '___' : editedRace.num_winners}&nbsp;
+                {votingMethod == undefined ? '___' : t(`methods.${methodValueToTextKey[votingMethod]}.full_name`)} with&nbsp;
+                {numWinners == undefined ? '___' : numWinners}&nbsp;
                 {methodFamily == undefined || methodFamily == 'single_winner' ? '' : <>{t(`edit_race.${methodFamily}_adj`)}&nbsp;</>}
-                {methodFamily == 'single_winner'? 'winner' : 'winners'}
+                {methodFamily == 'single_winner' ? 'winner' : 'winners'}
             </>}
         </Button>
-        <FormHelperText error sx={{ pl: 1}}>
-            {errors.votingMethod}
+        <FormHelperText error sx={{ pl: 1 }}>
+            {error}
         </FormHelperText>
 
         <Box sx={{
             position: 'relative',
             height: {
-                xs: `${[0, 155, 120, showAllMethods? 472 : 331, -pad][stepIndex[methodStep]]+pad}px`,
-                sm: `${[0, 180, 122, showAllMethods? 407 : 287, -pad][stepIndex[methodStep]]+pad}px`,
+                xs: `${[0, 155, 120, showAllMethods ? 472 : 331, -pad][stepIndex[methodStep]] + pad}px`,
+                sm: `${[0, 180, 122, showAllMethods ? 407 : 287, -pad][stepIndex[methodStep]] + pad}px`,
             },
             transition: 'height 0.5s',
         }}>
             <TransitionBox absolute enabled={methodStep == 'family'}>
-                <FamilyPage/>
+                <FamilyPage />
             </TransitionBox>
             <TransitionBox absolute enabled={methodStep == 'num_winners'}>
-                <NumWinnersPage/>
+                <NumWinnersPage />
             </TransitionBox>
             <TransitionBox absolute enabled={methodStep == 'method'}>
-                <VotingMethodPage/>
+                <VotingMethodPage />
             </TransitionBox>
         </Box>
-    </Box>
-}
+    </Box>;
+});
+
+export default VotingMethodSelector;

--- a/packages/frontend/src/components/ElectionForm/Races/useEditRace.tsx
+++ b/packages/frontend/src/components/ElectionForm/Races/useEditRace.tsx
@@ -1,17 +1,10 @@
-import { Dispatch, useEffect } from 'react'
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { scrollToElement } from '../../util';
-import useElection, { IElectionContext } from '../../ElectionContextProvider';
+import useElection from '../../ElectionContextProvider';
 import { Race as iRace } from '@equal-vote/star-vote-shared/domain_model/Race';
-import structuredClone from '@ungap/structured-clone';
-import useConfirm from '../../ConfirmationDialogProvider';
-import { Election as IElection } from '@equal-vote/star-vote-shared/domain_model/Election';
 import { makeID, ID_PREFIXES, ID_LENGTHS } from '@equal-vote/star-vote-shared/utils/makeID';
 import { Candidate } from '@equal-vote/star-vote-shared/domain_model/Candidate';
-import { useDeleteAllBallots } from '~/hooks/useAPI';
-import useSnackbar from '~/components/SnackbarContext';
-import { Election, NewElection } from '@equal-vote/star-vote-shared/domain_model/Election';
 
 export interface RaceErrors {
     raceTitle?: string,
@@ -41,36 +34,20 @@ export const useEditRace = (
     open=false,
 ) => {
     const { election } = useElection()
-    
-    const [editedRace, setEditedRace] = useState(race !== null ? race : makeDefaultRace())
-    const [errors, setErrors] = useState({
+
+    const getEmptyErrors = (): RaceErrors => ({
         raceTitle: '',
         raceDescription: '',
         candidates: '',
         votingMethod: '',
-    } as RaceErrors)
+    });
+    const [errors, setErrors] = useState<RaceErrors>(getEmptyErrors())
 
     useEffect(() => {
-        setEditedRace(race !== null ? race : makeDefaultRace())
-        setErrors({
-            raceTitle: '',
-            raceDescription: '',
-            candidates: '',
-            votingMethod: '',
-        })
+        setErrors(getEmptyErrors())
     }, [race, race_index, open])
 
-    const applyRaceUpdate = (updateFunc: (race: iRace) => void) => {
-        const raceCopy: iRace = structuredClone(editedRace)
-        updateFunc(raceCopy)
-        setEditedRace(raceCopy)
-    };
-
-    const resetRace = () => setEditedRace(
-        makeDefaultRace()
-    )
-
-    const validateRace = () => {
+    const validateRace = (editedRace: iRace) => {
         let isValid = true
         const newErrors: RaceErrors = {}
 
@@ -119,7 +96,10 @@ export const useEditRace = (
             isValid = false;
         }
 
-        setErrors(errors => ({ ...errors, ...newErrors }))
+        setErrors({
+            ...getEmptyErrors(),
+            ...newErrors,
+        })
 
         // NOTE: I'm passing the element as a function so that we can delay the query until the elements have been updated
         scrollToElement(() => document.querySelectorAll('.Mui-error'))
@@ -127,5 +107,5 @@ export const useEditRace = (
         return isValid
     }
 
-    return { editedRace, resetRace, errors, setErrors, applyRaceUpdate, validateRace }
+    return { errors, setErrors, validateRace }
 }


### PR DESCRIPTION
An alternative to #1310 for addressing #1302, i.e. molasses keystrokes.

This PR just moves state down instead of keeping draft states locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved form component structure with modular, reusable sub-components.
  * Simplified state management and form submission handling.
  * Enhanced error handling and validation workflows.

* **Performance**
  * Optimized rendering efficiency through strategic component memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->