### PR TITLE
Clean up the ballot-data export (JSON v2 + CSV Raw/Official)

### DIFF
--- a/packages/backend/src/test/exportFormat.test.ts
+++ b/packages/backend/src/test/exportFormat.test.ts
@@ -1,0 +1,113 @@
+import { Star } from '../Tabulators/Star';
+import { mapMethodInputs } from './TestHelper';
+import { buildElectionExport } from '@equal-vote/star-vote-shared/utils/exportFormat';
+
+// Builds a realistic STAR result and checks the v2 export shape.
+describe('buildElectionExport (v2 export format)', () => {
+    const names = ['Allison', 'Bill', 'Carmen'];
+    const votes = [
+        [5, 2, 1],
+        [5, 3, 0],
+        [4, 0, 5],
+        [3, 5, 5],
+        [5, 1, 4],
+    ];
+    const results: any = Star(...mapMethodInputs(names, votes), 1);
+
+    // Minimal election whose race candidates line up with the tabulator names.
+    const election: any = {
+        election_id: 'testelec',
+        title: 'Export format test',
+        state: 'closed',
+        create_date: '2026-07-05T13:41:39.541Z',
+        update_date: '1783258899541', // epoch-ms string — must normalize to ISO
+        owner_id: 'owner',
+        audit_ids: null,
+        public_archive_id: null,
+        head: true,
+        races: [
+            {
+                race_id: 'r1',
+                title: 'Race 1',
+                voting_method: 'STAR',
+                num_winners: 1,
+                candidates: names.map((n) => ({ candidate_id: n, candidate_name: n })),
+            },
+        ],
+        settings: { public_results: true },
+    };
+
+    const ballots: any = votes.map((v, i) => ({
+        ballot_id: `b${i}`,
+        election_id: 'testelec',
+        precinct: null,
+        votes: [
+            {
+                race_id: 'r1',
+                scores: names.map((n, j) => ({ candidate_id: n, score: v[j] })),
+            },
+        ],
+    }));
+
+    const out: any = buildElectionExport(election, ballots, [results]);
+    const json = JSON.stringify(out);
+
+    test('is versioned and self-describing', () => {
+        expect(out.format).toBe('bettervoting-export');
+        expect(out.format_version).toBe(2);
+        expect(typeof out.exported_at).toBe('string');
+        expect(Number.isNaN(Date.parse(out.exported_at))).toBe(false);
+    });
+
+    test('drops the O(n^2) pairwise maps from candidate objects', () => {
+        expect(json).not.toContain('votesPreferredOver');
+        expect(json).not.toContain('winsAgainst');
+    });
+
+    test('pairwise matrix is deduped with no self-pairs', () => {
+        const pw = out.results[0].pairwise;
+        for (const name of names) {
+            expect(pw[name]).toBeDefined();
+            expect(pw[name][name]).toBeUndefined(); // no self-vs-self
+        }
+        // Allison beats Bill head-to-head in this ballot set
+        expect(pw['Allison']['Bill'].wins).toBe(true);
+    });
+
+    test('uses snake_case throughout the results section', () => {
+        const r = out.results[0];
+        expect(r.voting_method).toBe('STAR');
+        expect(r).toHaveProperty('tie_break_type');
+        expect(r.summary).toHaveProperty('n_tally_votes');
+        expect(r.summary).not.toHaveProperty('nTallyVotes');
+        // candidate method field snake_cased
+        expect(r.candidates[0]).toHaveProperty('five_star_count');
+    });
+
+    test('references candidates by both id and name', () => {
+        const elected = out.results[0].elected;
+        expect(Array.isArray(elected)).toBe(true);
+        expect(elected[0]).toHaveProperty('id');
+        expect(elected[0]).toHaveProperty('name');
+        expect(elected[0].name).toBe('Allison');
+    });
+
+    test('ballot scores stay compact (id + score); names live on election.races', () => {
+        const score = out.ballots[0].votes[0].scores[0];
+        expect(score).toHaveProperty('candidate_id');
+        expect(score).toHaveProperty('score');
+        expect(score).not.toHaveProperty('candidate_name'); // not repeated per row
+        // name is resolvable from the race candidate list
+        const cand = out.election.races[0].candidates.find(
+            (c: any) => c.candidate_id === score.candidate_id,
+        );
+        expect(cand.candidate_name).toBeDefined();
+    });
+
+    test('normalizes timestamps to ISO-8601 and omits null fields', () => {
+        expect(out.election.update_date).toBe(new Date(1783258899541).toISOString());
+        expect(out.election.create_date).toBe('2026-07-05T13:41:39.541Z');
+        expect(out.election).not.toHaveProperty('audit_ids'); // null omitted
+        expect(out.election).not.toHaveProperty('public_archive_id');
+    });
+});

