### PR TITLE
DBs with head=true pattern should never have two rows with head=true

### DIFF
--- a/packages/backend/src/Migrations/2026_04_27_unique_head.ts
+++ b/packages/backend/src/Migrations/2026_04_27_unique_head.ts
@@ -1,0 +1,30 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+    await db.schema.createIndex('electionDB_unique_head')
+        .on('electionDB')
+        .column('election_id')
+        .unique()
+        .where(sql.ref('head'), '=', true)
+        .execute()
+
+    await db.schema.createIndex('ballotDB_unique_head')
+        .on('ballotDB')
+        .column('ballot_id')
+        .unique()
+        .where(sql.ref('head'), '=', true)
+        .execute()
+
+    await db.schema.createIndex('electionRollDB_unique_head')
+        .on('electionRollDB')
+        .columns(['election_id', 'voter_id'])
+        .unique()
+        .where(sql.ref('head'), '=', true)
+        .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await db.schema.dropIndex('electionRollDB_unique_head').execute()
+    await db.schema.dropIndex('ballotDB_unique_head').execute()
+    await db.schema.dropIndex('electionDB_unique_head').execute()
+}

--- a/packages/backend/src/Migrations/2026_04_27_unique_head.ts
+++ b/packages/backend/src/Migrations/2026_04_27_unique_head.ts
@@ -10,7 +10,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 
     await db.schema.createIndex('ballotDB_unique_head')
         .on('ballotDB')
-        .column('ballot_id')
+        .columns(['ballot_id', 'election_id'])
         .unique()
         .where(sql.ref('head'), '=', true)
         .execute()


### PR DESCRIPTION
Merge this before we launch the new admin panel so we don't have to do manual cleanup later if there are races.