### PR TITLE
Let admins clear the voter roll of a draft election

### DIFF
--- a/packages/backend/src/Controllers/Roll/clearElectionRollController.ts
+++ b/packages/backend/src/Controllers/Roll/clearElectionRollController.ts
@@ -1,0 +1,40 @@
+import ServiceLocator from "../../ServiceLocator";
+import Logger from "../../Services/Logging/Logger";
+import { permissions } from '@equal-vote/star-vote-shared/domain_model/permissions';
+import { expectPermission } from "../controllerUtils";
+import { BadRequest } from "@curveball/http-errors";
+import { IElectionRequest } from "../../IRequest";
+import { Response, NextFunction } from 'express';
+
+const ElectionRollModel = ServiceLocator.electionRollDb();
+
+const className = "VoterRolls.Controllers";
+
+// Draft-only escape hatch for admins who picked the wrong voter auth mode: once a roll exists
+// the auth/access radios lock, and there was no in-app way to undo that short of recreating the
+// election. Clearing archives the rows (head=false) rather than deleting them, so the audit
+// trail survives and the radios re-enable because the roll now reads as empty.
+const clearElectionRoll = async (req: IElectionRequest, res: Response, next: NextFunction) => {
+    expectPermission(req.user_auth.roles, permissions.canAddToElectionRoll)
+    Logger.info(req, `${className}.clearElectionRoll ${req.election.election_id}`);
+
+    if (req.election.state !== 'draft') {
+        Logger.info(req, `Refusing to clear roll, election state=${req.election.state}`);
+        throw new BadRequest("The voter list can only be cleared while the election is in draft")
+    }
+
+    const cleared = await ElectionRollModel.archiveRollsByElectionID(
+        req.election.election_id,
+        req,
+        `${req.user.email} cleared the voter list of draft election ${req.election.election_id}`
+    );
+
+    Logger.info(req, `${className}.clearElectionRoll archived ${cleared} voters from ${req.election.election_id}`);
+
+    res.status(200).json({ election: req.election, cleared });
+    return next()
+}
+
+export {
+    clearElectionRoll,
+}

--- a/packages/backend/src/Controllers/Roll/index.ts
+++ b/packages/backend/src/Controllers/Roll/index.ts
@@ -1,5 +1,6 @@
 export * from './addElectionRollController';
 export * from './changeElectionRollController';
+export * from './clearElectionRollController';
 export * from './editElectionRollController';
 export * from './getElectionRollController';
 export * from './registerVoterController';

--- a/packages/backend/src/Models/ElectionRolls.ts
+++ b/packages/backend/src/Models/ElectionRolls.ts
@@ -197,6 +197,25 @@ export default class ElectionRollDB implements IElectionRollStore {
         }
     }
 
+    // Clears the roll without destroying it: every head row for the election is demoted to
+    // head=false, so getRollsByElectionID / getByVoterID stop seeing them but the rows (and
+    // their history) survive for auditing. The partial unique index is on (election_id,
+    // voter_id) WHERE head, so the same voter_id can be re-added afterwards.
+    async archiveRollsByElectionID(election_id: string, ctx: ILoggingContext, reason: string, db?: Kysely<Database> | Transaction<Database>): Promise<number> {
+        Logger.debug(ctx, `${tableName}.archiveRollsByElectionID ${election_id}: ${reason}`);
+
+        const client = db || this._postgresClient;
+        const archived = await client
+            .updateTable(tableName)
+            .where('election_id', '=', election_id)
+            .where('head', '=', true)
+            .set('head', false)
+            .returning('voter_id')
+            .execute()
+
+        return archived.length
+    }
+
     delete(election_roll: ElectionRoll, ctx: ILoggingContext, reason: string): Promise<boolean> {
         Logger.debug(ctx, `${tableName}.delete`);
         var sqlString = `DELETE FROM ${this._tableName} WHERE election_id = $1 AND voter_id=$2`;

--- a/packages/backend/src/Models/IElectionRollStore.ts
+++ b/packages/backend/src/Models/IElectionRollStore.ts
@@ -41,4 +41,10 @@ export interface IElectionRollStore {
         reason: string,
         db?: Kysely<Database> | Transaction<Database>
     ) => Promise<boolean>;
+    archiveRollsByElectionID: (
+        election_id: string,
+        ctx: ILoggingContext,
+        reason: string,
+        db?: Kysely<Database> | Transaction<Database>
+    ) => Promise<number>;
 }