--- a/packages/backend/src/test/exportFormat.test.ts
+++ b/packages/backend/src/test/exportFormat.test.ts
@@ -104,6 +104,50 @@ describe('buildElectionExport (v2 export format)', () => {
         expect(cand.candidate_name).toBeDefined();
     });
 
+    test('preserves a null score (abstention) distinct from an explicit 0', () => {
+        // null = "did not score this candidate"; must NOT be dropped or turned into 0.
+        const election2: any = {
+            election_id: 'e2',
+            title: 'null score test',
+            head: true,
+            races: [
+                {
+                    race_id: 'r1',
+                    title: 'R',
+                    voting_method: 'STAR',
+                    num_winners: 1,
+                    candidates: [
+                        { candidate_id: 'a', candidate_name: 'Amy' },
+                        { candidate_id: 'b', candidate_name: 'Bo' },
+                    ],
+                },
+            ],
+            settings: {},
+        };
+        const ballots2: any = [
+            {
+                ballot_id: 'x',
+                election_id: 'e2',
+                votes: [
+                    {
+                        race_id: 'r1',
+                        scores: [
+                            { candidate_id: 'a', score: 0 }, // flat zero
+                            { candidate_id: 'b', score: null }, // abstained on Bo
+                        ],
+                    },
+                ],
+            },
+        ];
+        const o: any = buildElectionExport(election2, ballots2, undefined);
+        const scores = o.ballots[0].votes[0].scores;
+        const a = scores.find((s: any) => s.candidate_id === 'a');
+        const b = scores.find((s: any) => s.candidate_id === 'b');
+        expect(a.score).toBe(0);
+        expect(b).toHaveProperty('score'); // key kept
+        expect(b.score).toBeNull(); // and it stays null, not dropped, not 0
+    });
+
     test('normalizes timestamps to ISO-8601 and omits null fields', () => {
         expect(out.election.update_date).toBe(new Date(1783258899541).toISOString());
         expect(out.election.create_date).toBe('2026-07-05T13:41:39.541Z');

--- a/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
+++ b/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
@@ -25,7 +25,12 @@ export const BallotDataExport = ({ election, results }: Props) => {
         key: string;
     })[]>([]);
     const { ballots, fetchBallots } = useAnonymizedBallots();
-    const downloadCSV = async () => {
+    // 'raw'      => keep a blank (null / not scored) as an empty cell — preserves the audit
+    //               trail (an empty cell is distinct from an explicit 0). Ref issue #1160 Option B.
+    // 'official' => fill blanks with 0 so 3rd-party counting tools (Excel/Python) don't choke.
+    //               Ref issue #1160 Option A.
+    const [csvMode, setCsvMode] = useState<'raw' | 'official'>('raw');
+    const downloadCSV = async (mode: 'raw' | 'official' = 'raw') => {
         if (!ballots) return
         let header = [
             { label: 'ballot_id', key: 'ballot_id' },
@@ -46,7 +51,10 @@ export const BallotDataExport = ({ election, results }: Props) => {
             const row = { ballot_id: ballot.ballot_id, precinct: ballot.precinct };
             ballot.votes.forEach((vote) => {
                 vote.scores.forEach((score) => {
-                    row[`${vote.race_id}-${score.candidate_id}`] = score.score;
+                    // null / undefined = the voter didn't score this candidate.
+                    // Raw keeps it blank (distinct from an explicit 0); Official fills 0.
+                    row[`${vote.race_id}-${score.candidate_id}`] =
+                        score.score ?? (mode === 'official' ? 0 : '');
                 })
                 const race = election.races.find(r => r.race_id == vote.race_id);
                 if(race.voting_method == 'IRV' || race.voting_method == 'STV'){
@@ -56,6 +64,7 @@ export const BallotDataExport = ({ election, results }: Props) => {
             });
             return row;
         });
+        setCsvMode(mode);
         setCsvData(tempCsvData);
         setCsvHeaders(header);
         document.getElementById('csv-download-link')?.click();
@@ -83,9 +92,13 @@ export const BallotDataExport = ({ election, results }: Props) => {
                     {ballots && 
                         <Box sx={{m:1, maxWidth: '400px'}}>
                             <MenuButton label={"Download"} >
-                                <MenuItem key="csv"  id={"download-csv"} onClick={downloadCSV}>
+                                <MenuItem key="csv-official" id={"download-csv"} onClick={() => downloadCSV('official')}>
                                     <BorderAll sx={{ marginRight: 1 }} />
-                                    Download CSV
+                                    Download CSV (Official Count)
+                                </MenuItem>
+                                <MenuItem key="csv-raw" onClick={() => downloadCSV('raw')}>
+                                    <BorderAll sx={{ marginRight: 1 }} />
+                                    Download CSV (Raw / Audit)
                                 </MenuItem>
                                 <MenuItem key="json" onClick={downloadJson}>
                                     <DataObject sx={{ marginRight: 1 }} />
@@ -114,7 +127,7 @@ export const BallotDataExport = ({ election, results }: Props) => {
                     headers={csvHeaders}
                     
                     target="_blank"
-                    filename={`Ballot Data - ${limit(election.title, 50)}-${election.election_id}.csv`}
+                    filename={`Ballot Data - ${limit(election.title, 50)}-${election.election_id}-${csvMode}.csv`}
                     enclosingCharacter={``}
                     style={{ display: 'none' }}
                 />

--- a/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
+++ b/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
@@ -7,6 +7,7 @@ import BorderAll from '@mui/icons-material/BorderAll';
 import DataObject from '@mui/icons-material/DataObject';
 import { MenuButton } from '~/components/MenuButton';
 import useAnonymizedBallots from '~/components/AnonymizedBallotsContextProvider';
+import { buildElectionExport } from '@equal-vote/star-vote-shared/utils/exportFormat';
 import { Box } from '@mui/material';
 
 interface Props {
@@ -66,7 +67,7 @@ export const BallotDataExport = ({ election, results }: Props) => {
         return string.substring(0, limit);
     };
     const downloadJson = async () => {
-        const ballotObject = { Election: election, Ballots: ballots, ...(results && { Results: results }) };
+        const ballotObject = buildElectionExport(election, ballots, results);
         const ballotJson = JSON.stringify(ballotObject, null, 2);
         const blob = new Blob([ballotJson], { type: 'application/json' });
         const url = URL.createObjectURL(blob);

--- a/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
+++ b/packages/frontend/src/components/Election/Results/BallotDataExport.tsx
@@ -1,5 +1,3 @@
-import { CSVLink } from 'react-csv';
-import { useState } from 'react';
 import { Election } from '@equal-vote/star-vote-shared/domain_model/Election';
 import { ElectionResults } from '@equal-vote/star-vote-shared/domain_model/ITabulators';
 import MenuItem from "@mui/material/MenuItem";
@@ -16,23 +14,35 @@ interface Props {
 }
 
 export const BallotDataExport = ({ election, results }: Props) => {
-    const [csvData, setCsvData] = useState<Record<string, string | number | boolean>[]>([]);
-    const [csvHeaders, setCsvHeaders] = useState<({
-        label: string;
-        key: string;
-    }[] | {
-        label: string;
-        key: string;
-    })[]>([]);
     const { ballots, fetchBallots } = useAnonymizedBallots();
-    // 'raw'      => keep a blank (null / not scored) as an empty cell — preserves the audit
-    //               trail (an empty cell is distinct from an explicit 0). Ref issue #1160 Option B.
-    // 'official' => fill blanks with 0 so 3rd-party counting tools (Excel/Python) don't choke.
-    //               Ref issue #1160 Option A.
-    const [csvMode, setCsvMode] = useState<'raw' | 'official'>('raw');
-    const downloadCSV = async (mode: 'raw' | 'official' = 'raw') => {
-        if (!ballots) return
-        let header = [
+
+    const limit = (string = '', limit = 0) => {
+        if (!string) return '';
+        return string.substring(0, limit);
+    };
+
+    const triggerDownload = (contents: string, mime: string, filename: string) => {
+        const blob = new Blob([contents], { type: mime });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    // RFC-4180 field escaping (quote only when needed).
+    const csvField = (v: unknown) => {
+        const s = v === null || v === undefined ? '' : String(v);
+        return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+
+    // mode 'raw'      => keep a blank (null / not scored) as an empty cell, preserving the audit
+    //                   trail (an empty cell stays distinct from an explicit 0). #1160 Option B.
+    // mode 'official' => fill blanks with 0 so 3rd-party counting tools don't choke. #1160 Option A.
+    const downloadCSV = (mode: 'raw' | 'official') => {
+        if (!ballots) return;
+        const header = [
             { label: 'ballot_id', key: 'ballot_id' },
             { label: 'precinct', key: 'precinct' },
             ...election.races.map((race) => [
@@ -40,98 +50,82 @@ export const BallotDataExport = ({ election, results }: Props) => {
                     label: election.races.length == 1 ? c.candidate_name : `${race.title}!!${c.candidate_name}`,
                     key: `${race.race_id}-${c.candidate_id}`,
                 })),
-                ...((race.voting_method == 'IRV' || race.voting_method == 'STV')? [
-                    {label:'overvote_rank', key: 'overvote_rank'},
-                    {label:'has_duplicate_rank', key: 'has_duplicate_rank'},
-                ]: [])
+                ...((race.voting_method == 'IRV' || race.voting_method == 'STV') ? [
+                    { label: 'overvote_rank', key: 'overvote_rank' },
+                    { label: 'has_duplicate_rank', key: 'has_duplicate_rank' },
+                ] : []),
             ]),
-        ];
-        header = header.flat();
-        const tempCsvData = ballots.map((ballot) => {
-            const row = { ballot_id: ballot.ballot_id, precinct: ballot.precinct };
-            ballot.votes.forEach((vote) => {
-                vote.scores.forEach((score) => {
+        ].flat();
+
+        const rows = ballots.map((ballot: any) => {
+            const row: Record<string, string | number> = {
+                ballot_id: ballot.ballot_id,
+                precinct: ballot.precinct ?? '',
+            };
+            ballot.votes.forEach((vote: any) => {
+                vote.scores.forEach((score: any) => {
                     // null / undefined = the voter didn't score this candidate.
                     // Raw keeps it blank (distinct from an explicit 0); Official fills 0.
                     row[`${vote.race_id}-${score.candidate_id}`] =
                         score.score ?? (mode === 'official' ? 0 : '');
-                })
-                const race = election.races.find(r => r.race_id == vote.race_id);
-                if(race.voting_method == 'IRV' || race.voting_method == 'STV'){
+                });
+                const race = election.races.find((r) => r.race_id == vote.race_id);
+                if (race && (race.voting_method == 'IRV' || race.voting_method == 'STV')) {
                     row['overvote_rank'] = vote.overvote_rank ?? '';
                     row['has_duplicate_rank'] = vote.has_duplicate_rank ? 'TRUE' : 'FALSE';
                 }
             });
             return row;
         });
-        setCsvMode(mode);
-        setCsvData(tempCsvData);
-        setCsvHeaders(header);
-        document.getElementById('csv-download-link')?.click();
 
+        const lines = [
+            header.map((h) => csvField(h.label)).join(','),
+            ...rows.map((row) => header.map((h) => csvField(row[h.key])).join(',')),
+        ];
+        triggerDownload(
+            lines.join('\r\n'),
+            'text/csv;charset=utf-8;',
+            `Ballot Data - ${limit(election.title, 50)}-${election.election_id}-${mode}.csv`,
+        );
     };
 
-    const limit = (string = '', limit = 0) => {
-        if (!string) return '';
-        return string.substring(0, limit);
-    };
-    const downloadJson = async () => {
+    const downloadJson = () => {
         const ballotObject = buildElectionExport(election, ballots, results);
-        const ballotJson = JSON.stringify(ballotObject, null, 2);
-        const blob = new Blob([ballotJson], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `Ballot Data - ${limit(election.title, 50)}-${election.election_id}.json`;
-        a.click();
-    }
+        triggerDownload(
+            JSON.stringify(ballotObject, null, 2),
+            'application/json',
+            `Ballot Data - ${limit(election.title, 50)}-${election.election_id}.json`,
+        );
+    };
+
     return (
-            <>
-                <a onClick={fetchBallots}>
-                    {/*The MenuButton is redundant between the 2 but it's necessary to resolve the 'Menu Component doesn't accept fragment as child' warning*/}
-                    {ballots && 
-                        <Box sx={{m:1, maxWidth: '400px'}}>
-                            <MenuButton label={"Download"} >
-                                <MenuItem key="csv-official" id={"download-csv"} onClick={() => downloadCSV('official')}>
-                                    <BorderAll sx={{ marginRight: 1 }} />
-                                    Download CSV (Official Count)
-                                </MenuItem>
-                                <MenuItem key="csv-raw" onClick={() => downloadCSV('raw')}>
-                                    <BorderAll sx={{ marginRight: 1 }} />
-                                    Download CSV (Raw / Audit)
-                                </MenuItem>
-                                <MenuItem key="json" onClick={downloadJson}>
-                                    <DataObject sx={{ marginRight: 1 }} />
-                                    Download JSON
-                                </MenuItem>
-                            </MenuButton>
-                        </Box>
-                    }
-                    {!ballots && 
-                        <Box sx={{m:1, maxWidth: '400px'}}>
-                            <MenuButton label={"Download"} >
-                                <MenuItem disabled>Loading Ballots...</MenuItem>
-                            </MenuButton>
-                        </Box>
-                    }
-                </a>
-                
-                {csvData.length > 0 && (
-                    //For some reason, CSVDownload doesn't allow you to set the filename, so we use CSVLink instead,
-                    //but we hide it so it doesn't show up on the page.
-                    //I couldn't get it work clicking on CSVLink directly because the download was starting before the state was set.
-                    //This makes sure the download only starts when the state is set.
-                    <CSVLink
-                    id="csv-download-link"
-                    data={csvData}
-                    headers={csvHeaders}
-                    
-                    target="_blank"
-                    filename={`Ballot Data - ${limit(election.title, 50)}-${election.election_id}-${csvMode}.csv`}
-                    enclosingCharacter={``}
-                    style={{ display: 'none' }}
-                />
-                    )}
-            </>
+        <a onClick={fetchBallots}>
+            {/*The MenuButton is redundant between the 2 but it's necessary to resolve the 'Menu Component doesn't accept fragment as child' warning*/}
+            {ballots &&
+                <Box sx={{ m: 1, maxWidth: '400px' }}>
+                    <MenuButton label={"Download"} >
+                        <MenuItem key="csv-official" onClick={() => downloadCSV('official')}>
+                            <BorderAll sx={{ marginRight: 1 }} />
+                            Download CSV (Official Count)
+                        </MenuItem>
+                        <MenuItem key="csv-raw" onClick={() => downloadCSV('raw')}>
+                            <BorderAll sx={{ marginRight: 1 }} />
+                            Download CSV (Raw / Audit)
+                        </MenuItem>
+                        <MenuItem key="json" onClick={downloadJson}>
+                            <DataObject sx={{ marginRight: 1 }} />
+                            Download JSON
+                        </MenuItem>
+                    </MenuButton>
+                </Box>
+            }
+            {!ballots &&
+                <Box sx={{ m: 1, maxWidth: '400px' }}>
+                    <MenuButton label={"Download"} >
+                        <MenuItem disabled>Loading Ballots...</MenuItem>
+                    </MenuButton>
+                </Box>
+            }
+        </a>
     );
 };

--- a/packages/shared/src/utils/exportFormat.ts
+++ b/packages/shared/src/utils/exportFormat.ts
@@ -77,22 +77,29 @@ const cleanElection = (e: Election): any => {
 // ballot row — that re-bloats large elections (e.g. 51 candidates x 100 ballots).
 // Names are always resolvable from election.races[].candidates (and, when present,
 // results[].candidates), so no information is lost.
+//
+// IMPORTANT: a score of `null` is MEANINGFUL — it means the voter did not score
+// that candidate (an abstention on that candidate), which is distinct from an
+// explicit `0` and from scoring the "None of the Above" (c-nota) candidate. So
+// scores are preserved verbatim (including null); we do NOT run the null-omitting
+// pass over ballot rows. Only genuinely-absent optional metadata is dropped.
 const cleanBallots = (ballots: AnonymizedBallot[]): any[] =>
-    (ballots ?? []).map((b: any) =>
-        omitEmpty({
-            ballot_id: b.ballot_id,
-            precinct: b.precinct,
-            votes: (b.votes ?? []).map((v: any) => ({
-                race_id: v.race_id,
-                overvote_rank: v.overvote_rank,
-                has_duplicate_rank: v.has_duplicate_rank,
-                scores: (v.scores ?? []).map((s: any) => ({
-                    candidate_id: s.candidate_id,
-                    score: s.score,
-                })),
-            })),
-        }),
-    );
+    (ballots ?? []).map((b: any) => {
+        const out: any = { ballot_id: b.ballot_id };
+        if (b.precinct != null) out.precinct = b.precinct;
+        out.votes = (b.votes ?? []).map((v: any) => {
+            const vote: any = { race_id: v.race_id };
+            if (v.overvote_rank != null) vote.overvote_rank = v.overvote_rank;
+            if (v.has_duplicate_rank != null) vote.has_duplicate_rank = v.has_duplicate_rank;
+            // Preserve every score exactly, including explicit `null` (= not scored).
+            vote.scores = (v.scores ?? []).map((s: any) => ({
+                candidate_id: s.candidate_id,
+                score: s.score === undefined ? null : s.score,
+            }));
+            return vote;
+        });
+        return out;
+    });
 
 // Turn one race's tabulator result into the clean v2 shape.
 const cleanResult = (r: any): any => {

--- a/packages/shared/src/utils/exportFormat.ts
+++ b/packages/shared/src/utils/exportFormat.ts
@@ -1,0 +1,203 @@
+// exportFormat.ts
+//
+// Builds the downloadable "Ballot Data" JSON export (Election + Ballots + Results).
+//
+// The legacy export was `JSON.stringify({ Election, Ballots, Results })` of the raw
+// in-memory objects. That leaked the tabulator's internal shape into the export:
+//   - every candidate carried O(n^2) `votesPreferredOver` / `winsAgainst` maps keyed by
+//     UUID, including self-vs-self entries, duplicated across elected/tied/other/summary
+//   - Results used camelCase while Election/Ballots used snake_case
+//   - timestamps were inconsistent (ISO create_date vs epoch-ms-string update_date)
+//   - ballot scores referenced candidates by UUID only, forcing a join to read them
+//
+// This builds a versioned, self-describing v2 export: candidates listed once, a deduped
+// pairwise matrix (self-pairs removed, keyed by name), elected/tied/other as name lists,
+// snake_case keys throughout, ISO-8601 timestamps, null/empty fields omitted, and both
+// candidate_id and candidate_name wherever a candidate is referenced.
+
+import { Election } from '../domain_model/Election';
+import { AnonymizedBallot } from '../domain_model/Ballot';
+import { ElectionResults } from '../domain_model/ITabulators';
+
+export const EXPORT_FORMAT = 'bettervoting-export';
+export const EXPORT_FORMAT_VERSION = 2;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// camelCase -> snake_case for a single object key
+const toSnake = (k: string): string =>
+    k
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+        .toLowerCase();
+
+// Deep-convert object keys to snake_case; values are left untouched.
+const deepSnake = (v: any): any => {
+    if (Array.isArray(v)) return v.map(deepSnake);
+    if (v && typeof v === 'object') {
+        const out: any = {};
+        for (const [k, val] of Object.entries(v)) out[toSnake(k)] = deepSnake(val);
+        return out;
+    }
+    return v;
+};
+
+// Recursively drop null / undefined values (keeps the file terse).
+const omitEmpty = (v: any): any => {
+    if (Array.isArray(v)) return v.map(omitEmpty);
+    if (v && typeof v === 'object') {
+        const out: any = {};
+        for (const [k, val] of Object.entries(v)) {
+            if (val === null || val === undefined) continue;
+            out[k] = omitEmpty(val);
+        }
+        return out;
+    }
+    return v;
+};
+
+// Normalize a timestamp (ISO string, epoch-ms number, or epoch-ms string) to ISO-8601.
+const normalizeTimestamp = (v: any): string | undefined => {
+    if (v === null || v === undefined || v === '') return undefined;
+    const asNum =
+        typeof v === 'number' ? v : /^\d+$/.test(String(v)) ? Number(v) : NaN;
+    if (!Number.isNaN(asNum)) return new Date(asNum).toISOString();
+    const d = new Date(v);
+    return Number.isNaN(d.getTime()) ? String(v) : d.toISOString();
+};
+
+const cleanElection = (e: Election): any => {
+    const cleaned: any = omitEmpty({ ...e });
+    if (cleaned.create_date) cleaned.create_date = normalizeTimestamp(cleaned.create_date);
+    if (cleaned.update_date) cleaned.update_date = normalizeTimestamp(cleaned.update_date);
+    return cleaned;
+};
+
+// Ballots stay compact (id + score). Candidate names are NOT repeated on every
+// ballot row — that re-bloats large elections (e.g. 51 candidates x 100 ballots).
+// Names are always resolvable from election.races[].candidates (and, when present,
+// results[].candidates), so no information is lost.
+const cleanBallots = (ballots: AnonymizedBallot[]): any[] =>
+    (ballots ?? []).map((b: any) =>
+        omitEmpty({
+            ballot_id: b.ballot_id,
+            precinct: b.precinct,
+            votes: (b.votes ?? []).map((v: any) => ({
+                race_id: v.race_id,
+                overvote_rank: v.overvote_rank,
+                has_duplicate_rank: v.has_duplicate_rank,
+                scores: (v.scores ?? []).map((s: any) => ({
+                    candidate_id: s.candidate_id,
+                    score: s.score,
+                })),
+            })),
+        }),
+    );
+
+// Turn one race's tabulator result into the clean v2 shape.
+const cleanResult = (r: any): any => {
+    const summaryCandidates: any[] = r.summaryData?.candidates ?? [];
+
+    const idToName: Record<string, string> = {};
+    summaryCandidates.forEach((c) => {
+        idToName[c.id] = c.name;
+    });
+    const nm = (id: string) => idToName[id] ?? id;
+    const refs = (arr: any[] | undefined) =>
+        (arr ?? []).map((c: any) => ({ id: c.id, name: nm(c.id) }));
+
+    // Candidates listed once, without the O(n^2) pairwise maps.
+    const candidates = summaryCandidates.map((c) => {
+        const { votesPreferredOver, winsAgainst, ...rest } = c;
+        return deepSnake(rest);
+    });
+
+    // Deduped pairwise matrix: self-pairs removed, keyed by candidate name.
+    const pairwise: Record<string, Record<string, { prefer: number; wins: boolean }>> = {};
+    summaryCandidates.forEach((c) => {
+        const row: Record<string, { prefer: number; wins: boolean }> = {};
+        Object.keys(c.votesPreferredOver ?? {}).forEach((oid) => {
+            if (oid === c.id) return; // drop self-vs-self
+            row[nm(oid)] = {
+                prefer: c.votesPreferredOver[oid],
+                wins: !!c.winsAgainst?.[oid],
+            };
+        });
+        pairwise[nm(c.id)] = row;
+    });
+
+    const { candidates: _drop, ...summaryRest } = r.summaryData ?? {};
+    const summary = deepSnake(summaryRest);
+
+    const rounds = (r.roundResults ?? []).map((rr: any) => {
+        const out: any = {
+            winners: refs(rr.winners),
+            runner_up: refs(rr.runner_up),
+            tied: refs(rr.tied),
+            tie_break_type: rr.tieBreakType,
+            logs: rr.logs,
+        };
+        if (rr.eliminated) out.eliminated = refs(rr.eliminated);
+        if (rr.exhaustedVoteCount !== undefined) out.exhausted_vote_count = rr.exhaustedVoteCount;
+        return omitEmpty(out);
+    });
+
+    // Pull off the fields handled explicitly; deepSnake whatever method-specific
+    // top-level fields remain (e.g. IRV exhaustedVoteCounts / nExhaustedViaOvervote,
+    // STAR_PR logs).
+    const {
+        summaryData,
+        roundResults,
+        elected,
+        tied,
+        other,
+        perm,
+        votingMethod,
+        tieBreakType,
+        writeInDiagnostics,
+        ...extra
+    } = r;
+
+    return omitEmpty({
+        voting_method: votingMethod,
+        elected: refs(elected),
+        tied: refs(tied),
+        other: refs(other),
+        tie_break_type: tieBreakType,
+        candidates,
+        pairwise,
+        rounds,
+        summary,
+        perm: perm ? perm.map((id: string) => ({ id, name: nm(id) })) : undefined,
+        write_in_diagnostics: writeInDiagnostics ? deepSnake(writeInDiagnostics) : undefined,
+        ...deepSnake(extra),
+    });
+};
+
+export interface ElectionExport {
+    format: string;
+    format_version: number;
+    exported_at: string;
+    election: any;
+    ballots: any[];
+    results?: any[];
+}
+
+/**
+ * Build the clean, versioned election export object.
+ * @param election  the election config
+ * @param ballots   anonymized ballots (may be undefined while loading)
+ * @param results   per-race tabulation results (optional)
+ */
+export const buildElectionExport = (
+    election: Election,
+    ballots: AnonymizedBallot[] | undefined,
+    results?: ElectionResults[],
+): ElectionExport => ({
+    format: EXPORT_FORMAT,
+    format_version: EXPORT_FORMAT_VERSION,
+    exported_at: new Date().toISOString(),
+    election: cleanElection(election),
+    ballots: cleanBallots(ballots ?? []),
+    ...(results ? { results: results.map(cleanResult) } : {}),
+});


### PR DESCRIPTION
## Description

Cleans up the results **ballot-data export** (`BallotDataExport.tsx`) — both the JSON and CSV downloads, which previously leaked the tabulator's internal object shape and couldn't distinguish a blank from an explicit `0`.

### JSON — versioned v2 format

The old JSON download was `JSON.stringify({ Election, Ballots, Results })` of the raw in-memory objects, which leaked:
- every candidate's O(n²) `votesPreferredOver` / `winsAgainst` maps (keyed by UUID, incl. self-vs-self), duplicated across `elected`/`tied`/`other`/`summaryData`
- `Results` in camelCase while `Election`/`Ballots` were snake_case
- inconsistent timestamps (ISO `create_date` vs epoch-ms-string `update_date`)

New `packages/shared/src/utils/exportFormat.ts` (`buildElectionExport`) produces a versioned v2 export: candidates listed once, a deduped `pairwise` matrix (self-pairs removed, keyed by name), `{id,name}` refs, snake_case throughout, ISO-8601 timestamps, `format_version: 2`. **Ballot scores are preserved verbatim, including `score: null`** — a blank (didn't score) stays distinct from an explicit `0` and from a NOTA vote. Measured 69–74% of legacy size on real exports.

### CSV — Raw vs Official Count

The single CSV mode wrote a blank as an empty cell, ambiguous vs an explicit `0`. Split into two menu items:
- **Download CSV (Official Count)** — fills blanks with `0` so Excel/Python counting tools don't choke.
- **Download CSV (Raw / Audit)** — keeps blanks empty (`5,,4`), preserving the audit trail.

Transform-only — no change to the tabulation engine, the results endpoint, or what the UI renders. The export is write-only (nothing re-imports it). Unit-tested in `packages/backend/src/test/exportFormat.test.ts` (incl. a regression test that `null` ≠ `0` ≠ dropped).

## Screenshots / Videos (frontend only)

No visible page change; the outputs are the downloaded files. Download menu now offers: **CSV (Official Count)**, **CSV (Raw / Audit)**, **JSON**.

## Related Issues

- Addresses the export-shape cleanup in #1420.
- Implements the dual Raw-vs-Official export from #1160 (both JSON-null-preservation and the CSV split) — proposing `closes #1160`.
- Fixes the export-ambiguity half of #1090 and #791 (blank vs explicit `0` now distinguishable).
