### PR TITLE
fix(results): name and link Bloc STAR on the results page

### DIFF
--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -453,7 +453,10 @@ export default function Results({ race, results }: {race: Race, results: Electio
     const {i18n} = useSubstitutedTranslation();
 
     const votingMethodBase = race.voting_method
-    const methodKey = methodValueToTextKey[votingMethodBase];
+    // Bloc STAR is stored as plain STAR with more than one seat — the name is
+    // never written down anywhere, so the results page has to derive it (#1086).
+    const isBlocStar = votingMethodBase === 'STAR' && race.num_winners > 1;
+    const methodKey = isBlocStar ? 'star_bloc' : methodValueToTextKey[votingMethodBase];
     const learnLinkKey = `methods.${methodKey}.learn_link`;
     const votingMethod= t(`methods.${methodKey}.full_name`)
 

--- a/packages/frontend/src/i18n/en.yaml
+++ b/packages/frontend/src/i18n/en.yaml
@@ -157,6 +157,10 @@ methods:
     full_name: STAR Voting
     short_name: STAR Voting
     learn_link: https://www.starvoting.org/star
+  star_bloc:
+    full_name: Bloc STAR Voting
+    short_name: Bloc STAR
+    learn_link: https://docs.bettervoting.com/help/bloc_star.html
   star_pr:
     full_name: Proportional STAR Voting
     short_name: STAR PR


### PR DESCRIPTION
## Description

> **Draft — depends on #1474.** The `learn_link` added here points at `docs.bettervoting.com/help/bloc_star.html`, which is the page #1474 adds. Merging this first would ship a 404. Ready to un-draft the moment #1474 lands (or immediately, if you'd rather point it somewhere else — see below).

The results-page half of #1086. A STAR race with more than one seat **is** Bloc STAR, but the method is stored as plain `"STAR"` with the seat count in a separate field (`num_winners`), so `Results.tsx` had no way to know and:

- **Location 1** — the label under the winner announcement read *"Voting Method: STAR Voting"*.
- **Location 2** — the help link read *"How STAR Voting works"* and pointed at `methods.star.learn_link`, the single-winner explainer.

Both come from the same two lines, so both are fixed by deriving the bloc case once:

```ts
const isBlocStar = votingMethodBase === 'STAR' && race.num_winners > 1;
const methodKey = isBlocStar ? 'star_bloc' : methodValueToTextKey[votingMethodBase];
```

plus a `methods.star_bloc` block (`full_name: Bloc STAR Voting`, `short_name: Bloc STAR`, `learn_link`) alongside the existing `star` / `star_pr` entries.

**Scope — deliberately narrow, three things left alone:**

1. **The stored value is untouched.** `votingMethod: "STAR"` + `num_winners` is arguably correct — the field names the ballot/tabulation family and the seat count names the seats, making "Bloc STAR" a *derived* label. This PR treats it that way and derives it at the display layer only. (Reasoning and the exact export lines: [BV129 note](https://github.com/masiarek/star-voting-library/blob/master/02_STAR_Bloc/02_Examples/bv129_1086_method_name_note.md).)
2. **The "Edit Race" modal (#1086 problem area 1) is not fixed here.** It has its own composition path (`edit_race.bloc_multi_winner_adj`), and doing it properly means deciding how the adjective composes for *every* method — Bloc Approval, Bloc Ranked Robin, multi-winner Plurality — which is a naming decision for maintainers, not a drive-by. Same reason #912 and #904 exist.
3. **`useSubstitutedTranslation`'s `methodKey`** (line ~450) is untouched — it feeds term substitution across many strings, and widening it is a separate blast radius.

So #1086 shouldn't be auto-closed by this; it should lose one of its three problem areas.

**Translations:** en-only. `es` / `pl` / `pt-BR` each carry a `methods:` block, so a missing `star_bloc` falls back to English rather than rendering a key — same behaviour as any newly added string.

**Alternative if you don't want #1474:** point `methods.star_bloc.learn_link` at `https://electowiki.org/wiki/Bloc_STAR_Voting`, as #1086 originally suggested, and this becomes independent and mergeable today.

## Screenshots / Videos (frontend only)

Text-only change to an existing label and an existing anchor — no layout, no new elements. On a 2-seat STAR race the label reads "Voting Method: Bloc STAR Voting" and the link reads "How Bloc STAR Voting works".

## Related Issues

Part of #1086 (results-page half only — see scope above). Follows #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
