### PR TITLE
Fix links inside info tips being unclickable on touch devices

### DIFF
--- a/packages/frontend/src/components/styles.tsx
+++ b/packages/frontend/src/components/styles.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, ClickAwayListener, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Link, Paper, TextFieldProps, Tooltip, Typography } from "@mui/material"
 import { TextField } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import React, { ReactNode, useState, isValidElement } from "react";
+import React, { ReactNode, useRef, useState, isValidElement } from "react";
 import en from './en.yaml';
 import { useSubstitutedTranslation } from "./util";
 import useRace from "./RaceContextProvider";
@@ -24,14 +24,23 @@ export const Tip = (props: {name?: TipName, children?: ReactNode, content?: {tit
 
     const [clicked, setClicked] = useState(false);
     const [hovered, setHovered] = useState(false);
+    // The tooltip body renders in a portal, so ClickAwayListener counts taps inside it as "away".
+    // On touch that fires at touchend, before the browser synthesizes the click, and closing the
+    // tooltip flips the popper to pointer-events:none, so links in the tip never get clicked.
+    // Mice are unaffected: ClickAwayListener listens for 'click' there, which the link already got.
+    // Keeping the tip open for taps landing inside its body lets those links work on mobile.
+    const tipBody = useRef<HTMLSpanElement | null>(null);
     const learnLinkKey = props.name ? `tips.${props.name as string}.learn_link` : 'asdfasdf';
-    return <ClickAwayListener onClickAway={() => setClicked(false)}>
-        <Tooltip title={<>
+    return <ClickAwayListener onClickAway={(e) => {
+            if (tipBody.current?.contains(e.target as Node)) return;
+            setClicked(false);
+        }}>
+        <Tooltip title={<span ref={tipBody}>
                 <strong>{props.name ? t(`tips.${props.name as string}.title`, props.values ?? {}) : props.content.title}</strong>
                 <br/>
                 {props.name ? t(`tips.${props.name as string}.description`, props.values ?? {}) : props.content.description}
                 {i18n.exists(learnLinkKey) && <a href={t(learnLinkKey)} target='_blank' rel="noreferrer">Learn More</a>}
-            </>} onOpen={() => setHovered(true)} onClose={() => setHovered(false)} open={clicked || hovered} placement='top' slotProps={{
+            </span>} onOpen={() => setHovered(true)} onClose={() => setHovered(false)} open={clicked || hovered} placement='top' slotProps={{
                 tooltip: {
                     sx: {
                         background: '#2B344AFF', 


### PR DESCRIPTION
## Problem

The `[Read more about ties](https://docs.bettervoting.com/help/ties.html#random-tie-breakers)` link that appears when a race is decided by a random tiebreaker does nothing on mobile, but works fine on desktop.

The link lives inside a MUI `Tooltip` (the `!tip(random_tie_order)` info bubble on `results.random_tiebreak_subtitle`), rendered by the `Tip` component in `packages/frontend/src/components/styles.tsx`.

## Cause

`Tip` wraps the tooltip in a `ClickAwayListener` whose ref lands on the `IconButton`, while the tooltip body renders in a **portal**. A tap on the link therefore counts as "away." Two MUI defaults then combine:

1. `ClickAwayListener`'s touch default is `touchEvent: 'onTouchEnd'`, so it fires on `touchend` — *before* the browser synthesizes the `click`.
2. The tooltip popper is `pointerEvents: 'none'`, upgraded to `'auto'` only while `open`.

So on touch: `touchend` → `setClicked(false)` → popper is still visible (exit transition) but now `pointer-events: none` → the follow-up `click` hit-tests straight through the anchor.

Desktop is unaffected for two independent reasons: the mouse default is `mouseEvent: 'onClick'`, which runs after the anchor already received that same click; and hovering into the popper keeps the tip open anyway (MUI's interactive keep-open handlers are mouse/focus-only, with no touch equivalent).

## Fix

Ignore click-aways whose target is inside the tip body. Keeping `clicked` true keeps the popper at `pointer-events: auto`, so the click reaches the anchor. Desktop behavior is unchanged.

## Verification

Driven against the real component with Playwright (frontend dev server, tip icon on `/new_election`, temporarily given a link for the test), tapping the icon and then the link:

| | before | after |
|---|---|---|
| mobile (touch emulation) | click never reaches anchor | reaches anchor |
| desktop (mouse) | reaches anchor | reaches anchor |

`tsc --noEmit` is clean; `eslint` reports the same 19 pre-existing `react/prop-types` errors in this file before and after.

## Also affected

The same portal path breaks the "Learn More" anchor rendered from a tip's `learn_link`, which under `tips:` is `proportional_multi_winner`. (The other `learn_link` entries in `en.yaml` are under `methods:`, not `tips:`, so they don't go through this component.)

## Open question

With this fix the tip stays open after tapping the link, and the ties link resolves to `target='_self'` (no `newWindow` in the values passed at `Results.tsx:492`) — so on mobile it navigates away from the results page in the same tab. Opening tip links in a new tab may be friendlier, but that's a behavior change I left out of this PR. Happy to add it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)