### PR TITLE
fixed greedy link seeking bug in markdown parsing

### DIFF
--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -22,7 +22,7 @@ export const useLocalState = <T,>(value: T, onFlush: (v: T) => void): [T, (v: T)
     return [local, setLocal, flush];
 };
 
-const rLink = /\[(.*?)\]\((.*?)\)/;
+const rLink = /\[([^\]]*?)\]\(([^)]*?)\)/;
 const rBold = /\*\*(.*?)\*\*/;
 const rTip = / !tip\((.*)\)/;
 

--- a/packages/shared/src/utils/formatMarkdown.ts
+++ b/packages/shared/src/utils/formatMarkdown.ts
@@ -1,6 +1,6 @@
 import sanitizeHtml from 'sanitize-html';
 
-const rLink = /\[(.*?)\]\((.*?)\)/;
+const rLink = /\[([^\]]*?)\]\(([^)]*?)\)/;
 const rBold = /\*\*(.*?)\*\*/;
 
 export interface FormatMarkdownOptions {


### PR DESCRIPTION
User pointed out problem

<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/3b419738-58f7-4377-9342-96146f7e0807" />

pertaining to https://bettervoting.com/wcfj28/vote 

This PR fixes it.