### PR TITLE
Fix stale Settings toggles after navigating away (preliminary results, election open)

### DIFF
--- a/packages/frontend/src/components/Election/Admin/ElectionSettings.tsx
+++ b/packages/frontend/src/components/Election/Admin/ElectionSettings.tsx
@@ -42,7 +42,7 @@ function ElectionSwitchSetting({ settingKey, disabled, disabledMessage, onToggle
 }
 
 export default function ElectionSettings() {
-    const { election, updateElection, enqueueWrite } = useElection()
+    const { election, updateElection, enqueueWrite, refreshElection } = useElection()
     const min_rankings = 3;
     const max_rankings = Number(process.env.REACT_APP_MAX_BALLOT_RANKS) ? Number(process.env.REACT_APP_MAX_BALLOT_RANKS) : 8;
     const default_rankings = Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) ? Number(process.env.REACT_APP_DEFAULT_BALLOT_RANKS) : 6;
@@ -57,6 +57,11 @@ export default function ElectionSettings() {
             const res = await enqueueWrite(expected_update_date =>
                 makePublicResultsRequest({ public_results: v, expected_update_date })
             );
+            // updateElection updates the context as a side effect of building its
+            // request body, but this write doesn't go through it, so the context
+            // would keep the pre-write value until the next GET — leaving this page
+            // and coming back would re-mount the switch showing the old setting.
+            if (res) await refreshElection();
             return !!res && res.election?.settings?.public_results === v;
         }
     );

--- a/packages/frontend/src/components/Election/Admin/PublishAndShare.tsx
+++ b/packages/frontend/src/components/Election/Admin/PublishAndShare.tsx
@@ -100,9 +100,14 @@ export default () => {
         </Grid>}
     </Box>
 
-    const [isOpen, setIsOpen] = useOptimisticToggle(election.state === 'open', async (toggled) =>
-        !! await enqueueWrite(expected_update_date => setOpenState({ open: toggled, expected_update_date }))
-    );
+    const [isOpen, setIsOpen] = useOptimisticToggle(election.state === 'open', async (toggled) => {
+        const res = await enqueueWrite(expected_update_date => setOpenState({ open: toggled, expected_update_date }));
+        // Same as setPublicResults in ElectionSettings: this write bypasses
+        // updateElection, so nothing folds the new state into the context.
+        // Stale election.state also mislabels the sidebar (Preview vs Live Ballot).
+        if (res) await fetchElection();
+        return !!res;
+    });
     
     const hasScheduledTimes = !!(election.start_time || election.end_time);
     const canEditState = permissions?.includes('canEditElectionState') ?? false;


### PR DESCRIPTION
## The bug

Toggle **Show Preliminary Results** on the Settings page, navigate to another admin page (Build Ballot, Manage Voters), then come back. The switch has reverted to its old value — even though the backend was updated. Reloading the page shows the correct value.

`setOpenState` (the "Election is open" switch on Publish & Share) has the identical bug. Its stale `election.state` additionally mislabels the sidebar, which renders "Preview Ballot"/"Preview Results" instead of "Live Ballot"/"Live Results" (`Sidebar.tsx:28-29`).

## Why

`applyElectionUpdate` is the only thing that folds a change into the election context, and it does so as a *side effect of building its request body*:

```ts
updateFunc(data.election as IElection)                              // ElectionContextProvider.tsx:112
const result = await editElection({ Election: data.election, ... }) // :113
```

Line 112 mutates the same object the context hands to every consumer, and line 113 posts that object. So by the time the request leaves, the context already shows the new value. The response is discarded — `enqueueWrite` reads only `update_date` off it (`:88`) — and that's fine, because the callback already did the local update.

`setPublicResults` and `setOpenState` deliberately bypass `applyElectionUpdate`, because they're among the few settings that can change after the election leaves draft, and the generic edit endpoint rejects non-draft elections (`editElectionController.ts:24-26`). They call their dedicated endpoints straight through `enqueueWrite`, which never touches `data.election`. Same discarded response — but now with no side channel that already applied it.

The optimistic toggle keeps the switch looking right on the page where you made the change, so the staleness only surfaces on re-mount. It isn't a race: `ElectionInFlightGate` makes the whole admin layout `inert` while a write is outstanding, and the sidebar sits inside it, so by the time you *can* navigate the response has already come back. We simply never stored it.

## The fix

Refresh the election after these two writes. That's what `finalize` (`PublishAndShare.tsx:47`), `archive` (`AdminHome.tsx:71`), and the roles editor (`EditRoles.tsx:43`) already do — this brings the last two write paths in line with the existing convention. 14 lines, two files, no shared machinery touched.

