### PR TITLE
Allow ballot updates and public results to be enabled simultaneously

### DIFF
--- a/docs/help/preliminary_results.md
+++ b/docs/help/preliminary_results.md
@@ -19,7 +19,7 @@ When the setting is on:
 - The tally updates as ballots come in. A new ballot changes the numbers immediately.
 - After the election closes, the same view becomes the final results.
 
-When the setting is off, the tally is hidden from everyone (including voters and the public) until the election is closed and the admin chooses to publish.
+When the setting is off, the tally is hidden from everyone (both admins and voters) until the election is closed and the admin chooses to publish.
 
 ## What admins can see during an election
 
@@ -39,7 +39,7 @@ This is a legitimate feature for some kinds of polls (e.g. deliberative groups t
 - When their preferred candidate is behind, they can direct supporters to switch their vote to a backup choice, change rankings, or alter scores.
 - Because edits are silent and there is no rate limit, a coordinated swing in the final minutes can land before other voters notice.
 
-In voting methods like STAR, IRV, and STV, which are designed to reduce the incentive to vote strategically, this combination partially undoes that benefit. **If you are running a serious election and want sincere ballots, we recommend either leaving preliminary results off until the election closes, or turning off editable ballots.** BetterVoting will let you enable both, but you should do so deliberately.
+The methods on BetterVoting, are designed to reduce the incentive to vote strategically, but this combination partially undoes that benefit. **If you are running a serious election and want sincere ballots, we recommend either leaving preliminary results off until the election closes, or turning off editable ballots.** BetterVoting will let you enable both, but you should do so deliberately.
 
 ## Turning the setting off after it has been on
 
@@ -47,7 +47,7 @@ An admin can turn **Show Preliminary Results** off at any time, and the tally pa
 
 > **Turning the setting off does not un-reveal what has already been seen.** Anyone who looked at the tally while it was visible may have screenshotted, shared, or simply remembered it. Search engines, social media, and chat platforms can also retain copies. Treat the decision to show preliminary results as effectively one-way for any number you wouldn't want public, even briefly.
 
-The reverse switch — turning preliminary results **on** mid-election — is also possible, and it immediately exposes the full current tally, including ballots cast before the toggle.
+The reverse switch — turning preliminary results **on** mid-election — is also possible, and it immediately exposes the full current tally.
 
 ## Recommendations
 

--- a/docs/help/preliminary_results.md
+++ b/docs/help/preliminary_results.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Preliminary Results
+nav_order: 8
+parent: BetterVoting Documentation
+---
+
+# Preliminary Results
+
+When an election has **Show Preliminary Results** turned on, the running tally is visible to anyone with the election link while voting is still happening. This is great for casual polls, transparent community decisions, and demos — but it changes how the election behaves in some ways that voters and admins should understand before turning it on.
+
+This page is for both voters (so you know what other people can see when you vote) and admins (so you can make an informed choice about whether to enable it).
+
+## What "Show Preliminary Results" actually shows
+
+When the setting is on:
+
+- Anyone who visits the election page sees a **Preliminary Results** view with the current tally.
+- The tally updates as ballots come in. A new ballot changes the numbers immediately.
+- After the election closes, the same view becomes the final results.
+
+When the setting is off, the tally is hidden from everyone (including voters and the public) until the election is closed and the admin chooses to publish.
+
+## What admins can see during an election
+
+Independent of this setting, the admin always has access to a voter list that shows **which voters have cast a ballot and which have not**. This is part of how the email-list and ID-list flows work — admins need it to know who to remind. Admins do **not** see the contents of individual ballots: BetterVoting hides the link between a voter and their specific ballot.
+
+> **However**, if preliminary results are visible, an admin (or anyone watching the live tally) can combine the live tally with the voter-status list to infer some voters' choices. The simplest version: if only one voter casts a ballot during some window, the change in the tally during that window *is* that voter's ballot. With small numbers of voters or quiet periods, this kind of "delta analysis" can de-anonymize individual votes even though no single screen explicitly shows them.
+
+This is not a bug — it's a fundamental consequence of showing tallies live alongside a per-voter status list. If ballot secrecy matters to your election, leave preliminary results off until the election closes.
+
+## Preliminary results combined with editable ballots
+
+BetterVoting has a separate setting called **Allow Voters To Edit Vote** that lets voters change their ballot until the election closes. When both settings are enabled at the same time, voters can see how the election is going and then change their votes in response.
+
+This is a legitimate feature for some kinds of polls (e.g. deliberative groups that want to converge through discussion and revision). It also opens the door to **coordinated vote-switching**:
+
+- A campaign, faction, or chat group can watch the live tally together.
+- When their preferred candidate is behind, they can direct supporters to switch their vote to a backup choice, change rankings, or alter scores.
+- Because edits are silent and there is no rate limit, a coordinated swing in the final minutes can land before other voters notice.
+
+In voting methods like STAR, IRV, and STV, which are designed to reduce the incentive to vote strategically, this combination partially undoes that benefit. **If you are running a serious election and want sincere ballots, we recommend either leaving preliminary results off until the election closes, or turning off editable ballots.** BetterVoting will let you enable both, but you should do so deliberately.
+
+## Turning the setting off after it has been on
+
+An admin can turn **Show Preliminary Results** off at any time, and the tally page will stop being visible to voters and the public from that point forward.
+
+> **Turning the setting off does not un-reveal what has already been seen.** Anyone who looked at the tally while it was visible may have screenshotted, shared, or simply remembered it. Search engines, social media, and chat platforms can also retain copies. Treat the decision to show preliminary results as effectively one-way for any number you wouldn't want public, even briefly.
+
+The reverse switch — turning preliminary results **on** mid-election — is also possible, and it immediately exposes the full current tally, including ballots cast before the toggle.
+
+## Recommendations
+
+- **Casual polls, demos, opinion gathering**: Showing preliminary results is usually fine, and often what people expect.
+- **Serious elections where ballot secrecy matters**: Leave preliminary results off until the election is closed. Publish the final results after close.
+- **Serious elections where you want sincere ballots**: Do not combine preliminary results with editable ballots. Pick one.
+- **If you change your mind**: Remember that turning the setting off doesn't undo what was already visible.
+
+## Related
+
+- [Security Options](https://docs.bettervoting.com/help/security_options.html) — voter authentication and ballot-list options.
+- For more questions, reach out to our team at elections@equal.vote.

--- a/packages/backend/src/Controllers/Election/editElectionController.ts
+++ b/packages/backend/src/Controllers/Election/editElectionController.ts
@@ -30,11 +30,6 @@ const editElection = async (req: IElectionRequest, res: Response, next: NextFunc
         throw new BadRequest("Election ID must match the URL Param")
     }
 
-    // re-opening an election should maintain mutual exclusion of ballot_updates and preliminary results
-    if (inputElection.settings.ballot_updates && inputElection.state === "open" && inputElection.settings.public_results) {
-        inputElection.settings.public_results = false;
-    }
-
     Logger.debug(req, `election ID = ${inputElection}`);
     var failMsg = `Failed to update election`;
 

--- a/packages/backend/src/Controllers/Election/setOpenStateController.ts
+++ b/packages/backend/src/Controllers/Election/setOpenStateController.ts
@@ -32,11 +32,6 @@ const setOpenState = async (req: IElectionRequest, res: Response, next: NextFunc
     }
     election.state = open ? "open" : "closed";
 
-    // re-opening an election should maintain mutual exclusion of ballot_updates and preliminary results
-    if (election.settings.ballot_updates && election.state === "open" && election.settings.public_results) {
-        election.settings.public_results = false;
-    }
-
     if (msg) {
         Logger.info(req, msg);
         throw new BadRequest(msg);

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -685,9 +685,7 @@ tabulation_logs:
       **Random Tiebreaker**: {{winner}} wins against {{runner_up}} after a random tiebreaker. !tip(random_tie_order)
 
 disabled_msgs:
-    ballot_updates_with_prelim: Not supported when the election starts off with public results. This can be adjusted under the preview results tab.
     ballot_updates_when_open: Only supported when election uses email list
-    public_results: Not supported with vote editing. This can be adjusted under the setting tab.
 
 #######################################
 #### PRIORITY 4 : Info Bubbles ####

--- a/packages/shared/src/domain_model/ElectionSettings.ts
+++ b/packages/shared/src/domain_model/ElectionSettings.ts
@@ -73,9 +73,6 @@ function authenticationValidation(obj:authentication): string | null {
 function settingsCompatiblityValidation(settings: ElectionSettings, electionState?: ElectionState): string {
     let errorMsg = ''
     if (settings.ballot_updates) {
-        if (settings.public_results && !['closed', 'archived'].includes(electionState ?? '')) {
-            errorMsg += 'Preliminary results are not permitted when ballot updating is enabled.  ';
-        }
         if (settings.voter_access == 'open') {
             errorMsg += 'Ballot updating is not permitted on open access elections.  ';
         }


### PR DESCRIPTION
## Context

When doing the admin-rework, I decided to remove the UI logic for enforcing mutual exclusion between public_results and ballot_updates. I think we were over focused on secure elections when adding the ballot_updates feature and added more restrictions than needed. Removing them also makes our UI and backend a bit cleaner.

It's already removed on the frontend, and this change applies the corresponding backend changes. 

## Summary

- Removes the shared-layer compatibility validation that prevented `ballot_updates` and `public_results` from both being enabled when an election is in the `open` state
- Removes the auto-disable logic in `editElectionController` that silently cleared `public_results` when `ballot_updates` was enabled on an open election

## Test plan

- [x] Open an election with `ballot_updates` enabled and toggle `public_results` on — verify both remain set
- [x] Open an election with `public_results` enabled and toggle `ballot_updates` on — verify both remain set
- [x] Verify existing elections that had only one setting enabled are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)