### PR TITLE
Fix flaky Firefox e2e: make /new_election scroll to wizard reliable

### DIFF
--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -20,9 +20,9 @@ export const createWizardNav = (heading: string, isLandingPage: boolean) => {
     return isLandingPage ?
         {
             text: heading,
-            // no delay: the wizard is already rendered, and starting the scroll
-            // immediately avoids it kicking in mid-interaction with the wizard
-            onClick: () => scrollToElement(document.querySelector(`.wizard`), { delay: 0 }),
+            // cancelOnUserInput so the delayed scroll can't kick in mid-interaction
+            // if something else gets clicked before it starts
+            onClick: () => scrollToElement(document.querySelector(`.wizard`), { cancelOnUserInput: true }),
         } : {
             text: heading,
             href: '/new_election',
@@ -201,7 +201,7 @@ const Header = () => {
                                 {t('nav.your_account')}
                             </MenuItem>
                             {isLandingPage && 
-                            <MenuItem component={Link} onClick={() => scrollToElement(document.querySelector(`.wizard`), { delay: 0 })}>
+                            <MenuItem component={Link} onClick={() => scrollToElement(document.querySelector(`.wizard`), { cancelOnUserInput: true })}>
                                 {t('nav.new_election')}
                             </MenuItem>
                             }

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -20,7 +20,9 @@ export const createWizardNav = (heading: string, isLandingPage: boolean) => {
     return isLandingPage ?
         {
             text: heading,
-            onClick: () => scrollToElement(document.querySelector(`.wizard`)),
+            // no delay: the wizard is already rendered, and starting the scroll
+            // immediately avoids it kicking in mid-interaction with the wizard
+            onClick: () => scrollToElement(document.querySelector(`.wizard`), { delay: 0 }),
         } : {
             text: heading,
             href: '/new_election',
@@ -199,7 +201,7 @@ const Header = () => {
                                 {t('nav.your_account')}
                             </MenuItem>
                             {isLandingPage && 
-                            <MenuItem component={Link} onClick={() => scrollToElement(document.querySelector(`.wizard`))}>
+                            <MenuItem component={Link} onClick={() => scrollToElement(document.querySelector(`.wizard`), { delay: 0 })}>
                                 {t('nav.new_election')}
                             </MenuItem>
                             }

--- a/packages/frontend/src/components/LandingPage.tsx
+++ b/packages/frontend/src/components/LandingPage.tsx
@@ -24,10 +24,30 @@ const LandingPage = () => {
             openFeedback();
         }
 
-        if(checkUrl.pathname === "/new_election")
-        {
-            scrollToElement(document.querySelector(`.wizard`))
-        }
+        if(checkUrl.pathname !== "/new_election") return;
+
+        // Jump straight to the wizard, then keep re-aligning while the content
+        // above it (carousel, images) loads and pushes it down. A one-shot
+        // delayed smooth scroll can land short of the wizard (especially on
+        // Firefox) when the page reflows after the scroll starts.
+        const align = () => scrollToElement(document.querySelector(`.wizard`), { behavior: 'auto', delay: 0 });
+        align();
+
+        const observer = new ResizeObserver(align);
+        observer.observe(document.body);
+        const stop = () => observer.disconnect();
+
+        // stop re-aligning once layout has settled, or as soon as the user
+        // scrolls on their own
+        const settleTimeout = setTimeout(stop, 2000);
+        const userEvents: (keyof WindowEventMap)[] = ['wheel', 'pointerdown', 'keydown'];
+        userEvents.forEach((e) => window.addEventListener(e, stop, { passive: true }));
+
+        return () => {
+            clearTimeout(settleTimeout);
+            stop();
+            userEvents.forEach((e) => window.removeEventListener(e, stop));
+        };
     }, [checkUrl]);
 
     

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -321,9 +321,21 @@ export const openFeedback = () => {
   (button as HTMLButtonElement).click();
 };
 
-export function scrollToElement(e, opts: { behavior?: ScrollBehavior; delay?: number } = {}) {
-  const { behavior = "smooth", delay = 250 } = opts;
-  setTimeout(() => {
+export function scrollToElement(e, opts: { behavior?: ScrollBehavior; delay?: number; cancelOnUserInput?: boolean } = {}) {
+  const { behavior = "smooth", delay = 250, cancelOnUserInput = false } = opts;
+
+  // cancelOnUserInput drops a still-pending scroll if the user interacts
+  // during the delay, so a delayed scroll never yanks the page out from
+  // under a click that happened after the triggering one
+  const userEvents: (keyof WindowEventMap)[] = ["wheel", "pointerdown", "keydown"];
+  const removeListeners = () => userEvents.forEach((ev) => window.removeEventListener(ev, cancel));
+  function cancel() {
+    clearTimeout(timer);
+    removeListeners();
+  }
+
+  const timer = setTimeout(() => {
+    removeListeners();
     // TODO: I feel like there's got to be an easier way to do this
     let openedSection = typeof e === "function" ? e() : e;
 
@@ -355,6 +367,8 @@ export function scrollToElement(e, opts: { behavior?: ScrollBehavior; delay?: nu
       });
     }
   }, delay);
+
+  if (cancelOnUserInput) userEvents.forEach((ev) => window.addEventListener(ev, cancel, { passive: true }));
 }
 
 export const epochToDateString = (e) => {

--- a/packages/frontend/src/components/util.tsx
+++ b/packages/frontend/src/components/util.tsx
@@ -321,7 +321,8 @@ export const openFeedback = () => {
   (button as HTMLButtonElement).click();
 };
 
-export function scrollToElement(e) {
+export function scrollToElement(e, opts: { behavior?: ScrollBehavior; delay?: number } = {}) {
+  const { behavior = "smooth", delay = 250 } = opts;
   setTimeout(() => {
     // TODO: I feel like there's got to be an easier way to do this
     let openedSection = typeof e === "function" ? e() : e;
@@ -350,10 +351,10 @@ export function scrollToElement(e) {
     if (elemTop < windowTop || elemBottom > windowBottom) {
       window.scrollTo({
         top: elemTop - navHeight,
-        behavior: "smooth",
+        behavior,
       });
     }
-  }, 250);
+  }, delay);
 }
 
 export const epochToDateString = (e) => {

--- a/testing/tests/create-election.spec.ts
+++ b/testing/tests/create-election.spec.ts
@@ -49,7 +49,7 @@ test.describe('Create Election', () => {
         await page.getByRole('link', { name: 'About Us' }).click();
         await page.getByRole('link', { name: 'Create Election' }).click();
         const electionButton = page.getByRole('radio', { name: 'Election' })
-        await expect(electionButton).toBeInViewport({timeout: 2000}); // larger timeout since this will require navigating to a different page
+        await expect(electionButton).toBeInViewport({timeout: 10000}); // larger timeout since this requires a full page load, which can take a couple seconds on Firefox in dev mode
         await electionButton.check();
 
         // Fill out form


### PR DESCRIPTION
Fixes #1393

## Problem

On Firefox, `create-election.spec.ts` intermittently failed after the Create Election nav was changed from the native `/#wizard` anchor to the `/new_election` route, where the scroll to the wizard is done in JS. Two distinct races (both rooted in `scrollToElement`'s fixed 250ms delay + smooth scroll):

1. **`/new_election` full page load** (test :45): the one-shot delayed smooth scroll could land short of the wizard when async landing-page content (carousel, images) reflowed the page, and in Firefox dev mode the page takes ~1.5s+ to render at all, leaving no headroom in the test's 2s `toBeInViewport` budget.
2. **Landing-page nav click** (test :118): the click handler scheduled the scroll 250ms later, so Playwright would validate the `Poll` radio as stable and click exactly as the scroll kicked in — the click missed (`Clicking the checkbox did not change its state`).

## Fix

This combines options 1 and 2 from the issue:

- **`LandingPage.tsx`**: on `/new_election`, position at the wizard instantly (like the old native `/#wizard` anchor did) and keep re-aligning via a `ResizeObserver` on `document.body` while content above the wizard loads and reflows. Re-aligning stops once layout settles (2s) or as soon as the user scrolls/interacts, so we never fight the user. This also fixes the minor UX regression where the nav could land short of the wizard on Firefox.
- **`Header.tsx` / `util.tsx`**: the in-page wizard-nav click keeps its original feel (250ms pause, then smooth scroll). The race is closed instead with a new `cancelOnUserInput` option on `scrollToElement`: if the user (or the test) interacts during the delay, the still-pending scroll is dropped, so it can never yank the page out from under a later click. `scrollToElement`'s defaults are unchanged for all other callers.
- **`create-election.spec.ts`**: raise the `toBeInViewport` timeout from 2s to 10s for the test that does a full page load of `/new_election` (matching the 10s timeouts already used elsewhere in the spec).

## Testing

Against the local dev stack:

- `npx playwright test tests/create-election.spec.ts --project=firefox --repeat-each=3` — 15/15 pass (previously test :45 failed most runs and :118 failed ~half)
- Tests :6 and :118 repeated 5x each on Firefox — the wizard-scroll flakes are gone
- Full spec on Chromium + Firefox and the full suite — all pass
- Instrumented Firefox runs confirm the page scrolls to the wizard as soon as it renders and stays there (no snap-back)
- `npm run build -w @equal-vote/star-vote-frontend` passes; eslint reports no new issues on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJ6tU9igwGYGrFGumeCA7d