## Testing

- Frontend `tsc --noEmit` clean.
- `eslint` on both touched files: 22 pre-existing errors before and after, none added. (Repo lint baseline is ~6000 errors.)
- Manual: toggle each switch, navigate away and back, confirm the value sticks; confirm the sidebar label flips with `setOpenState`.

No E2E coverage exists for either toggle today — worth adding alongside the follow-up below.

---

## Follow-up: paying off the underlying debt

This PR fixes the symptom the same way the codebase already fixes it elsewhere. It does not fix the reason the hole was easy to miss, which is worth a separate, deliberate change.

**The root issue is that nothing owns "the current election."** Four different mechanisms write to `data.election`, and which one applies is a per-callsite convention rather than anything the design enforces:

| write | how the context gets updated |
|---|---|
| `updateElection` (all draft settings) | mutation side effect of building the payload |
| `finalize` / `archive` / roles | ad-hoc `refreshElection()` at the callsite |
| `setPublicResults` / `setOpenState` | *(nothing — this PR adds `refreshElection()`)* |
| `enqueueWrite` | stamps `update_date` only |

Consequences worth naming:

1. **The sync channel already exists and is half-used.** Every admin write returns the canonical election, because the `expected_update_date` optimistic-concurrency scheme requires the client to advance its version on every write. `enqueueWrite` reaches into that response and takes one field. The right fix is not "add state management" — it's "the write response *is* the sync channel; apply all of it."
2. **React isn't the owner.** Because the context election is mutated in place, nothing tells React it changed. Consumers re-render only because `setInFlight(false)` happens to re-render the provider on the way out of `enqueueWrite`. Correctness of display is coupled to a loading indicator. Wrapping the context value in `useMemo` — an ordinary-looking optimization — would silently break every write.
3. **One boolean lives in four places:** the server, `data.election.settings`, `useOptimisticToggle`'s `localValue`, and its `committedValue` ref. Copies 3 and 4 are seeded from copy 2 on mount, which is exactly why this bug was invisible until a re-mount.

**Why this is unusually cheap to pay off:** `enqueueWrite` is already a mandatory chokepoint — the `inFlightRef` throw guarantees no admin write bypasses it. There is exactly one function that would need to apply the response. The invariant is one line of English: *every admin write returns the canonical election, and `enqueueWrite` applies it; nothing else writes to the context.*

Sketch:

- Expose `setData` from `useFetch`; have `enqueueWrite` sync the returned election into it.
- `applyElectionUpdate` clones before mutating, so it builds a payload instead of editing shared state. A failed write then leaves the context untouched, which makes the repair `fetchData()` at `:115` unnecessary.
- Keep the latest election in a ref for the read-modify-write path, so a stale closure can't post a pre-write snapshot. This is the one real hazard of moving off aliasing, and it's why the current mutation is load-bearing rather than merely sloppy.

Checks already done against that plan:

- No `useEffect` anywhere depends on the `election` object's identity — the two effects that resync local state key on `election.election_id` (`useEditElectionDetails.tsx:42`, `ElectionDetailsInlineForm.tsx:29`). Identity churn is safe.
- No component mutates the context election outside an `updateElection` callback.
- The `localElection` branch of `applyElectionUpdate` (`:104-106`) **already** does clone-and-replace, and every Wizard callsite runs on it today. The change makes both halves of the function behave the same instead of one aliasing and one replacing.
- Callsite impact: zero. Every remote-path caller either awaits and then calls `refreshElection()`, or fires-and-forgets and re-reads from context on the next render.

The one behavioral difference to watch: a handler that closes over `election` and reads `election.*` *after* an await currently sees the mutated object, but would see a pre-write snapshot. Exactly one place does this — `PublishAndShare.tsx:52-58`, reading `voter_access`/`invitation`/`start_time`/`end_time` after `finalize` — and it's harmless only because `finalize` touches none of those fields. Worth tightening regardless.

**Adjacent, still open after that refactor:**

- `precinctFilteredElection` is never updated by any write path — the same hole one level down. It's why race edits call `refreshElection()`.
- `ElectionInFlightGate` doesn't cover the `Header` (rendered outside `<Routes>` at `App.tsx:42`) or browser history navigation; `beforeunload` catches only tab close/reload, and there's no `useBlocker`. Escaping mid-write leaves the write to land server-side with its optimistic revert silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bLN8HSw2JbtwNH4GmtZQK