--- a/packages/backend/src/Models/__mocks__/ElectionRolls.ts
+++ b/packages/backend/src/Models/__mocks__/ElectionRolls.ts
@@ -17,7 +17,9 @@ export default class ElectionRollDB implements IElectionRollStore{
         const inserted: ElectionRoll[] = [];
         electionRolls.forEach(function(roll){
             Logger.debug(ctx, `Mock Election Roll Store:  submit:  ${JSON.stringify(roll)}`);
-            var existing = self._electionRolls.find(x => x.election_id==roll.election_id && x.voter_id==roll.voter_id)
+            // Mirrors the partial unique index: only head rows conflict, so a voter_id
+            // whose rows have all been archived can be re-added.
+            var existing = self._electionRolls.find(x => x.election_id==roll.election_id && x.voter_id==roll.voter_id && x.head)
             if (existing){
                 Logger.error(ctx, `Already have conflicting voter roll entry!  ${JSON.stringify(existing)}`);
             }
@@ -34,7 +36,7 @@ export default class ElectionRollDB implements IElectionRollStore{
     }
 
     getRollsByElectionID(election_id: string, ctx:ILoggingContext): Promise<ElectionRoll[] | null> {
-        const electionRolls = this._electionRolls.filter(roll => roll.election_id===election_id)
+        const electionRolls = this._electionRolls.filter(roll => roll.election_id===election_id && roll.head)
         if (!electionRolls){
             return Promise.resolve(null)
         }
@@ -44,7 +46,7 @@ export default class ElectionRollDB implements IElectionRollStore{
 
     getByVoterID(election_id: string,voter_id:string, ctx:ILoggingContext): Promise<ElectionRoll | null> {
         Logger.debug(ctx, `MockElectionRolls getByVoterID ${election_id}, voter:${voter_id}`);
-        const roll = this._electionRolls.find(electionRolls => electionRolls.election_id==election_id && electionRolls.voter_id==voter_id)
+        const roll = this._electionRolls.find(electionRolls => electionRolls.election_id==election_id && electionRolls.voter_id==voter_id && electionRolls.head)
 
         if (!roll){
             Logger.debug(ctx, "Mock ElectionRoll DB could not match election and voter. Current data:\n"+JSON.stringify(this._electionRolls));
@@ -59,6 +61,7 @@ export default class ElectionRollDB implements IElectionRollStore{
         Logger.debug(ctx, `MockElectionRolls get election:${election_id}, voter_id:${voter_id}, email: ${email}, ip_hash: ${ip_hash}`);
         let roll = this._electionRolls.filter(electionRolls => {
             if (electionRolls.election_id!==election_id) return false
+            if (!electionRolls.head) return false
             if (ip_hash && electionRolls.ip_hash===ip_hash) return true
             if (voter_id && electionRolls.voter_id ===voter_id) return true
             if (email && electionRolls.email === email) return true
@@ -79,7 +82,7 @@ export default class ElectionRollDB implements IElectionRollStore{
         const index = this._electionRolls.findIndex(electionRoll => {
             var electionMatch = electionRoll.election_id===voter_roll.election_id;
             var voterMatch = electionRoll.voter_id===voter_roll.voter_id;
-            return electionMatch && voterMatch
+            return electionMatch && voterMatch && electionRoll.head
         });
         if (index < 0){
             return Promise.resolve(null)
@@ -92,6 +95,18 @@ export default class ElectionRollDB implements IElectionRollStore{
         };
         this._electionRolls[index] = sanitized;
         return Promise.resolve(JSON.parse(JSON.stringify(sanitized)));
+    }
+
+    archiveRollsByElectionID(election_id: string, ctx:ILoggingContext, reason:string, db?: any): Promise<number> {
+        Logger.debug(ctx, `MockElectionRolls archiveRollsByElectionID ${election_id}`);
+        let archived = 0;
+        this._electionRolls.forEach(roll => {
+            if (roll.election_id === election_id && roll.head) {
+                roll.head = false;
+                archived++;
+            }
+        });
+        return Promise.resolve(archived)
     }
 
     delete(voter_roll: ElectionRoll, ctx:ILoggingContext,reason:string): Promise<boolean> {

--- a/packages/backend/src/Routes/roll.routes.ts
+++ b/packages/backend/src/Routes/roll.routes.ts
@@ -9,7 +9,8 @@ import {
     flagElectionRoll,
     invalidateElectionRoll,
     uninvalidateElectionRoll,
-    revealVoterIdByEmail
+    revealVoterIdByEmail,
+    clearElectionRoll
 } from '../Controllers/Roll';
 import {
     getElectionByID,
@@ -166,6 +167,43 @@ rollRouter.get('/Election/:id/rolls/:voter_id', asyncHandler(getByVoterID))
  *         description: Election not found
  */
 rollRouter.post('/Election/:id/rolls/', asyncHandler(addElectionRoll))
+
+/**
+ * @swagger
+ * /Election/{id}/rolls:
+ *   delete:
+ *     summary: Clear the entire election roll (draft elections only)
+ *     description: Archives every voter on the roll (marks them as non-head) rather than deleting the rows, so the roll reads as empty and the voter auth settings unlock again. Only permitted while the election is in draft.
+ *     tags: [Rolls]
+ *     security:
+ *      - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The election ID
+ *     responses:
+ *       200:
+ *         description: Roll cleared
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 election:
+ *                   type: object
+ *                   $ref: '#/components/schemas/Election'
+ *                 cleared:
+ *                   type: number
+ *                   description: Number of voters removed from the roll
+ *       400:
+ *         description: Election is not in draft
+ *       404:
+ *         description: Election not found
+ */
+rollRouter.delete('/Election/:id/rolls/', asyncHandler(clearElectionRoll))
 
 /** 
  * @swagger

--- a/packages/backend/src/test/TestHelper.ts
+++ b/packages/backend/src/test/TestHelper.ts
@@ -240,6 +240,32 @@ export class TestHelper {
         return r.send({ electionRoll: electionRoll });
     }
 
+    async clearElectionRoll(
+        electionId: Uid,
+        userToken: string | null,
+        customToken: string| null = null
+    ): Promise<any> {
+        var r = request(this.expressApp)
+            .delete(`/API/Election/${electionId}/rolls`)
+            .set("Accept", "application/json");
+
+        r = this.addUserTokenVoterIdCookie(r, userToken, null, customToken, null);
+        return r.send();
+    }
+
+    async fetchElectionRoll(
+        electionId: Uid,
+        userToken: string | null,
+        customToken: string| null = null
+    ): Promise<any> {
+        var r = request(this.expressApp)
+            .get(`/API/Election/${electionId}/rolls`)
+            .set("Accept", "application/json");
+
+        r = this.addUserTokenVoterIdCookie(r, userToken, null, customToken, null);
+        return r.send();
+    }
+
     private addUserTokenVoterIdCookie(
         req: any,
         userToken: string | null,

--- a/packages/backend/src/test/clearElectionRoll.test.ts
+++ b/packages/backend/src/test/clearElectionRoll.test.ts
@@ -1,0 +1,88 @@
+require("dotenv").config();
+import { TestHelper } from "./TestHelper";
+import testInputs from "./testInputs";
+
+const th = new TestHelper();
+
+afterEach(() => {
+    jest.clearAllMocks();
+    th.afterEach();
+});
+
+describe("Clear Election Roll", () => {
+    beforeAll(() => {
+        jest.clearAllMocks();
+    });
+    var electionId = "";
+    test("Create draft election, responds 200", async () => {
+        const response = await th.createElection(
+            { ...testInputs.EmailRollElection, state: 'draft' },
+            testInputs.user1token
+        );
+
+        expect(response.statusCode).toBe(200);
+        electionId = response.election.election_id;
+        th.testComplete();
+    });
+    test("Add Voter Roll", async () => {
+        const response = await th.submitElectionRoll(
+            electionId,
+            testInputs.EmailRoll,
+            testInputs.user1token
+        );
+        expect(response.statusCode).toBe(200);
+        th.testComplete();
+    });
+    test("Roll has both voters", async () => {
+        const response = await th.fetchElectionRoll(electionId, testInputs.user1token);
+        expect(response.statusCode).toBe(200);
+        expect(response.body.electionRoll).toHaveLength(2);
+        th.testComplete();
+    });
+    test("Non-owner can't clear the roll", async () => {
+        const response = await th.clearElectionRoll(electionId, testInputs.user2token);
+        expect(response.statusCode).toBe(401);
+        th.testComplete();
+    });
+    test("Owner clears the roll", async () => {
+        const response = await th.clearElectionRoll(electionId, testInputs.user1token);
+        expect(response.statusCode).toBe(200);
+        expect(response.body.cleared).toBe(2);
+        th.testComplete();
+    });
+    test("Roll is empty afterwards", async () => {
+        const response = await th.fetchElectionRoll(electionId, testInputs.user1token);
+        expect(response.statusCode).toBe(200);
+        expect(response.body.electionRoll).toHaveLength(0);
+        th.testComplete();
+    });
+    test("Clearing an already empty roll is a no-op", async () => {
+        const response = await th.clearElectionRoll(electionId, testInputs.user1token);
+        expect(response.statusCode).toBe(200);
+        expect(response.body.cleared).toBe(0);
+        th.testComplete();
+    });
+    test("The same voters can be re-added after clearing", async () => {
+        const response = await th.submitElectionRoll(
+            electionId,
+            testInputs.EmailRoll,
+            testInputs.user1token
+        );
+        expect(response.statusCode).toBe(200);
+
+        const rolls = await th.fetchElectionRoll(electionId, testInputs.user1token);
+        expect(rolls.body.electionRoll).toHaveLength(2);
+        th.testComplete();
+    });
+    test("Roll can't be cleared once the election is finalized", async () => {
+        const finalized = await th.finalizeElection(electionId, testInputs.user1token);
+        expect(finalized.statusCode).toBe(200);
+
+        const response = await th.clearElectionRoll(electionId, testInputs.user1token);
+        expect(response.statusCode).toBe(400);
+
+        const rolls = await th.fetchElectionRoll(electionId, testInputs.user1token);
+        expect(rolls.body.electionRoll).toHaveLength(2);
+        th.testComplete();
+    });
+});

--- a/packages/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
+++ b/packages/frontend/src/components/Election/Admin/ViewElectionRolls.tsx
@@ -6,7 +6,7 @@ import AddElectionRoll from "./AddElectionRoll";
 import PermissionHandler from "../../PermissionHandler";
 import { Box, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, Radio, RadioGroup, Typography } from "@mui/material";
 import EnhancedTable, { HeadKey }  from "./../../EnhancedTable";
-import { useGetRolls, useSendEmails } from "../../../hooks/useAPI";
+import { useClearRolls, useGetRolls, useSendEmails } from "../../../hooks/useAPI";
 import useElection from "../../ElectionContextProvider";
 import useFeatureFlags from "../../FeatureFlagContextProvider";
 import { ElectionRollResponse } from "@equal-vote/star-vote-shared/domain_model/ElectionRoll";
@@ -21,6 +21,7 @@ const ViewElectionRolls = () => {
     const { election, permissions, t, updateElection } = useElection()
     const { data, isPending, makeRequest: fetchRolls } = useGetRolls(election.election_id)
     const sendEmails = useSendEmails(election.election_id)
+    const clearRolls = useClearRolls(election.election_id)
     useEffect(() => {
         if(election.settings.voter_access == 'closed')  fetchRolls()
     }, [])
@@ -94,6 +95,16 @@ const ViewElectionRolls = () => {
         [data]
     );
 
+    // Adding the first voter locks the voter auth radios above. While the election is still a
+    // draft that lock is undoable: clearing the roll empties it and re-enables the radios.
+    const canClearRolls = election.state === 'draft' && electionRollData.length > 0;
+
+    const onClearRolls = async () => {
+        if (!await confirm(t('admin_home.clear_voter_roll_confirm', { voter_count: electionRollData.length }))) return;
+        if (!await clearRolls.makeRequest()) return;
+        await fetchRolls();
+    }
+
     return (
         <>
             <Box>
@@ -157,6 +168,13 @@ const ViewElectionRolls = () => {
                         }
                         {usesEmail &&
                             <SecondaryButton onClick={() => setDialogOpen(true)} sx={{ml: 2}}>Draft Email Blast</SecondaryButton>
+                        }
+                        {canClearRolls &&
+                            <PermissionHandler permissions={permissions} requiredPermission={'canAddToElectionRoll'}>
+                                <SecondaryButton onClick={onClearRolls} disabled={clearRolls.isPending} sx={{ml: 2}}>
+                                    {t('admin_home.clear_voter_roll_button')}
+                                </SecondaryButton>
+                            </PermissionHandler>
                         }
                         <EnhancedTable
                             headKeys={headKeys}

--- a/packages/frontend/src/hooks/useAPI.ts
+++ b/packages/frontend/src/hooks/useAPI.ts
@@ -99,6 +99,14 @@ export const usePostRolls = (election_id: string) => {
     return useFetch<{ electionRoll: ElectionRoll[] }, object>(`/API/Election/${election_id}/rolls/`, 'post')
 }
 
+export const useClearRolls = (election_id: string) => {
+    return useFetch<undefined, { election: Election, cleared: number }>(
+        `/API/Election/${election_id}/rolls/`,
+        'delete',
+        'Voter List Cleared!',
+    )
+}
+
 export const useSetPublicResults = (election_id: string) => {
     return useFetch<{ public_results: boolean, expected_update_date: string }, { election: Election }>(`/API/Election/${election_id}/setPublicResults`, 'post')
 }

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -1130,6 +1130,12 @@ admin_home:
     title: Confirm Adding First Voters
     message: Once your first voters have been added, your voter list settings will be locked in for this election. Would you like to continue?
 
+  clear_voter_roll_button: Clear Voter List
+  clear_voter_roll_confirm:
+    title: Confirm Clearing Voter List
+    message: This removes all {{voter_count}} voters from your election and unlocks your voter list settings so you can change them. You'll need to add your voters again afterwards. Would you like to continue?
+    submit: 'Yes, clear the list'
+
   finalize_email_confirm:
     title: Send Email Blast
     message: You can send emails from the voters tab at anytime. Would you like to notify your voters? 

--- a/testing/tests/election-with-rolls.spec.ts
+++ b/testing/tests/election-with-rolls.spec.ts
@@ -141,6 +141,34 @@ test.describe('Add Voters', () => {
         await page.getByLabel('Voter Data').fill(voterIds.join('\n'));
         await page.getByRole('button', {name: 'Submit'}).click();
     });
+    test('clear voters to unlock the voter list settings', async ({ page, request }) => {
+        const response = await request.post(`${API_BASE_URL}/Election/${electionId}/rolls`, {
+            data: {
+                "electionRoll": voterIds.map(voter_id => ({ state: 'approved', voter_id }))
+            }
+        });
+        await expect(response).toBeOK();
+
+        await page.goto(`/${electionId}/admin/voters`);
+        await expect(page.getByText('1–5 of 5')).toBeVisible();
+
+        // adding the first voter locks the voter list settings
+        await expect(page.getByRole('radio', { name: 'Yes' })).toBeDisabled();
+
+        await page.getByRole('button', { name: 'Clear Voter List' }).click();
+        await page.getByRole('button', { name: 'Yes, clear the list' }).click();
+
+        // roll is empty and the settings unlock again
+        await expect(page.getByText("This election doesn't have any voters yet")).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Clear Voter List' })).toHaveCount(0);
+        await expect(page.getByRole('radio', { name: 'Yes' })).toBeEnabled();
+
+        // which was the point: the admin can now pick the other voter ID scheme
+        const emailList = page.getByRole('radio', { name: /BetterVoting-managed voter IDs/ });
+        await emailList.click();
+        await expect(emailList).toBeChecked();
+    });
+
     test('vote in election restricted by ID', async ({ page, request }) => {
         await page.goto(`/`);
         const response = await request.post(`${API_BASE_URL}/Election/${electionId}/rolls`, {


### PR DESCRIPTION
Closes #1363

## Problem

Adding the first voter locks the voter-access and voter-id/email radios on Manage Voters:

```ts
disabled={election.state !== 'draft' || electionRollData.length > 0}
```

That lock is permanent even while the election is still a draft, so an admin who picked the wrong auth mode (email list when they wanted an ID list, or vice versa) had no in-app way to undo it short of recreating the election. There was no DELETE route on the roll router at all.

## What this does

Adds `DELETE /API/Election/:id/rolls`:

- Guarded by `canAddToElectionRoll` — the same permission used to add voters, on the theory that an admin who can create the lock should be able to undo it.
- Refused with a 400 for any non-draft election.
- **Archives rather than deletes**, per the last note on the issue. Every `head=true` row is demoted to `head=false`, so all the model's read paths (which already filter on `head`) stop seeing them and the roll reads as empty, but the rows and their `history` survive for auditing. `update_date` is untouched, so there's no collision with the `(election_id, voter_id, update_date)` primary key, and the partial unique index is on `(election_id, voter_id) WHERE head`, so the same voter_ids can be re-added afterwards.

Frontend gets a `useClearRolls` hook and a "Clear Voter List" button on Manage Voters, rendered only in draft with a non-empty roll and behind a confirm dialog that names the voter count. On success it refetches the roll, which drops the count to 0 and re-enables the radios through the existing condition.

The mock roll store now honors `head` in its reads and its conflict check, matching the real store.

## Testing

- New `clearElectionRoll.test.ts` — 9 tests: non-owner → 401, owner → 200 with the archived count, roll empty afterwards, no-op on an already-empty roll, the same voters re-added successfully, and 400 once the election is finalized.
- Full backend suite passes (22 suites / 149 tests), which is what confirms the mock's new `head` filters didn't disturb existing tests.
- Frontend `tsc --noEmit` is clean and the touched files add no lint errors.
- Added an E2E case to `election-with-rolls.spec.ts` that clears the roll and then flips to the other voter-ID scheme. **This one is unverified** — I didn't have a live stack to run Playwright against, so it needs a run in CI or locally before merge.

## Deliberately out of scope

The issue's "possibly related" per-voter `DELETE /rolls/:voter_id` — flagged there as maybe-split, so it's not in this PR. Happy to add it here if you'd rather have both at once.

Only `en.yaml` gained strings; the other locales don't carry the neighboring `add_first_voter_roll_confirm` keys either and fall back to English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
