### PR TITLE
fix "(elected)" label in many-round STV

### DIFF
--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -389,7 +389,7 @@ function STVResultsViewer() {
 
   const winIndex = (aa) => {
     const i = results.elected.findIndex(e => e.id == aa.id);
-    if(i == -1) return results.elected.length;
+    if(i == -1) return Infinity;
     return i;
   }
 


### PR DESCRIPTION
Right now it does this which makes no sense 😄 

<img width="597" height="617" alt="Screenshot 2026-05-12 at 3 02 44 PM" src="https://github.com/user-attachments/assets/7b35b72f-7651-4d0e-82c1-61dff78cfd1f" />

This PR fixes it.