### PR TITLE
fix(i18n): rewrite the Public Results tip and link the help article

### DIFF
--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -736,10 +736,11 @@ tips:
 
   public_results:
     title: Public Results
-    description: |
-      Allows voters to see the results of the {{election}}.
-      If enabled while voting is open then voters will be shown to the preliminary results after completing their ballot.
-      High profile {{elections}} will usually keep the results hidden, and then reveal them after the {{election}} is closed.
+    description: >
+      Controls whether voters can see {{election}} results.
+      When enabled during an open {{election}}, voters will see preliminary results after submitting their {{ballot}}.
+      High-profile {{elections}} typically keep results hidden until the {{election}} closes.
+    learn_link: https://docs.bettervoting.com/help/preliminary_results.html
 
   voter_groups:
     title: Enable Voter Groups


### PR DESCRIPTION
Part of #1350.

Three changes to `tips.public_results`, all in `packages/frontend/src/i18n/en.yaml`:

**1. Reworded**, per the issue's Should-be text — with one deliberate deviation. The issue quotes the *rendered* string, so pasting it verbatim would hard-code "election" and regress poll terminology. This keeps the `{{election}}` / `{{elections}}` interpolation and adds `{{ballot}}`, so as a poll it now reads "…after submitting their **response**" (`keyword.poll.ballot` is `response`).

**2. Block style `|` → `>`.** `applyLineBreaks` turns a literal block's newlines into `<br/>`, so the old tip rendered as three separate lines in the tooltip. The replacement is a single paragraph and now renders as one. (Screenshot of the current three-line rendering to follow.)


**3. Added `learn_link`.** `docs/help/preliminary_results.md` has been in the repo for a while but is linked from nowhere in `packages/` — a grep for `preliminary_results` returns only the label key and its one consumer. It already covers what #1350 asks an article to cover: what a live tally exposes, that admins can always see who voted, delta-analysis de-anonymization, the editable-ballots interaction, and that turning the setting off doesn't un-reveal. `styles.tsx` renders `learn_link` as a "Learn More" anchor with `target='_blank'`, so this needs no component change.

Verified `https://docs.bettervoting.com/help/preliminary_results.html` returns 200.

---

**Scope:** this is the admin-side copy half of #1350 only. The on-ballot notice for voters, the closed-list warning layer, and the qualification to the article's own L26 claim are separate and still open — the closed-list wording in particular needs someone to sign off on what it may claim (see my comment on the issue).

**Translations:** en-only. `es` / `pl` / `pt-BR` carry no `tips:` block at all, and `tips:` sits in PRIORITY 4, so this creates no translator obligation.

**Noticed while in this region, not touched here:** `results.admin_results_toggle` and `disabled_msgs.ballot_updates_when_open` both appear to have no consumer outside `en.yaml`. Happy to remove them in a separate cleanup PR rather than widen this diff.

