### PR TITLE
optimistic concurrency for electiondb

### DIFF
--- a/packages/backend/src/Controllers/Election/archiveElectionController.ts
+++ b/packages/backend/src/Controllers/Election/archiveElectionController.ts
@@ -25,7 +25,8 @@ const archiveElection = async (req: IElectionRequest, res: Response, next: NextF
 
     var failMsg = "Failed to update Election";
     election.state = 'archived'
-    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Archive election`);
+    const expected_update_date = req.body.expected_update_date;
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Archive election`, expected_update_date);
     if (!updatedElection) {
         Logger.info(req, failMsg);
         throw new BadRequest(failMsg)

--- a/packages/backend/src/Controllers/Election/claimElectionController.ts
+++ b/packages/backend/src/Controllers/Election/claimElectionController.ts
@@ -32,7 +32,8 @@ const claimElection = async (req: IElectionRequest, res: Response, next: NextFun
     }
 
     req.election.owner_id = req.user.sub;
-    await ElectionsModel.updateElection(req.election, req, `Transferring Ownership`);
+    const expected_update_date = req.body.expected_update_date;
+    await ElectionsModel.updateElection(req.election, req, `Transferring Ownership`, expected_update_date);
 
     res.send()
 }

--- a/packages/backend/src/Controllers/Election/editElectionController.ts
+++ b/packages/backend/src/Controllers/Election/editElectionController.ts
@@ -38,7 +38,8 @@ const editElection = async (req: IElectionRequest, res: Response, next: NextFunc
     Logger.debug(req, `election ID = ${inputElection}`);
     var failMsg = `Failed to update election`;
 
-    const updatedElection = await ElectionsModel.updateElection(inputElection, req, `User editing draft Election`);
+    const expected_update_date = req.body.expected_update_date;
+    const updatedElection = await ElectionsModel.updateElection(inputElection, req, `User editing draft Election`, expected_update_date);
     if (!updatedElection) {
         Logger.error(req, failMsg);
         throw new BadRequest(failMsg)

--- a/packages/backend/src/Controllers/Election/editElectionRolesController.ts
+++ b/packages/backend/src/Controllers/Election/editElectionRolesController.ts
@@ -26,7 +26,8 @@ const editElectionRoles = async (req: IElectionRequest, res: Response, next: Nex
     req.election.admin_ids = req.body.admin_ids
     req.election.audit_ids = req.body.audit_ids
     req.election.credential_ids = req.body.credential_ids
-    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Update election roles`);
+    const expected_update_date = req.body.expected_update_date;
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Update election roles`, expected_update_date);
     if (!updatedElection) {
         Logger.info(req, failMsg);
         throw new BadRequest(failMsg)

--- a/packages/backend/src/Controllers/Election/finalizeElectionController.ts
+++ b/packages/backend/src/Controllers/Election/finalizeElectionController.ts
@@ -38,7 +38,8 @@ const finalizeElection = async (req: IElectionRequest, res: Response, next: Next
 
     var failMsg = "Failed to update Election";
     req.election.state = 'finalized'
-    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Finalizing election`);
+    const expected_update_date = req.body.expected_update_date;
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Finalizing election`, expected_update_date);
     if (!updatedElection) {
         Logger.info(req, failMsg);
         throw new BadRequest(failMsg)

--- a/packages/backend/src/Controllers/Election/finalizeElectionController.ts
+++ b/packages/backend/src/Controllers/Election/finalizeElectionController.ts
@@ -23,8 +23,6 @@ const finalizeElection = async (req: IElectionRequest, res: Response, next: Next
         throw new BadRequest(msg)
     }
 
-    innerDeleteAllBallotsForElectionID(req);
-
     const electionId = req.election.election_id;
     let electionRoll: ElectionRoll[] | null = null
     if (req.election.settings.voter_access === 'closed' && req.election.settings.invitation === 'email') {
@@ -37,13 +35,17 @@ const finalizeElection = async (req: IElectionRequest, res: Response, next: Next
     }
 
     var failMsg = "Failed to update Election";
-    req.election.state = 'finalized'
+    // Use a finalized copy for the OC-protected update; leave req.election in draft state
+    // so the subsequent ballot-deletion's draft-state guard still passes.
+    const finalizedElection = { ...req.election, state: 'finalized' as const }
     const expected_update_date = req.body.expected_update_date;
-    const updatedElection = await ElectionsModel.updateElection(req.election, req, `Finalizing election`, expected_update_date);
+    const updatedElection = await ElectionsModel.updateElection(finalizedElection, req, `Finalizing election`, expected_update_date);
     if (!updatedElection) {
         Logger.info(req, failMsg);
         throw new BadRequest(failMsg)
     }
+
+    await innerDeleteAllBallotsForElectionID(req);
 
     res.json({ election: updatedElection })
 }

--- a/packages/backend/src/Controllers/Election/setOpenStateController.ts
+++ b/packages/backend/src/Controllers/Election/setOpenStateController.ts
@@ -42,7 +42,8 @@ const setOpenState = async (req: IElectionRequest, res: Response, next: NextFunc
         throw new BadRequest(msg);
     }
 
-    const updatedElection = await ElectionsModel.updateElection(req.election, req, "Open or close election");
+    const expected_update_date = req.body.expected_update_date;
+    const updatedElection = await ElectionsModel.updateElection(req.election, req, "Open or close election", expected_update_date);
     if (!updatedElection) {
         const failMsg = `Failed to set election state to ${election.state}`;
         Logger.info(req, failMsg);

--- a/packages/backend/src/Controllers/Election/setPublicResultsController.ts
+++ b/packages/backend/src/Controllers/Election/setPublicResultsController.ts
@@ -21,7 +21,8 @@ const setPublicResults = async (req: IElectionRequest, res: Response, next: Next
     }
     election.settings.public_results = public_results
 
-    const updatedElection = await ElectionsModel.updateElection(election, req, `Publish Results`);
+    const expected_update_date = req.body.expected_update_date;
+    const updatedElection = await ElectionsModel.updateElection(election, req, `Publish Results`, expected_update_date);
     if (!updatedElection) {
         const failMsg = 'could not update public_results setting'
         Logger.info(req, failMsg);

--- a/packages/backend/src/Models/Elections.ts
+++ b/packages/backend/src/Models/Elections.ts
@@ -6,7 +6,7 @@ import { Kysely, sql } from 'kysely'
 import { Election, electionValidation } from '@equal-vote/star-vote-shared/domain_model/Election';
 import { sharedConfig } from '@equal-vote/star-vote-shared/config';
 import { IElectionStore } from './IElectionStore';
-import { InternalServerError } from '@curveball/http-errors';
+import { Conflict, InternalServerError } from '@curveball/http-errors';
 import { BadRequest } from "@curveball/http-errors";
 
 const tableName = 'electionDB';
@@ -79,7 +79,7 @@ export default class ElectionsDB implements IElectionStore {
                 .executeTakeFirst()
 
             if (expected_update_date !== undefined && result.numUpdatedRows === BigInt(0)) {
-                throw new InternalServerError('Concurrent write detected, please try again');
+                throw new Conflict('Concurrent write detected, please try again');
             }
 
             return await trx.insertInto('electionDB')

--- a/packages/backend/src/Models/__mocks__/Elections.ts
+++ b/packages/backend/src/Models/__mocks__/Elections.ts
@@ -3,6 +3,7 @@ import { Uid } from '@equal-vote/star-vote-shared/domain_model/Uid';
 import { ILoggingContext } from '../../Services/Logging/ILogger';
 import Logger from '../../Services/Logging/Logger';
 import { IElectionStore } from '../IElectionStore';
+import { Conflict } from '@curveball/http-errors';
 
 export default class ElectionsDB implements IElectionStore {
 
@@ -26,7 +27,7 @@ export default class ElectionsDB implements IElectionStore {
             throw new Error("Election Not Found")
         }
         if (expected_update_date !== undefined && this.elections[foundIndex].update_date !== expected_update_date) {
-            throw new Error("Concurrent write detected, please try again")
+            throw new Conflict("Concurrent write detected, please try again")
         }
         var copy = JSON.parse(JSON.stringify(election));
         copy.update_date = Date.now().toString();

--- a/packages/backend/src/OpenApi/swagger.json
+++ b/packages/backend/src/OpenApi/swagger.json
@@ -953,6 +953,18 @@
         ],
         "type": "string"
       },
+      "MethodTextKey": {
+        "enum": [
+          "approval",
+          "choose_one",
+          "ranked_robin",
+          "rcv",
+          "star",
+          "star_pr",
+          "stv"
+        ],
+        "type": "string"
+      },
       "NewBallot": {
         "properties": {
           "ballot_id": {
@@ -4118,11 +4130,83 @@
                   "properties": {
                     "elections": {
                       "type": "number",
-                      "description": "Number of elections"
+                      "description": "Total elections (legacy_elections + sum of per-method elections)"
                     },
                     "votes": {
                       "type": "number",
-                      "description": "Number of votes"
+                      "description": "Total votes cast (legacy_votes + sum of per-method votes)"
+                    },
+                    "legacy_elections": {
+                      "type": "number",
+                      "description": "Elections imported from classic star.vote"
+                    },
+                    "legacy_votes": {
+                      "type": "number",
+                      "description": "Votes imported from classic star.vote"
+                    },
+                    "star_elections": {
+                      "type": "number",
+                      "description": "Elections using STAR voting"
+                    },
+                    "star_votes": {
+                      "type": "number",
+                      "description": "Votes cast in STAR elections"
+                    },
+                    "rcv_elections": {
+                      "type": "number",
+                      "description": "Elections using Ranked Choice Voting (IRV)"
+                    },
+                    "rcv_votes": {
+                      "type": "number",
+                      "description": "Votes cast in RCV elections"
+                    },
+                    "approval_elections": {
+                      "type": "number",
+                      "description": "Elections using Approval voting"
+                    },
+                    "approval_votes": {
+                      "type": "number",
+                      "description": "Votes cast in Approval elections"
+                    },
+                    "ranked_robin_elections": {
+                      "type": "number",
+                      "description": "Elections using Ranked Robin voting"
+                    },
+                    "ranked_robin_votes": {
+                      "type": "number",
+                      "description": "Votes cast in Ranked Robin elections"
+                    },
+                    "star_pr_elections": {
+                      "type": "number",
+                      "description": "Elections using STAR Proportional Representation"
+                    },
+                    "star_pr_votes": {
+                      "type": "number",
+                      "description": "Votes cast in STAR PR elections"
+                    },
+                    "choose_one_elections": {
+                      "type": "number",
+                      "description": "Elections using Plurality voting"
+                    },
+                    "choose_one_votes": {
+                      "type": "number",
+                      "description": "Votes cast in Plurality elections"
+                    },
+                    "stv_elections": {
+                      "type": "number",
+                      "description": "Elections using Single Transferable Vote"
+                    },
+                    "stv_votes": {
+                      "type": "number",
+                      "description": "Votes cast in STV elections"
+                    },
+                    "multi_method_elections": {
+                      "type": "number",
+                      "description": "Elections with races using multiple different voting methods"
+                    },
+                    "multi_method_votes": {
+                      "type": "number",
+                      "description": "Votes cast in multi-method elections"
                     }
                   }
                 }

--- a/packages/backend/src/test/editElection.test.ts
+++ b/packages/backend/src/test/editElection.test.ts
@@ -111,4 +111,42 @@ describe("Edit Election", () => {
             // TODO
         })
     })
+
+    describe("Optimistic concurrency (expected_update_date)", () => {
+        test("accepts edit when expected_update_date matches", async () => {
+            const electionId = await setupInitialElection();
+            const current = await fetchElectionById(electionId);
+            const election1Copy = { ...testInputs.Election1, election_id: electionId };
+
+            const response = await th.postRequest(
+                `/API/Election/${electionId}/edit`,
+                { Election: election1Copy, expected_update_date: current.update_date },
+                testInputs.user1token,
+            );
+            expect(response.statusCode).toBe(200);
+            th.testComplete();
+        })
+
+        test("rejects edit with 409 when expected_update_date is stale", async () => {
+            const electionId = await setupInitialElection();
+            const election1Copy = { ...testInputs.Election1, election_id: electionId };
+
+            const response = await th.postRequest(
+                `/API/Election/${electionId}/edit`,
+                { Election: election1Copy, expected_update_date: 'definitely-not-the-current-date' },
+                testInputs.user1token,
+            );
+            expect(response.statusCode).toBe(409);
+            th.testComplete();
+        })
+
+        test("accepts edit when expected_update_date is omitted (backwards compatible)", async () => {
+            const electionId = await setupInitialElection();
+            const election1Copy = { ...testInputs.Election1, election_id: electionId };
+
+            const response = await th.editElection(election1Copy, testInputs.user1token);
+            expect(response.statusCode).toBe(200);
+            th.testComplete();
+        })
+    })
 })


### PR DESCRIPTION
Get all the optimistic concurrency backend stuff for electiondb squared away so we can iterate on the frontend more easily to fix some slight correctness issues (e.g., if admin changes a setting and then immediately navigates away before debounce).  