### PR TITLE
fix(results): highlight every winner in Ranked Robin and Choose One

### DIFF
--- a/packages/frontend/src/components/Election/Results/Results.tsx
+++ b/packages/frontend/src/components/Election/Results/Results.tsx
@@ -67,7 +67,7 @@ function STARResultsViewer({ filterRandomFromLogs }: {filterRandomFromLogs: bool
 
 function RankedRobinResultsViewer() {
   let {results} = useRace();
-  const {t} = useRace();
+  const {race, t} = useRace();
   results = results as rankedRobinResults;
 
   const candidates = results.summaryData.candidates;
@@ -81,7 +81,7 @@ function RankedRobinResultsViewer() {
           }
           percentage
           percentDenominator={results.summaryData.candidates.length-1}
-          stars={1}
+          stars={race.num_winners}
         />
       </Widget>
     </WidgetContainer>
@@ -89,7 +89,7 @@ function RankedRobinResultsViewer() {
     <DetailExpander>
       <WidgetContainer>
         <Widget title={t('results.ranked_robin.table_title')}>
-          <ResultsTable className='rankedRobinTable' data={[
+          <ResultsTable className='rankedRobinTable' winningRows={race.num_winners} data={[
             t('results.ranked_robin.table_columns'),
             ...results.summaryData.candidates.map(c => [
               c.name, c.copelandScore, formatPercent(c.copelandScore / (results.summaryData.candidates.length-1))
@@ -172,7 +172,7 @@ function IRVResultsViewer() {
 
 function PluralityResultsViewer() {
   const { results } = useRace();
-  const { t } = useRace();
+  const { race, t } = useRace();
 
   return <ResultsViewer methodKey='choose_one'>
     <WidgetContainer>
@@ -184,7 +184,7 @@ function PluralityResultsViewer() {
               votes: c.score,
             }))
           }
-          stars={1}
+          stars={race.num_winners}
           percentage
         />
       </Widget>
@@ -193,7 +193,7 @@ function PluralityResultsViewer() {
     <DetailExpander>
       <WidgetContainer>
         <Widget title={t('results.choose_one.table_title')}>
-          <ResultsTable className='chooseOneTable' data={[
+          <ResultsTable className='chooseOneTable' winningRows={race.num_winners} data={[
             t('results.choose_one.table_columns'),
             ...results.summaryData.candidates.map(c => [
               c.name, c.score, formatPercent(c.score / results.summaryData.nTallyVotes)


### PR DESCRIPTION
Fixes #1166.

`RankedRobinResultsViewer` hard-codes a single winner into the two shared result components, so a multi-winner race names *N* winners in its heading and then stars one of them in the bar chart and gold-highlights one row in the detailed table.

| | Before | After |
|---|---|---|
| `ResultsBarChart` | `stars={1}` | `stars={race.num_winners}` |
| `ResultsTable` | `winningRows` not passed → defaults to `1` | `winningRows={race.num_winners}` |

Neither shared component needed changing — both already accept a count. And this isn't a STAR-shaped design mismatch to work around, as the issue tentatively suggests: **`ApprovalResultsViewer` is a bloc method rendering through these same two components and already passes `race.num_winners` to both**, 140 lines below in the same file. Ranked Robin just never got it. The diff makes the two viewers agree.

### Why Plurality is in here too

`PluralityResultsViewer` had the identical two omissions, and multi-winner Choose One is reachable: `VotingMethodSelector` offers Plurality under *More Options* once `num_winners >= 2`, and `Plurality.ts` tabulates through `runBlocTabulator` with `nWinners`, so it really does elect *N*. It's the same two-line change; splitting it would mean a second review round for a defect already understood. Happy to drop the hunk if you'd rather keep #1166 literal.

### Deliberately untouched

| Viewer | Why it's already right |
|---|---|
| STAR | `WinnerResultPages` renders one summary widget per round |
| IRV / STV | `IRV/top.tsx` renders one `IRVWinnerView` per winner search, so `stars={1}` inside each is correct |
| STAR_PR | Already marks winners individually — `star: winIndex(…) < page` |
| Approval | Already passes `race.num_winners` — this PR's model |

### Reproduction

The reporter's poll, [`qq6qkp`](https://bettervoting.com/qq6qkp/results) (Ranked Robin, `num_winners: 3`, 10 candidates, 26 voters), on production as of 2026-08-04:

```
⭐ Baldur's Gate, Dragon Age, and Mass Effect and/or KOTOR win! ⭐
...
Head-to-head wins
⭐ Baldur's Gate
Dragon Age
Mass Effectand/or KOTOR
```

`GET /API/ElectionResult/qq6qkp` confirms all three are in `elected`.

### One thing this does *not* fix

Highlighting is **positional** — the first *N* rows of `summaryData.candidates` — while `elected` is built round by round. In Ranked Robin those can disagree:

- `summaryData.candidates` is sorted once, up front, by `copelandScore` desc then `tieBreakOrder` asc, and RR passes no `evaluate` callback to `runBlocTabulator`, so it's never re-sorted into round-win order.
- `singleWinnerRankedRobin`'s second tiebreak rung is **head-to-head**, which ignores `tieBreakOrder` entirely.

Since `tieBreakOrder` is a seeded shuffle carrying no information about who beat whom, a Copeland tie that **straddles the winner cutoff** puts the two mechanisms a coin-flip apart. That rung is not exotic — round 1 of `qq6qkp` itself was decided on it (`Dragon Age preferred over Mass Effect and/or KOTOR in runoff`, a 7.5–7.5 tie). It's invisible there only because Dragon Age also sorts first *and* both were elected anyway at N=3.

It's pre-existing, it affects Approval as well, and fixing it properly means an API change on `ResultsTable` (an index set alongside the count) — so it's left out of this PR and filed separately rather than widened into a `good first issue`.

### Testing

Verified by inspection against the Approval call sites, which use identical prop types; I don't have a local stack with this branch built, so **this has not been run**. Worth a reviewer checking: Ranked Robin with 3 winners (3 stars, 3 gold rows), Ranked Robin with 1 winner (unchanged), Choose One with 2 winners (2 stars, 2 gold rows), and Approval with 3 winners as a regression guard.
