### PR TITLE
fix(wizard): replace voter list toggle with auto voter ID choice

### DIFF
--- a/packages/frontend/src/components/ElectionForm/Wizard/WizardExtra.tsx
+++ b/packages/frontend/src/components/ElectionForm/Wizard/WizardExtra.tsx
@@ -28,27 +28,27 @@ const templateMappers = {
             },
         }
     }),
-    'email_list': (election) => ({
+    'auto_voter_id_yes':(election:NewElection):NewElection => ({
         ...election,
-        is_public: false,
-        settings: {
+        is_public:false,
+        settings:{
             ...election.settings,
-            voter_authentication: {
+            voter_authentication:{
                 ...election.settings.voter_authentication,
-                // email: true <- this means login will be required, that's not what we want for this setting. TODO: figure out refactored name
-                voter_id: true
+                voter_id:true
             },
-            invitation: 'email',
+            invitation:'email',
+
         }
     }),
-    'id_list': (election) => ({
+    'auto_voter_id_no':(election:NewElection):NewElection => ({
         ...election,
-        is_public: false,
-        settings: {
+        is_public:false,
+        settings:{
             ...election.settings,
-            voter_authentication: {
+            voter_authentication:{
                 ...election.settings.voter_authentication,
-                voter_id: true
+                voter_id:true
             },
         }
     }),
@@ -187,16 +187,40 @@ export default ({onBack, multiRace, onAddElection}) => {
                 <StepLabel>{t('wizard.template_title')}</StepLabel>
                 <StepContent>
                     <Typography>
-                        {t('wizard.template_prompt')}
+                        {election.settings.voter_access === 'closed'
+                            ? 'Automatically generate voter ID?'
+                            : t('wizard.template_prompt')}
                     </Typography>
                     <Box style={{ height: '10px' }} /> {/*hacky padding*/}
-                    {(election.settings.voter_access === 'closed' ? ['email_list', 'id_list'] : ['demo', 'unlisted']).map((name) =>
+                    {(election.settings.voter_access === 'closed' ? ['auto_voter_id_yes', 'auto_voter_id_no'] : ['demo', 'unlisted']).map((name) =>
                         <RowButtonWithArrow
-                            title={t(`wizard.${name}_title`)}
-                            description={t(`wizard.${name}_description`)}
+                            title={
+                                name === 'auto_voter_id_yes'
+                                ? 'Yes'
+                                :name === 'auto_voter_id_no'
+                                ? 'No'
+                                : t(`wizard.${name}_title`)
+                            }
+                            description={
+                                name ==='auto_voter_id_yes'
+                                ? 'Yes (auto-generate IDs)'
+                                : name === 'auto_voter_id_no'
+                                ? 'No (provide IDs manually)'
+                                : t(`wizard.${name}_description`)
+                            }
                             key={name}
-                            onClick={() => onAddElection(templateMappers[name](election), '/admin')}
-                            ariaLabel={t(`wizard.${name}_title`)}
+                            onClick={() => {
+                                const updated = templateMappers[name](election);
+                                onAddElection(updated, '/admin');
+                            }}
+                            ariaLabel={
+                                name === 'auto_voter_id_yes'
+                                ? 'Yes'
+                                : name === 'auto_voter_id_no'
+                                ? 'No'
+                                : t(`wizard.${name}_title`)
+
+                            }
                         />
                     )}
 


### PR DESCRIPTION

Replaces the ID list vs email list toggle with a yes/no choice for automatically generating voter IDs.
<img width="501" height="512" alt="Screenshot 2026-04-14 at 5 39 38 PM" src="https://github.com/user-attachments/assets/a4141f86-42c2-40bf-a4a4-7c3fa4daa414" />


Changes:
- Added auto_voter_id_yes and auto_voter_id_no mappings
- Updated wizard UI to reflect new choice
- Ensures different election configurations based on selection

Tested locally.

Closes #1307